### PR TITLE
docs: add issue-driven development workflow (#6)

### DIFF
--- a/.claude/commands/issue-pr.md
+++ b/.claude/commands/issue-pr.md
@@ -141,8 +141,57 @@ git commit -m "chore: remove draft design (moved to PR)"
 
 ```bash
 git push -u origin HEAD
+```
 
-gh pr create --title "[prefix]: タイトル (#[issue-number])" --body "..."
+**設計書がある場合:**
+
+```bash
+gh pr create --title "[prefix]: タイトル (#[issue-number])" --body "$(cat <<'EOF'
+## Summary
+
+(Issueの概要)
+
+Closes #[issue-number]
+
+## Design
+
+<details>
+<summary>設計書</summary>
+
+(設計書の内容)
+
+</details>
+
+## Changes
+
+- (変更点)
+
+## Test Plan
+
+- [x] テストパス
+EOF
+)"
+```
+
+**設計書がない場合:**
+
+```bash
+gh pr create --title "[prefix]: タイトル (#[issue-number])" --body "$(cat <<'EOF'
+## Summary
+
+(Issueの概要)
+
+Closes #[issue-number]
+
+## Changes
+
+- (変更点)
+
+## Test Plan
+
+- [x] テストパス
+EOF
+)"
 ```
 
 ### Step 8: 完了報告


### PR DESCRIPTION
## Summary

Issue駆動開発ワークフローを導入し、12個のスラッシュコマンドを追加しました。

Closes #6

## Changes

- `docs/DEVELOPMENT_WORKFLOW.md`: ワークフロー全体の説明
- `.claude/commands/issue-*.md`: 12個のコマンド定義
  - ライフサイクル: create, start, pr, close
  - 設計: design, review-design, fix-design, verify-design
  - 実装: implement, review-code, fix-code, verify-code
- `pr-prepare.md`: 非推奨マーク追加（issue-prに統合）

## Test Plan

- [x] 既存テストがパス（ドキュメントのみの変更）
- [x] 手動検証: Issue #6 で実際にワークフローを試行