### PR TITLE
feat: make current Claude skills usable from Codex

### DIFF
--- a/.agents/skills/_shared
+++ b/.agents/skills/_shared
@@ -1,0 +1,1 @@
+../../.claude/skills/_shared

--- a/.agents/skills/issue-close
+++ b/.agents/skills/issue-close
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-close

--- a/.agents/skills/issue-create
+++ b/.agents/skills/issue-create
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-create

--- a/.agents/skills/issue-design
+++ b/.agents/skills/issue-design
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-design

--- a/.agents/skills/issue-doc-check
+++ b/.agents/skills/issue-doc-check
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-doc-check

--- a/.agents/skills/issue-fix-code
+++ b/.agents/skills/issue-fix-code
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-fix-code

--- a/.agents/skills/issue-fix-design
+++ b/.agents/skills/issue-fix-design
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-fix-design

--- a/.agents/skills/issue-implement
+++ b/.agents/skills/issue-implement
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-implement

--- a/.agents/skills/issue-pr
+++ b/.agents/skills/issue-pr
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-pr

--- a/.agents/skills/issue-review-code
+++ b/.agents/skills/issue-review-code
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-review-code

--- a/.agents/skills/issue-review-design
+++ b/.agents/skills/issue-review-design
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-review-design

--- a/.agents/skills/issue-start
+++ b/.agents/skills/issue-start
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-start

--- a/.agents/skills/issue-verify-code
+++ b/.agents/skills/issue-verify-code
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-verify-code

--- a/.agents/skills/issue-verify-design
+++ b/.agents/skills/issue-verify-design
@@ -1,0 +1,1 @@
+../../.claude/skills/issue-verify-design

--- a/.claude/skills/issue-close/SKILL.md
+++ b/.claude/skills/issue-close/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: イシュー完了時に使用。設計書アーカイブ・PRマージ・worktree削除・ブランチ削除を一括実行
-argument-hint: <issue-number>
+name: issue-close
 ---
 
 # Issue Close

--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue作成とラベル付与を行う。開発ワークフローの起点。
-argument-hint: <title> [type] [description]
+name: issue-create
 ---
 
 # Issue Create

--- a/.claude/skills/issue-design/SKILL.md
+++ b/.claude/skills/issue-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue要件に基づき、draft/design/に設計書を作成する。worktree内での作業が前提。
-argument-hint: <issue-number>
+name: issue-design
 ---
 
 # Issue Design

--- a/.claude/skills/issue-doc-check/SKILL.md
+++ b/.claude/skills/issue-doc-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: PR前の品質ゲートとして、コード変更に伴うドキュメント影響を網羅チェックする
-argument-hint: <issue-number>
+name: issue-doc-check
 ---
 
 # Issue Doc Check

--- a/.claude/skills/issue-fix-code/SKILL.md
+++ b/.claude/skills/issue-fix-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: レビュー指摘事項に対し、技術的妥当性を検討した上で修正対応（または反論）を行う
-argument-hint: <issue-number>
+name: issue-fix-code
 ---
 
 # Issue Fix Code

--- a/.claude/skills/issue-fix-design/SKILL.md
+++ b/.claude/skills/issue-fix-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: 設計レビューの指摘事項に基づき、設計ドキュメントを修正または議論する。
-argument-hint: <issue-number>
+name: issue-fix-design
 ---
 
 # Issue Fix Design

--- a/.claude/skills/issue-implement/SKILL.md
+++ b/.claude/skills/issue-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: 設計書（draft/design/）に基づき、TDD（テスト駆動開発）アプローチを用いて機能を実装する。
-argument-hint: <issue-number>
+name: issue-implement
 ---
 
 # Issue Implement

--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: コミット整理・プッシュ・PR作成を一括実行
-argument-hint: <issue-number>
+name: issue-pr
 ---
 
 # Issue PR

--- a/.claude/skills/issue-review-code/SKILL.md
+++ b/.claude/skills/issue-review-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: 実装完了後の成果物に対し、設計整合性とコード品質の観点から厳格なレビューを実施する
-argument-hint: <issue-number>
+name: issue-review-code
 ---
 
 # Issue Review Code

--- a/.claude/skills/issue-review-design/SKILL.md
+++ b/.claude/skills/issue-review-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: 設計ドキュメントに対し、汎用的なソフトウェア設計原則に基づいてレビューを行う。
-argument-hint: <issue-number>
+name: issue-review-design
 ---
 
 # Issue Review Design

--- a/.claude/skills/issue-start/SKILL.md
+++ b/.claude/skills/issue-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: イシュー着手時に使用。worktreeで分離された開発環境を構築し、Issue本文にメタ情報を追記する
-argument-hint: <issue-number> [prefix]
+name: issue-start
 ---
 
 # Issue Start

--- a/.claude/skills/issue-verify-code/SKILL.md
+++ b/.claude/skills/issue-verify-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: コード修正が適切に行われたかを確認する。新規指摘は行わない（レビュー収束のため）。
-argument-hint: <issue-number>
+name: issue-verify-code
 ---
 
 # Issue Verify Code

--- a/.claude/skills/issue-verify-design/SKILL.md
+++ b/.claude/skills/issue-verify-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: 設計修正が適切に行われたかを確認する。新規指摘は行わない（レビュー収束のため）。
-argument-hint: <issue-number>
+name: issue-verify-design
 ---
 
 # Issue Verify Design


### PR DESCRIPTION
## Summary
- add Codex/Gemini skill mirror directory `.agents/skills` as symlinks to `.claude/skills`
- update all 13 `.claude/skills/*/SKILL.md` frontmatters for cross-client compatibility
  - add required `name`
  - remove `argument-hint` (Codex warning source)
- keep skill body content unchanged (frontmatter minimum change only)

## Why
To align with the compatibility policy discussed in:
- https://github.com/apokamo/kamo2/issues/651

This keeps Claude skill assets as the single source of truth while making Codex load them without warnings.

## Verification
- `argument-hint` remaining in `.claude/skills`: 0
- `name` present in all 13 skill frontmatters
- `.agents/skills` contains symlink entries for all current skills (+ `_shared`)
