### PR TITLE
docs: add link to DEVELOPMENT_WORKFLOW.md in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,3 +139,7 @@ IMPLEMENT ──(always)──> IMPLEMENT_REVIEW
 
 9ステートのフルワークフロー。bugfix-v5 から移植予定。
 `review → fix → verify` パターンを適用予定。
+
+## Related
+
+- [DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md) - Claude Code スキルによる開発ワークフロー（`draft/design/` パターン等）


### PR DESCRIPTION
## Summary

- architecture.md に DEVELOPMENT_WORKFLOW.md へのリンクを追加
- `draft/design/` パターンは Claude Code スキルの運用プロセスであり、dao 本体のアーキテクチャとは無関係と判断

## Changes

- `docs/architecture.md`: Related セクションを追加し、DEVELOPMENT_WORKFLOW.md へのリンクを記載

## Decision

Issue #11 の完了条件4「draft/design/ パターンの設計追記」について検討した結果：

| 当初案 | 決定 |
|--------|------|
| architecture.md に設計書ライフサイクルを追記 | **対応不要** |

**理由**: `draft/design/` パターンは Claude Code スキル（プロンプト）の運用プロセスであり、dao 本体の Python 実装アーキテクチャとは無関係。詳細は DEVELOPMENT_WORKFLOW.md に既存。

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)