### PR TITLE
docs: add .venv symlink steps for worktree workflow

### DIFF
--- a/.claude/commands/issue-close.md
+++ b/.claude/commands/issue-close.md
@@ -57,19 +57,27 @@ gh pr merge [branch-name] --merge --delete-branch
 
 マージコミットを作成してブランチ履歴を保持する。
 
-### Step 4: worktree削除
+### Step 4: venv シンボリックリンク削除
+
+worktree 削除前に `.venv` シンボリックリンクを削除（untracked files エラー回避）:
+
+```bash
+rm [worktree-path]/.venv
+```
+
+### Step 5: worktree削除
 
 ```bash
 git worktree remove [worktree-path]
 ```
 
-### Step 5: mainを最新化
+### Step 6: mainを最新化
 
 ```bash
 git pull origin main
 ```
 
-### Step 6: 完了報告
+### Step 7: 完了報告
 
 以下の形式で報告してください:
 
@@ -80,6 +88,7 @@ git pull origin main
 |------|------|
 | Issue | #[issue-number] |
 | PR | マージ済み |
+| .venv symlink | 削除済み |
 | worktree | 削除済み |
 | リモートブランチ | 削除済み (--delete-branch) |
 | main | 最新化済み |

--- a/.claude/commands/issue-start.md
+++ b/.claude/commands/issue-start.md
@@ -46,7 +46,17 @@ $ARGUMENTS から issue-number と prefix を取得してください。
 git worktree add -b [prefix]/[issue-number] ../[prefix]-[issue-number] main
 ```
 
-### Step 2: Worktreeの確認
+### Step 2: venv シンボリックリンク作成
+
+main の `.venv` へのシンボリックリンクを作成:
+
+```bash
+ln -s ../main/.venv ../[prefix]-[issue-number]/.venv
+```
+
+これにより `ruff`、`mypy`、`pytest` が即座に実行可能になります。
+
+### Step 3: Worktreeの確認
 
 ```bash
 git worktree list
@@ -54,7 +64,7 @@ git worktree list
 
 ワークツリーが正しく作成されたことを確認してください。
 
-### Step 3: Issue本文にメタ情報を追記
+### Step 4: Issue本文にメタ情報を追記
 
 Issue本文の先頭にWorktree情報を追記します:
 
@@ -76,7 +86,7 @@ EOF
 gh issue edit [issue-number] --body "$NEW_BODY"
 ```
 
-### Step 4: セットアップ完了報告
+### Step 5: セットアップ完了報告
 
 以下の形式で報告してください:
 
@@ -89,7 +99,17 @@ gh issue edit [issue-number] --body "$NEW_BODY"
 | ブランチ | [prefix]/[issue-number] |
 | ディレクトリ | ../[prefix]-[issue-number] |
 | 基点ブランチ | main |
+| .venv | main へのシンボリックリンク |
 | メタ情報 | Issue本文に追記済み |
+
+### 注意事項
+
+⚠️ `.venv` は main のシンボリックリンクです:
+- `pip install` は main に影響します
+- pyproject.toml を変更する場合は個別 venv を作成してください:
+  ```bash
+  rm .venv && python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+  ```
 
 ### 次のステップ
 

--- a/docs/guides/git-worktree.md
+++ b/docs/guides/git-worktree.md
@@ -79,6 +79,42 @@ git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git worktree add main main
 ```
 
+## Python 仮想環境
+
+### 初回セットアップ（main worktree）
+
+```bash
+cd /home/user/dev/project-name/main
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+### 新規 worktree での .venv 共有
+
+新しい worktree を作成したら、main の `.venv` へシンボリックリンクを作成:
+
+```bash
+# プロジェクトルートから実行
+cd /home/user/dev/project-name
+ln -s ../main/.venv ./feature-xxx/.venv
+```
+
+これにより `ruff`、`mypy`、`pytest` が即座に実行可能になる。
+
+### 注意事項
+
+⚠️ `.venv` は main のシンボリックリンク:
+- `pip install` は main に影響する
+- pyproject.toml の依存関係を変更する場合は個別 venv を作成:
+  ```bash
+  cd ./feature-xxx
+  rm .venv
+  python3 -m venv .venv
+  source .venv/bin/activate
+  pip install -e ".[dev]"
+  ```
+
 ## 日常運用
 
 ### Worktree の作成
@@ -92,6 +128,9 @@ git worktree add -b feature/new-feature ./feature-new-feature main
 
 # 既存ブランチでworktree作成
 git worktree add ./hotfix-123 hotfix/123
+
+# .venv シンボリックリンク作成
+ln -s ../main/.venv ./feature-new-feature/.venv
 ```
 
 ### Worktree の一覧表示


### PR DESCRIPTION
## Summary

Worktree 作成時に main の `.venv` をシンボリックリンクで共有する手順を追加。
これにより新しい worktree で即座に `ruff`、`mypy`、`pytest` が実行可能になる。

## Changes

- `docs/guides/git-worktree.md`: Python仮想環境セクション追加
- `.claude/commands/issue-start.md`: Step 2 に .venv symlink 作成を追加
- `.claude/commands/issue-close.md`: Step 4 に .venv symlink 削除を追加

## Test Plan

- [x] ドキュメントの手順に従って worktree を作成し、.venv symlink が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)