### PR TITLE
docs: ADRから汎用ガイドを分離

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,65 +44,17 @@ dao list              # List workflows
 dao design --help     # Design workflow help
 ```
 
-## Git Worktree
-
-This project uses bare repository + worktree pattern:
-
-```bash
-# Create new worktree
-cd /home/aki/dev/dev-agent-orchestra
-git worktree add <branch-name> -b <branch-name> main
-
-# Switch context
-cd ../<branch-name>
-
-# Remove worktree
-git worktree remove <branch-name>
-```
-
-**Do:** ディレクトリ移動でブランチ切り替え
-**Don't:** `git checkout` を使わない
-
 ## Git & GitHub
+
 - **GitHub CLI**: `gh` available (PR, Issue, API operations)
 - **Branches**: Feature branches via worktree, never commit to main directly
 - **Commits**: Conventional Commits (feat/fix/docs/test/refactor)
 - **Merge**: `--no-ff` only (squash merge prohibited)
 - **Before commit**: Run pre-commit checks
 
-## Git Workflow (git absorb + --no-ff)
-
-作業中は自由にコミット（バックアップ）、PR前に `git absorb` で整理:
-
-```bash
-# 1. 作業中（自由にコミット = バックアップ）
-git commit -m "feat: 機能追加"
-git commit -m "wip: バックアップ"
-git commit -m "fix: 修正"
-
-# 2. レビュー指摘対応後（自動でfixup + rebase）
-git add .
-git absorb --and-rebase
-
-# 3. PR作成
-gh pr create ...
-
-# 4. マージ（ブランチ可視化維持）
-git switch main
-git merge --no-ff feature-branch
-git push
-```
-
-**Required tool**: [git-absorb](https://github.com/tummychow/git-absorb)
-```bash
-brew install git-absorb  # macOS
-apt install git-absorb   # Ubuntu/Debian
-```
-
-**Why this workflow?**
-- バックアップ: レビュー前に自由にコミット可能
-- 履歴: `git absorb` で自動整理
-- 可視化: `--no-ff` でブランチの分岐・合流が git graph で確認可能
+詳細ガイド:
+- [Git Worktree ガイド](docs/guides/git-worktree.md) - Bare Repository + Worktree パターン
+- [Git コミット戦略](docs/guides/git-commit-flow.md) - git absorb + --no-ff ワークフロー
 
 ## Core Principles
 
@@ -127,3 +79,4 @@ apt install git-absorb   # Ubuntu/Debian
 |-------|----------|
 | Architecture | docs/architecture.md |
 | ADR | docs/adr/ |
+| Guides | docs/guides/ |

--- a/docs/adr/2025-12-27-dev-agent-orchestra-design.md
+++ b/docs/adr/2025-12-27-dev-agent-orchestra-design.md
@@ -184,67 +184,11 @@ dao --list-workflows
 
 ---
 
-## 4. Git Worktree 構成
+## 4. 開発環境
 
-### 4.1 推奨構成: Bare Repository パターン
+Git Worktree + Bare Repository パターンを採用。
 
-2024-2025年のベストプラクティスに基づく構成:
-
-```
-/home/aki/dev/dev-agent-orchestra/    # プロジェクトコンテナ
-├── .bare/                            # bare git repository (実データ)
-├── .git                              # ポインタファイル → .bare を参照
-├── main/                             # worktree (main ブランチ)
-├── feature-design/                   # worktree (feature-design ブランチ)
-└── issue-42/                         # worktree (issue-42 ブランチ)
-```
-
-### 4.2 構成のメリット
-
-| 観点 | メリット |
-|------|----------|
-| **整理性** | 1リポジトリ = 1ディレクトリ、他リポジトリと混ざらない |
-| **分離** | bare repo は純粋なGitデータ、worktree がファイル操作 |
-| **AI並列開発** | 各worktreeで独立したClaude Codeセッション実行可能 |
-| **コンテキスト保持** | ブランチごとに会話履歴・状態が保持される |
-
-### 4.3 セットアップ手順
-
-```bash
-# 1. プロジェクトコンテナ作成
-mkdir -p /home/aki/dev/dev-agent-orchestra
-cd /home/aki/dev/dev-agent-orchestra
-
-# 2. GitHubリポジトリ作成
-gh repo create apokamo/dev-agent-orchestra --public \
-  --description "AI-driven software development workflow orchestrator"
-
-# 3. bare repository として初期化
-git clone --bare git@github.com:apokamo/dev-agent-orchestra.git .bare
-
-# 4. .git ポインタファイル作成
-echo "gitdir: ./.bare" > .git
-
-# 5. fetch 設定追加
-git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-
-# 6. main worktree 作成
-git worktree add main -b main
-cd main
-git commit --allow-empty -m "Initial commit"
-git push -u origin main
-```
-
-### 4.4 運用ルール
-
-**Do:**
-- ディレクトリ移動でブランチ切り替え (`cd ../feature-xxx`)
-- worktree管理はプロジェクトルートから実行
-- 各worktreeでupstream設定 (`git branch --set-upstream-to=origin/xxx`)
-
-**Don't:**
-- `git checkout` を使わない（ディレクトリ移動で対応）
-- プロジェクトルートで一般的なgitコマンドを実行しない
+詳細は [Git Worktree ガイド](../guides/git-worktree.md) を参照。
 
 ---
 
@@ -274,15 +218,6 @@ git push -u origin main
 ---
 
 ## 6. 参考資料
-
-### Git Worktree ベストプラクティス
-- [How to use git worktree and in a clean way](https://morgan.cugerone.com/blog/how-to-use-git-worktree-and-in-a-clean-way/)
-- [Bare Git Worktrees AGENTS.md](https://gist.github.com/ben-vargas/fd99be9bbce6d485c70442dd939f1a3d)
-- [Git Worktree Best Practices and Tools](https://gist.github.com/ChristopherA/4643b2f5e024578606b9cd5d2e6815cc)
-
-### AI並列開発
-- [incident.io: Shipping faster with Claude Code and Git Worktrees](https://incident.io/blog/shipping-faster-with-claude-code-and-git-worktrees)
-- [Parallel AI Coding with Git Worktrees](https://docs.agentinterviews.com/blog/parallel-ai-coding-with-gitworktrees/)
 
 ### 既存実装
 - bugfix-v5: `.claude/agents/bugfix-v5/`

--- a/docs/guides/git-commit-flow.md
+++ b/docs/guides/git-commit-flow.md
@@ -1,0 +1,173 @@
+# Git コミット戦略ガイド
+
+git absorb + `--no-ff` マージによるコミット履歴管理戦略。
+
+## 概要
+
+このワークフローは以下を両立する：
+
+- **意味のあるコミット単位**: 機能・修正ごとにコミット
+- **レビュー指摘の自動吸収**: `git absorb` で過去コミットに自動fixup
+- **ブランチの可視化**: `--no-ff` マージでブランチの分岐・合流が明確
+
+## 必須ツール
+
+[git-absorb](https://github.com/tummychow/git-absorb) のインストールが必要：
+
+```bash
+# macOS
+brew install git-absorb
+
+# Ubuntu/Debian
+apt install git-absorb
+
+# Cargo (Rust)
+cargo install git-absorb
+```
+
+## ワークフロー
+
+### 1. 作業中（意味のある単位でコミット）
+
+```bash
+git commit -m "feat: ユーザー認証機能を追加"
+git commit -m "feat: ログアウト機能を追加"
+git commit -m "fix: 認証トークンの有効期限チェックを修正"
+```
+
+機能・修正ごとに意味のあるコミットを作成する。
+
+### 2. レビュー指摘対応（git absorb で自動吸収）
+
+> **⚠️ コミットしない**: 修正はステージのみ。コミットすると `git absorb` で吸収できなくなる。
+
+```bash
+# レビュー指摘に対応してファイルを修正
+vim src/auth.py
+
+# 修正をステージ（コミットしない！）
+git add src/auth.py
+
+# 適切な過去コミットに自動吸収
+git absorb --and-rebase
+```
+
+`git absorb` は **ステージされた変更のみ** を対象とする。誤ってコミットした場合は「[リカバリー](#リカバリー)」を参照。
+
+### 3. PR作成
+
+```bash
+gh pr create --title "feat: 新機能" --body "..."
+```
+
+### 4. マージ（ブランチ可視化維持）
+
+```bash
+git switch main
+git merge --no-ff feature-branch
+git push
+```
+
+**重要**: `--no-ff` を必ず使用する。
+
+## なぜ `--no-ff` か
+
+### Fast-forward マージ（デフォルト）
+
+```
+main:    A---B---C---D---E  (feature commits absorbed)
+```
+
+ブランチの存在が履歴から消える。
+
+### No-fast-forward マージ
+
+```
+main:    A---B-----------M
+              \         /
+feature:       C---D---E
+```
+
+ブランチの分岐・合流が `git log --graph` で確認可能。
+
+## コミットメッセージ規約
+
+[Conventional Commits](https://www.conventionalcommits.org/) に従う：
+
+| Prefix | 用途 |
+|--------|------|
+| feat | 新機能 |
+| fix | バグ修正 |
+| docs | ドキュメント |
+| test | テスト |
+| refactor | リファクタリング |
+| chore | その他（ビルド、CI等） |
+
+例：
+```
+feat: ユーザー認証機能を追加
+fix: ログイン時のエラーハンドリングを修正
+docs: READMEにインストール手順を追加
+```
+
+## 禁止事項
+
+- `git merge` のデフォルト（fast-forward）使用
+- squash マージ（履歴が失われる）
+- main ブランチへの直接コミット
+
+## git absorb の動作原理
+
+1. ステージされた変更を分析
+2. 各変更がどの過去のコミットに属するか判定
+3. 自動で `fixup!` コミットを作成
+4. `--and-rebase` オプションで自動リベース
+
+### 例
+
+```bash
+# 3つのコミットがある状態
+# commit A: file1.py に関数追加
+# commit B: file2.py に関数追加
+# commit C: file3.py に関数追加
+
+# file1.py と file2.py を修正
+vim file1.py file2.py
+git add .
+git absorb --and-rebase
+
+# 結果: 修正がそれぞれ commit A, B に吸収される
+```
+
+## リカバリー
+
+### 誤ってコミットした場合
+
+レビュー修正を別コミットにしてしまった場合の対処法。
+
+#### 方法1: コミットを取り消してやり直す（推奨）
+
+```bash
+# 直前のコミットを取り消し、変更をステージ状態に戻す
+git reset --soft HEAD~1
+
+# git absorb で吸収
+git absorb --and-rebase
+```
+
+#### 方法2: rebase で統合する
+
+既にプッシュ済み、または複数コミットを整理する場合。
+
+```bash
+# インタラクティブrebaseで統合
+GIT_SEQUENCE_EDITOR="sed -i '2s/pick/fixup/'" git rebase -i main
+
+# force push（プッシュ済みの場合）
+git push --force-with-lease
+```
+
+## 参考資料
+
+- [git-absorb GitHub](https://github.com/tummychow/git-absorb)
+- [Conventional Commits](https://www.conventionalcommits.org/)

--- a/docs/guides/git-worktree.md
+++ b/docs/guides/git-worktree.md
@@ -1,0 +1,143 @@
+# Git Worktree ガイド
+
+Bare Repository + Worktree パターンによる並列開発環境の構築・運用ガイド。
+
+## 概要
+
+Git Worktree を使用することで、1つのリポジトリで複数のブランチを同時に作業ディレクトリとして展開できる。これにより：
+
+- **並列開発**: 複数のブランチで同時に作業可能
+- **コンテキスト切り替え不要**: `git checkout` なしでディレクトリ移動のみ
+- **AI並列開発**: 各worktreeで独立したClaude Codeセッション実行可能
+
+## 推奨構成: Bare Repository パターン
+
+```
+/home/user/dev/project-name/        # プロジェクトコンテナ
+├── .bare/                          # bare git repository (実データ)
+├── .git                            # ポインタファイル → .bare を参照
+├── main/                           # worktree (main ブランチ)
+├── feature-xxx/                    # worktree (feature-xxx ブランチ)
+└── issue-42/                       # worktree (issue-42 ブランチ)
+```
+
+### 構成のメリット
+
+| 観点 | メリット |
+|------|----------|
+| 整理性 | 1リポジトリ = 1ディレクトリ、他リポジトリと混ざらない |
+| 分離 | bare repo は純粋なGitデータ、worktree がファイル操作 |
+| AI並列開発 | 各worktreeで独立したClaude Codeセッション実行可能 |
+| コンテキスト保持 | ブランチごとに会話履歴・状態が保持される |
+
+## セットアップ手順
+
+### 新規リポジトリの場合
+
+```bash
+# 1. プロジェクトコンテナ作成
+mkdir -p /home/user/dev/project-name
+cd /home/user/dev/project-name
+
+# 2. GitHubリポジトリ作成（READMEを含めて初期コミットを作成）
+gh repo create username/project-name --public \
+  --description "Project description" \
+  --add-readme
+
+# 3. bare repository として初期化
+git clone --bare git@github.com:username/project-name.git .bare
+
+# 4. .git ポインタファイル作成
+echo "gitdir: ./.bare" > .git
+
+# 5. fetch 設定追加
+git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+
+# 6. main worktree 作成
+git worktree add main main
+```
+
+> **Note**: `--add-readme` オプションで初期コミットが作成される。
+> これがないと空リポジトリとなり、`git worktree add main main` が失敗する。
+
+### 既存リポジトリの移行
+
+```bash
+# 1. 既存リポジトリをbare形式でクローン
+cd /home/user/dev
+mkdir project-name
+cd project-name
+git clone --bare git@github.com:username/project-name.git .bare
+
+# 2. .git ポインタファイル作成
+echo "gitdir: ./.bare" > .git
+
+# 3. fetch 設定追加
+git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+
+# 4. main worktree 作成
+git worktree add main main
+```
+
+## 日常運用
+
+### Worktree の作成
+
+```bash
+# プロジェクトルートから実行
+cd /home/user/dev/project-name
+
+# 新規ブランチでworktree作成
+git worktree add -b feature/new-feature ./feature-new-feature main
+
+# 既存ブランチでworktree作成
+git worktree add ./hotfix-123 hotfix/123
+```
+
+### Worktree の一覧表示
+
+```bash
+git worktree list
+```
+
+### Worktree の削除
+
+```bash
+# worktreeディレクトリを削除
+git worktree remove ./feature-new-feature
+
+# ブランチも削除する場合（マージ済み）
+git branch -d feature/new-feature
+
+# ブランチも削除する場合（強制）
+git branch -D feature/new-feature
+```
+
+### ブランチ切り替え
+
+```bash
+# git checkout は使わない
+# 代わりにディレクトリ移動
+cd ../feature-xxx
+```
+
+## 運用ルール
+
+### Do
+
+- ディレクトリ移動でブランチ切り替え (`cd ../feature-xxx`)
+- worktree管理はプロジェクトルートから実行
+- 各worktreeでupstream設定 (`git branch --set-upstream-to=origin/xxx`)
+
+### Don't
+
+- `git checkout` を使わない（ディレクトリ移動で対応）
+- プロジェクトルートで一般的なgitコマンドを実行しない
+
+## 参考資料
+
+- [How to use git worktree and in a clean way](https://morgan.cugerone.com/blog/how-to-use-git-worktree-and-in-a-clean-way/)
+- [Bare Git Worktrees AGENTS.md](https://gist.github.com/ben-vargas/fd99be9bbce6d485c70442dd939f1a3d)
+- [Git Worktree Best Practices and Tools](https://gist.github.com/ChristopherA/4643b2f5e024578606b9cd5d2e6815cc)
+- [incident.io: Shipping faster with Claude Code and Git Worktrees](https://incident.io/blog/shipping-faster-with-claude-code-and-git-worktrees)
+- [Parallel AI Coding with Git Worktrees](https://docs.agentinterviews.com/blog/parallel-ai-coding-with-gitworktrees/)


### PR DESCRIPTION
## Summary

- ADRおよびCLAUDE.mdに含まれていた汎用的な開発プラクティスを独立したガイドドキュメントとして切り出し
- ADRは設計決定の記録に集中し、How-toはガイドに分離

## Changes

| ファイル | 変更 |
|----------|------|
| `docs/guides/git-worktree.md` | 新規 - Bare Repository + Worktree パターン |
| `docs/guides/git-commit-flow.md` | 新規 - git absorb + --no-ff 戦略 |
| `docs/adr/2025-12-27-dev-agent-orchestra-design.md` | Section 4 削除、ガイドへの参照に置換 |
| `CLAUDE.md` | Git Workflow セクションをガイドへの参照に置換 |

## Test plan

- [x] ガイド内のコマンド例が正しいことを確認
- [x] リンクが正しく機能することを確認
- [x] レビュー指摘対応（git absorb の説明改善、初期コミット処理の明確化）

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)