### PR TITLE
fix: 品質チェックコマンドを bugfix_agent/ に修正、lint/typeエラー解消 (#53)

### DIFF
--- a/.claude/skills/issue-fix-code/SKILL.md
+++ b/.claude/skills/issue-fix-code/SKILL.md
@@ -73,9 +73,9 @@ $ARGUMENTS = <issue-number>
 
    ```bash
    cd [worktree-absolute-path] && source .venv/bin/activate && \
-     ruff check src/ tests/ && \
-     ruff format src/ tests/ && \
-     mypy src/ && \
+     ruff check bugfix_agent/ tests/ && \
+     ruff format bugfix_agent/ tests/ && \
+     mypy bugfix_agent/ && \
      pytest
    ```
 

--- a/.claude/skills/issue-implement/SKILL.md
+++ b/.claude/skills/issue-implement/SKILL.md
@@ -113,9 +113,9 @@ cat [worktree-absolute-path]/draft/design/issue-[number]-*.md
 
 ```bash
 cd [worktree-absolute-path] && source .venv/bin/activate && \
-  ruff check src/ tests/ && \
-  ruff format src/ tests/ && \
-  mypy src/ && \
+  ruff check bugfix_agent/ tests/ && \
+  ruff format bugfix_agent/ tests/ && \
+  mypy bugfix_agent/ && \
   pytest
 ```
 

--- a/.claude/skills/issue-review-code/SKILL.md
+++ b/.claude/skills/issue-review-code/SKILL.md
@@ -66,7 +66,7 @@ $ARGUMENTS = <issue-number>
 ```bash
 cd [worktree-absolute-path] && source .venv/bin/activate && \
   ruff check bugfix_agent/ tests/ && \
-  ruff format --check src/ tests/ && \
+  ruff format --check bugfix_agent/ tests/ && \
   mypy bugfix_agent/ && \
   pytest
 ```

--- a/.claude/skills/issue-review-code/SKILL.md
+++ b/.claude/skills/issue-review-code/SKILL.md
@@ -65,9 +65,9 @@ $ARGUMENTS = <issue-number>
 
 ```bash
 cd [worktree-absolute-path] && source .venv/bin/activate && \
-  ruff check src/ tests/ && \
+  ruff check bugfix_agent/ tests/ && \
   ruff format --check src/ tests/ && \
-  mypy src/ && \
+  mypy bugfix_agent/ && \
   pytest
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Treat the user as an equal partner. Goal: clarity, traction, and progress.
 ## ⚠️ Pre-Commit (REQUIRED)
 ```bash
 source .venv/bin/activate
-ruff check src/ tests/ && ruff format src/ tests/ && mypy src/ && pytest
+ruff check bugfix_agent/ tests/ && ruff format bugfix_agent/ tests/ && mypy bugfix_agent/ && pytest
 ```
 
 ## Essential Commands
@@ -34,10 +34,10 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 
 # Quality checks (run before commit)
-ruff check src/ tests/       # Lint
-ruff format src/ tests/      # Format
-mypy src/                    # Type check
-pytest                       # Test
+ruff check bugfix_agent/ tests/       # Lint
+ruff format bugfix_agent/ tests/      # Format
+mypy bugfix_agent/                    # Type check
+pytest                                # Test
 
 # CLI
 dao list              # List workflows

--- a/bugfix_agent/context.py
+++ b/bugfix_agent/context.py
@@ -5,10 +5,8 @@ This module provides context data construction:
 """
 
 from pathlib import Path
-from typing import Any
 
 from .config import get_config_value, get_workdir
-from .run_logger import RunLogger
 
 
 def build_context(
@@ -66,7 +64,7 @@ def build_context(
             content = resolved.read_text(encoding="utf-8")
             result_parts.append(f"\n--- {path_str} ---\n{content}\n")
         except (PermissionError, OSError) as e:
-            _log_warning(f"Failed to read {path_str}: {e}")
+            print(f"⚠️ Failed to read {path_str}: {e}")
             continue
 
     result = "".join(result_parts)

--- a/bugfix_agent/handlers/design.py
+++ b/bugfix_agent/handlers/design.py
@@ -71,15 +71,11 @@ def handle_detail_design_review(ctx: AgentContext, state: SessionState) -> State
     log_dir = ctx.artifacts_state_dir("detail_design_review")
     prompt = load_prompt("detail_design_review", issue_url=ctx.issue_url)
 
-    decision, _ = ctx.reviewer.run(
-        prompt=prompt, context=ctx.issue_url, log_dir=log_dir
-    )
+    decision, _ = ctx.reviewer.run(prompt=prompt, context=ctx.issue_url, log_dir=log_dir)
     check_tool_result(decision, "reviewer")
 
     # VERDICT形式でパース（Issue #292: ハイブリッドフォールバック対応）
-    ai_formatter = create_ai_formatter(
-        ctx.reviewer, context=ctx.issue_url, log_dir=log_dir
-    )
+    ai_formatter = create_ai_formatter(ctx.reviewer, context=ctx.issue_url, log_dir=log_dir)
     verdict = parse_verdict(decision, ai_formatter=ai_formatter)
 
     # ABORTの場合は例外を送出（Issue #292 責務分離）

--- a/bugfix_agent/handlers/implement.py
+++ b/bugfix_agent/handlers/implement.py
@@ -87,9 +87,7 @@ def handle_implement_review(ctx: AgentContext, state: SessionState) -> State:
     check_tool_result(decision, "reviewer")
 
     # VERDICT形式でパース（Issue #292: ハイブリッドフォールバック対応）
-    ai_formatter = create_ai_formatter(
-        ctx.reviewer, context=ctx.issue_url, log_dir=log_dir
-    )
+    ai_formatter = create_ai_formatter(ctx.reviewer, context=ctx.issue_url, log_dir=log_dir)
     verdict = parse_verdict(decision, ai_formatter=ai_formatter)
 
     # ABORTの場合は例外を送出（Issue #292 責務分離）

--- a/bugfix_agent/handlers/init.py
+++ b/bugfix_agent/handlers/init.py
@@ -32,15 +32,11 @@ def handle_init(ctx: AgentContext, state: SessionState) -> State:
     log_dir = ctx.artifacts_state_dir("init")
     prompt = load_prompt("init", issue_url=ctx.issue_url)
 
-    result, _ = ctx.reviewer.run(
-        prompt=prompt, context=ctx.issue_url, log_dir=log_dir
-    )
+    result, _ = ctx.reviewer.run(prompt=prompt, context=ctx.issue_url, log_dir=log_dir)
     check_tool_result(result, "reviewer")
 
     # VERDICT形式でパース（Issue #292: ハイブリッドフォールバック対応）
-    ai_formatter = create_ai_formatter(
-        ctx.reviewer, context=ctx.issue_url, log_dir=log_dir
-    )
+    ai_formatter = create_ai_formatter(ctx.reviewer, context=ctx.issue_url, log_dir=log_dir)
     verdict = parse_verdict(result, ai_formatter=ai_formatter)
 
     # ABORTの場合はコメントを投稿してから例外を送出

--- a/bugfix_agent/handlers/investigate.py
+++ b/bugfix_agent/handlers/investigate.py
@@ -71,15 +71,11 @@ def handle_investigate_review(ctx: AgentContext, state: SessionState) -> State:
     log_dir = ctx.artifacts_state_dir("investigate_review")
     prompt = load_prompt("investigate_review", issue_url=ctx.issue_url)
 
-    decision, _ = ctx.reviewer.run(
-        prompt=prompt, context=ctx.issue_url, log_dir=log_dir
-    )
+    decision, _ = ctx.reviewer.run(prompt=prompt, context=ctx.issue_url, log_dir=log_dir)
     check_tool_result(decision, "reviewer")
 
     # VERDICT形式でパース（Issue #292: ハイブリッドフォールバック対応）
-    ai_formatter = create_ai_formatter(
-        ctx.reviewer, context=ctx.issue_url, log_dir=log_dir
-    )
+    ai_formatter = create_ai_formatter(ctx.reviewer, context=ctx.issue_url, log_dir=log_dir)
     verdict = parse_verdict(decision, ai_formatter=ai_formatter)
 
     # ABORTの場合は例外を送出（Issue #292 責務分離）

--- a/bugfix_agent/handlers/pr.py
+++ b/bugfix_agent/handlers/pr.py
@@ -4,8 +4,9 @@ This module provides:
 - handle_pr_create: Create Pull Request and share PR URL
 """
 
-from ..agent_context import AgentContext
 import subprocess
+
+from ..agent_context import AgentContext
 from ..state import SessionState, State
 
 

--- a/bugfix_agent/tools/base.py
+++ b/bugfix_agent/tools/base.py
@@ -8,8 +8,6 @@ This module provides:
 from pathlib import Path
 from typing import Protocol
 
-from ..run_logger import RunLogger
-
 
 class AIToolProtocol(Protocol):
     """AI CLI ツールの統一インターフェース

--- a/bugfix_agent/tools/claude.py
+++ b/bugfix_agent/tools/claude.py
@@ -9,15 +9,14 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from ..cli import run_cli_streaming
 from ..config import get_config_value
 from ..context import build_context
 
 if TYPE_CHECKING:
-    from ..run_logger import RunLogger
-
+    pass
 
 
 class ClaudeTool:

--- a/bugfix_agent/tools/claude.py
+++ b/bugfix_agent/tools/claude.py
@@ -9,14 +9,11 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ..cli import run_cli_streaming
 from ..config import get_config_value
 from ..context import build_context
-
-if TYPE_CHECKING:
-    pass
 
 
 class ClaudeTool:

--- a/bugfix_agent/tools/codex.py
+++ b/bugfix_agent/tools/codex.py
@@ -9,14 +9,10 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from ..cli import run_cli_streaming
 from ..config import get_config_value, get_workdir
 from ..context import build_context
-
-if TYPE_CHECKING:
-    pass
 
 
 class CodexTool:

--- a/bugfix_agent/tools/codex.py
+++ b/bugfix_agent/tools/codex.py
@@ -16,8 +16,7 @@ from ..config import get_config_value, get_workdir
 from ..context import build_context
 
 if TYPE_CHECKING:
-    from ..run_logger import RunLogger
-
+    pass
 
 
 class CodexTool:

--- a/bugfix_agent/tools/gemini.py
+++ b/bugfix_agent/tools/gemini.py
@@ -9,14 +9,10 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from ..cli import run_cli_streaming
 from ..config import get_config_value
 from ..context import build_context
-
-if TYPE_CHECKING:
-    pass
 
 
 class GeminiTool:

--- a/bugfix_agent/tools/gemini.py
+++ b/bugfix_agent/tools/gemini.py
@@ -16,8 +16,7 @@ from ..config import get_config_value
 from ..context import build_context
 
 if TYPE_CHECKING:
-    from ..run_logger import RunLogger
-
+    pass
 
 
 class GeminiTool:

--- a/tests/test_issue_provider.py
+++ b/tests/test_issue_provider.py
@@ -6,8 +6,9 @@ These tests verify:
 3. Handler integration with IssueProvider
 """
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from bugfix_agent.agent_context import AgentContext
 from bugfix_agent.errors import AgentAbortError


### PR DESCRIPTION
## Summary

品質チェックコマンドが存在しない `src/` を対象にしていたバグを修正し、`bugfix_agent/` に統一。合わせて既存の ruff/mypy エラー（11件）をすべて解消した。

Closes #53

## Changes

- `CLAUDE.md`: Pre-Commit・Essential Commands の ruff/mypy 対象を `src/` → `bugfix_agent/` に修正
- `.claude/skills/issue-{implement,fix-code,review-code}/SKILL.md`: 同様にコマンド修正
- `bugfix_agent/context.py`: 未使用 import 削除、未定義 `_log_warning` → `print()`、末尾改行追加
- `bugfix_agent/handlers/pr.py`: import 順序修正
- `bugfix_agent/tools/{base,claude,codex,gemini}.py`: 未使用 `RunLogger` import・空 `TYPE_CHECKING` ブロック削除
- `tests/test_issue_provider.py`: import 順序修正

## Test Plan

- [x] 既存テストがパス（36 passed）
- [x] `ruff check bugfix_agent/ tests/` → All checks passed
- [x] `mypy bugfix_agent/` → no issues found