### PR TITLE
feat: dao run CLIエントリーポイントの実装 (#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ pytest                               # Test
 dao run <workflow.yaml> <issue>                    # Run a workflow
 dao run <workflow.yaml> <issue> --from <step-id>   # Resume from a step
 dao run <workflow.yaml> <issue> --step <step-id>   # Run a single step
+dao run <workflow.yaml> <issue> --workdir <dir>    # Set agent working directory
+dao run <workflow.yaml> <issue> --quiet            # Suppress agent output
 ```
 
 ## Git & GitHub

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ Issue駆動のTDD開発フロー:
 
 各フェーズにレビューサイクルあり。詳細: [docs/dev/development_workflow.md](docs/dev/development_workflow.md)
 
+## ワークフロー実行
+
+```bash
+# ワークフローを実行
+dao run workflows/feature-development.yaml 57
+
+# 途中から再開
+dao run workflows/feature-development.yaml 57 --from fix-code
+
+# 単一ステップ実行
+dao run workflows/feature-development.yaml 57 --step review-code
+```
+
+詳細: [docs/dev/workflow-authoring.md](docs/dev/workflow-authoring.md)
+
 ## 品質チェック
 
 コミット前に必ず実行:

--- a/dao_harness/cli_main.py
+++ b/dao_harness/cli_main.py
@@ -1,0 +1,135 @@
+"""CLI entrypoint for dao_harness.
+
+Provides the `dao` command with subcommands (e.g., `dao run`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .errors import (
+    HarnessError,
+    SecurityError,
+    SkillNotFound,
+    WorkflowValidationError,
+)
+from .runner import WorkflowRunner
+from .workflow import load_workflow
+
+EXIT_OK = 0
+EXIT_ABORT = 1
+EXIT_DEFINITION_ERROR = 2
+EXIT_RUNTIME_ERROR = 3
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the top-level argument parser with subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="dao",
+        description="AI-driven development workflow orchestrator",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _register_run(subparsers)
+    return parser
+
+
+def _register_run(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the `run` subcommand."""
+    p = subparsers.add_parser("run", help="Run a workflow")
+    p.add_argument("workflow", type=Path, help="Path to workflow YAML file")
+    p.add_argument("issue", type=int, help="GitHub Issue number")
+    p.add_argument("--from", dest="from_step", help="Resume from a specific step")
+    p.add_argument("--step", dest="single_step", help="Run a single step only")
+    p.add_argument(
+        "--workdir",
+        type=Path,
+        default=Path.cwd(),
+        help="Working directory for agent CLI (default: current directory)",
+    )
+    p.add_argument("--quiet", action="store_true", help="Suppress agent output streaming")
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    """Execute the `run` subcommand."""
+    # Mutual exclusion: --from and --step
+    if args.from_step and args.single_step:
+        print(
+            "Error: --from and --step are mutually exclusive",
+            file=sys.stderr,
+        )
+        return EXIT_DEFINITION_ERROR
+
+    # Validate --workdir
+    workdir = args.workdir.resolve()
+    if not workdir.is_dir():
+        print(
+            f"Error: --workdir '{args.workdir}' is not a valid directory",
+            file=sys.stderr,
+        )
+        return EXIT_DEFINITION_ERROR
+
+    # Load and validate workflow
+    workflow_path = args.workflow
+    if not workflow_path.exists():
+        print(
+            f"Error: Workflow file not found: {workflow_path}",
+            file=sys.stderr,
+        )
+        return EXIT_DEFINITION_ERROR
+
+    try:
+        workflow = load_workflow(workflow_path)
+    except WorkflowValidationError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_DEFINITION_ERROR
+
+    # Run workflow
+    try:
+        runner = WorkflowRunner(
+            workflow=workflow,
+            issue_number=args.issue,
+            workdir=workdir,
+            from_step=args.from_step,
+            single_step=args.single_step,
+            verbose=not args.quiet,
+        )
+        state = runner.run()
+    except (WorkflowValidationError, SkillNotFound, SecurityError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_DEFINITION_ERROR
+    except HarnessError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_RUNTIME_ERROR
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        return EXIT_ABORT
+
+    # Check for ABORT verdict
+    if state.last_transition_verdict and state.last_transition_verdict.status == "ABORT":
+        print(
+            f"Workflow aborted: {state.last_transition_verdict.reason}",
+            file=sys.stderr,
+        )
+        return EXIT_ABORT
+
+    # Success summary
+    print(f"Workflow '{workflow.name}' completed for issue #{args.issue}")
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entrypoint."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        return cmd_run(args)
+
+    parser.print_help()
+    return EXIT_ABORT
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/dev/workflow-authoring.md
+++ b/docs/dev/workflow-authoring.md
@@ -178,7 +178,24 @@ dao run workflows/feature-development.yaml 57 --from fix-code
 
 # 単発実行（1ステップのみ実行して終了）
 dao run workflows/feature-development.yaml 57 --step review-code
+
+# エージェント作業ディレクトリを指定
+dao run workflows/feature-development.yaml 57 --workdir ../dao-feat-57
+
+# エージェント出力のストリーミング表示を抑制
+dao run workflows/feature-development.yaml 57 --quiet
 ```
+
+**注意**: `--from` と `--step` は排他オプションです（同時指定不可）。
+
+### 終了コード
+
+| 終了コード | 意味 |
+|-----------|------|
+| 0 | 正常終了 |
+| 1 | ワークフロー ABORT または予期しないエラー |
+| 2 | 定義エラー（YAML不正、スキル未検出、引数エラー等） |
+| 3 | 実行時エラー（CLI実行失敗、タイムアウト、verdict解析失敗等） |
 
 ## 関連ドキュメント
 

--- a/draft/design/issue-67-cli-run.md
+++ b/draft/design/issue-67-cli-run.md
@@ -8,19 +8,19 @@ Issue: #67
 
 ## 背景・目的
 
-ハーネスのコア機能（`WorkflowRunner`, `load_workflow`, `SessionState` 等）は実装・テスト済みだが、CLIフロントエンドが存在しないため `dao run <workflow.yaml> <issue>` として実行できない。#65 で CLI基盤（`cli_main.py` + argparse サブコマンド構造 + `pyproject.toml` の `[project.scripts]` 有効化）が作成される前提で、本イシューでは `run` サブコマンドを追加する。
+ハーネスのコア機能（`WorkflowRunner`, `load_workflow`, `SessionState` 等）は実装・テスト済みだが、CLIフロントエンドが存在しないため `dao run <workflow.yaml> <issue>` として実行できない。
 
-## 前提条件
+## 前提条件・スコープ
 
-- #65 (`dao validate`) がマージ済みであること
-- `cli_main.py` に argparse サブコマンドパーサーが存在すること
+本イシューで CLI 基盤（`cli_main.py` + argparse サブコマンドパーサー + `pyproject.toml` の `[project.scripts]` 有効化）と `run` サブコマンドの両方を実装する。
 
-### #65 依存の解消方針
+#65 (`dao validate`) は 2026-03-11 時点で OPEN であり、マージ待ちでブロックするのではなく、#67 側で CLI 基盤を構築する。#65 は後から `validate` サブコマンドを追加する形で進める（基盤の重複実装を回避）。
 
-#65 は 2026-03-11 時点で OPEN。以下の方針で対応する:
+### 本イシューの実装範囲
 
-1. **実装開始条件**: #65 のマージを待つ。#67 ブランチは `main` から作成済みのため、#65 マージ後に `git merge main` で基盤を取り込む
-2. **#65 が長期停滞した場合**: #67 のスコープを拡張し、CLI 基盤（`cli_main.py` + `[project.scripts]`）ごと本イシューで実装する。この場合 #65 は #67 に吸収される
+1. `dao_harness/cli_main.py` — argparse サブコマンドパーサー + `run` サブコマンド
+2. `pyproject.toml` — `[project.scripts]` のコメント解除 + `dao` エントリポイント追加
+3. テスト
 
 ## インターフェース
 
@@ -77,17 +77,30 @@ dao run workflows/design.yaml 67 --workdir ../dao-feat-67 --quiet
 
 | 対象 | 保存先 | `--workdir` の影響 |
 |------|--------|-------------------|
-| `SessionState` | `test-artifacts/<issue>/state.json`（プロセス cwd 基準） | なし |
+| `SessionState` | `test-artifacts/<issue>/session-state.json`（プロセス cwd 基準） | なし |
 | 実行ログ | `test-artifacts/<issue>/runs/<timestamp>/`（プロセス cwd 基準） | なし |
 | エージェント CLI の `cwd` | `--workdir` で指定されたディレクトリ | **あり** |
 
 この分離は `WorkflowRunner` の既存設計に従ったもの。`runner.py` で `run_dir` はプロセス cwd 基準、`execute_cli()` の `cwd=workdir` はエージェント実行先のみを指す。
 
+### `--workdir` 不正時のエラー契約
+
+`cmd_run` は `WorkflowRunner` を呼ぶ前に `--workdir` の事前検証を行う:
+
+```python
+workdir = args.workdir.resolve()
+if not workdir.is_dir():
+    print(f"Error: --workdir '{args.workdir}' is not a valid directory", file=sys.stderr)
+    return 2  # 定義エラー（実行前に検出可能）
+```
+
+**理由**: `cli.py` L54-59 では `subprocess.Popen(..., cwd=workdir)` の `FileNotFoundError` が `CLINotFoundError` に包まれるため、事前検証なしでは「作業ディレクトリ不正」が「CLI が見つからない」という誤った診断になる。事前検証により正確なエラーメッセージを返し、exit code 2（定義エラー）で終了する。
+
 ## 方針
 
-### 1. `cli_main.py` への `run` サブコマンド追加
+### 1. `cli_main.py` の作成と `run` サブコマンド追加
 
-#65 が作成する `cli_main.py` のサブコマンドパーサーに `run` を追加する。
+`cli_main.py` を新規作成し、argparse サブコマンドパーサーと `run` サブコマンドを実装する。サブコマンド構造は #65 (`validate`) が後から追加できる拡張性を持たせる。
 
 ```python
 # 疑似コード
@@ -151,6 +164,7 @@ except Exception as e:
 - 引数パース: 各オプションが正しく `WorkflowRunner` のパラメータにマッピングされること
 - exit code マッピング: 全 `HarnessError` サブクラス（`WorkflowValidationError`, `SkillNotFound`, `SecurityError`, `CLIExecutionError`, `CLINotFoundError`, `StepTimeoutError`, `MissingResumeSessionError`, `InvalidTransition`, `VerdictNotFound`, `VerdictParseError`, `InvalidVerdictValue`）が正しい exit code に変換されること
 - `HarnessError` 以外の予期しない例外 → exit 1
+- `--workdir` 事前検証: 存在しないパス → exit 2、ファイルパス（ディレクトリではない） → exit 2
 - サマリー出力のフォーマット
 
 ### Medium テスト
@@ -159,7 +173,7 @@ except Exception as e:
 - 不正なYAML → exit 2 + エラーメッセージが stderr に出力
 - `WorkflowRunner.run()` が `CLIExecutionError` → exit 3
 - `WorkflowRunner.run()` が ABORT verdict → exit 1
-- `--workdir` に存在しないディレクトリ → エラー
+- `--workdir` に存在しないディレクトリ → exit 2 + 正確なエラーメッセージ（`CLINotFoundError` ではなく）
 - `subprocess` 経由での `dao run --help` 出力検証
 
 ### Large テスト
@@ -171,7 +185,7 @@ except Exception as e:
 
 | ドキュメント | 影響の有無 | 理由 |
 |-------------|-----------|------|
-| docs/adr/ | なし | 新しい技術選定なし（argparse は #65 で選定済み） |
+| docs/adr/ | なし | argparse 選定は #65 で議論済み。本イシューは同方針を踏襲 |
 | docs/ARCHITECTURE.md | 軽微 | L108-113 で `dao run` の `--from` 再開を既に記述済み。新フラグ (`--workdir`, `--quiet`) の追記が必要な可能性 |
 | docs/dev/workflow-authoring.md | 更新 | L170-181 で `dao run` コマンド例を既に記述済み。新フラグの追記 + exit code の説明追加 |
 | docs/dev/skill-authoring.md | なし | コンテキスト変数の変更なし |
@@ -186,5 +200,6 @@ except Exception as e:
 |--------|----------|-------------------|
 | argparse 公式ドキュメント | https://docs.python.org/3/library/argparse.html | サブコマンドパーサー (`add_subparsers`) の仕様。#65 で選定済みの手法を踏襲 |
 | WorkflowRunner 実装 | `dao_harness/runner.py` | `run()` メソッドのシグネチャ: `workflow`, `issue_number`, `workdir`, `from_step`, `single_step`, `verbose` |
-| #65 設計 | GitHub Issue #65 | CLI基盤（`cli_main.py` + argparse + `[project.scripts]`）の設計。`run` サブコマンドは明示的にスコープ外 |
+| #65 設計 | https://github.com/apokamo/dev-agent-orchestra/issues/65 | CLI基盤（`cli_main.py` + argparse + `[project.scripts]`）の設計。`run` サブコマンドは明示的にスコープ外。#67 で基盤を先行実装する方針に変更 |
+| state.py | `dao_harness/state.py` L15-16 | `STATE_FILE = "session-state.json"`。状態ファイルの正式名称 |
 | errors.py | `dao_harness/errors.py` | 例外階層: `HarnessError` を基底とし、各エラーが明確に分類済み |

--- a/draft/design/issue-67-cli-run.md
+++ b/draft/design/issue-67-cli-run.md
@@ -1,0 +1,151 @@
+# [設計] dao run CLIサブコマンドの実装
+
+Issue: #67
+
+## 概要
+
+`dao run` サブコマンドを実装し、ワークフローをコマンドラインから実行可能にする。
+
+## 背景・目的
+
+ハーネスのコア機能（`WorkflowRunner`, `load_workflow`, `SessionState` 等）は実装・テスト済みだが、CLIフロントエンドが存在しないため `dao run <workflow.yaml> <issue>` として実行できない。#65 で CLI基盤（`cli_main.py` + argparse サブコマンド構造 + `pyproject.toml` の `[project.scripts]` 有効化）が作成される前提で、本イシューでは `run` サブコマンドを追加する。
+
+## 前提条件
+
+- #65 (`dao validate`) がマージ済みであること
+- `cli_main.py` に argparse サブコマンドパーサーが存在すること
+
+## インターフェース
+
+### 入力
+
+```
+dao run <workflow> <issue> [options]
+```
+
+| 引数/オプション | 型 | 必須 | 説明 |
+|-----------------|-----|------|------|
+| `workflow` | positional (str) | ○ | ワークフローYAMLファイルパス |
+| `issue` | positional (int) | ○ | GitHub Issue番号 |
+| `--from STEP_ID` | option (str) | × | 指定ステップから再開 |
+| `--step STEP_ID` | option (str) | × | 単一ステップのみ実行 |
+| `--workdir DIR` | option (str) | × | 作業ディレクトリ（デフォルト: カレントディレクトリ） |
+| `--quiet` | flag | × | エージェント出力のストリーミング表示を抑制 |
+
+`--from` と `--step` は排他（同時指定はエラー）。
+
+### 出力
+
+- **正常終了**: exit 0、最終状態のサマリーを stdout に出力
+- **ワークフロー ABORT**: exit 1、ABORT 理由を stderr に出力
+- **バリデーションエラー**: exit 2、エラー詳細を stderr に出力
+- **CLI 実行エラー**: exit 3、エラー詳細を stderr に出力
+
+### 使用例
+
+```bash
+# 基本実行
+dao run workflows/design.yaml 67
+
+# 途中から再開
+dao run workflows/design.yaml 67 --from review-design
+
+# 単一ステップ実行
+dao run workflows/design.yaml 67 --step implement
+
+# 作業ディレクトリ指定 + 静かに実行
+dao run workflows/design.yaml 67 --workdir ../dao-feat-67 --quiet
+```
+
+## 制約・前提条件
+
+- 外部依存を追加しない（argparse のみ）
+- `WorkflowRunner` の既存インターフェースを変更しない
+- エラーハンドリングは `HarnessError` 階層をそのまま活用
+- exit code は意味を持たせる（スクリプトからの呼び出しを想定）
+
+## 方針
+
+### 1. `cli_main.py` への `run` サブコマンド追加
+
+#65 が作成する `cli_main.py` のサブコマンドパーサーに `run` を追加する。
+
+```python
+# 疑似コード
+def register_run(subparsers):
+    p = subparsers.add_parser("run", help="Run a workflow")
+    p.add_argument("workflow", type=Path)
+    p.add_argument("issue", type=int)
+    p.add_argument("--from", dest="from_step")
+    p.add_argument("--step", dest="single_step")
+    p.add_argument("--workdir", type=Path, default=Path.cwd())
+    p.add_argument("--quiet", action="store_true")
+    p.set_defaults(func=cmd_run)
+```
+
+### 2. `cmd_run` 関数
+
+`load_workflow` → `WorkflowRunner` → `run()` のパイプラインを実行し、例外を exit code にマッピングする。
+
+```python
+def cmd_run(args) -> int:
+    # 排他チェック: --from と --step
+    # load_workflow(args.workflow)
+    # WorkflowRunner(...).run()
+    # エラーハンドリング → 適切な exit code
+```
+
+### 3. exit code マッピング
+
+| 例外 | exit code |
+|------|-----------|
+| 正常終了 | 0 |
+| ABORT verdict | 1 |
+| `WorkflowValidationError` | 2 |
+| `CLIExecutionError` / `CLINotFoundError` / `StepTimeoutError` | 3 |
+| `MissingResumeSessionError` / `InvalidTransition` | 3 |
+| その他の予期しない例外 | 1 |
+
+## テスト戦略
+
+> **CRITICAL**: S/M/L すべてのサイズのテスト方針を定義すること。
+
+### Small テスト
+
+- `--from` と `--step` の排他バリデーション
+- 引数パース: 各オプションが正しく `WorkflowRunner` のパラメータにマッピングされること
+- exit code マッピング: 各例外クラスが正しい exit code に変換されること
+- サマリー出力のフォーマット
+
+### Medium テスト
+
+- 有効なワークフローYAML + モック済み `WorkflowRunner` で正常終了 → exit 0
+- 不正なYAML → exit 2 + エラーメッセージが stderr に出力
+- `WorkflowRunner.run()` が `CLIExecutionError` → exit 3
+- `WorkflowRunner.run()` が ABORT verdict → exit 1
+- `--workdir` に存在しないディレクトリ → エラー
+- `subprocess` 経由での `dao run --help` 出力検証
+
+### Large テスト
+
+- 実際の `dao run` コマンドを subprocess で実行し、有効なワークフローYAML（ただしエージェントCLI未インストールの状態）で `CLINotFoundError` 相当のエラーが返ること
+- `pip install -e .` 後に `dao run --help` が利用可能であること
+
+## 影響ドキュメント
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | なし | 新しい技術選定なし（argparse は #65 で選定済み） |
+| docs/ARCHITECTURE.md | なし | アーキテクチャ変更なし |
+| docs/dev/ | なし | ワークフロー手順変更なし |
+| docs/cli-guides/ | あり | `dao run` の使い方ガイドを追加または更新 |
+| CLAUDE.md | なし | `dao run` の使い方は既に記載済み |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| argparse 公式ドキュメント | https://docs.python.org/3/library/argparse.html | サブコマンドパーサー (`add_subparsers`) の仕様。#65 で選定済みの手法を踏襲 |
+| WorkflowRunner 実装 | `dao_harness/runner.py` | `run()` メソッドのシグネチャ: `workflow`, `issue_number`, `workdir`, `from_step`, `single_step`, `verbose` |
+| #65 設計 | GitHub Issue #65 | CLI基盤（`cli_main.py` + argparse + `[project.scripts]`）の設計。`run` サブコマンドは明示的にスコープ外 |
+| errors.py | `dao_harness/errors.py` | 例外階層: `HarnessError` を基底とし、各エラーが明確に分類済み |

--- a/draft/design/issue-67-cli-run.md
+++ b/draft/design/issue-67-cli-run.md
@@ -15,6 +15,13 @@ Issue: #67
 - #65 (`dao validate`) がマージ済みであること
 - `cli_main.py` に argparse サブコマンドパーサーが存在すること
 
+### #65 依存の解消方針
+
+#65 は 2026-03-11 時点で OPEN。以下の方針で対応する:
+
+1. **実装開始条件**: #65 のマージを待つ。#67 ブランチは `main` から作成済みのため、#65 マージ後に `git merge main` で基盤を取り込む
+2. **#65 が長期停滞した場合**: #67 のスコープを拡張し、CLI 基盤（`cli_main.py` + `[project.scripts]`）ごと本イシューで実装する。この場合 #65 は #67 に吸収される
+
 ## インターフェース
 
 ### 入力
@@ -29,7 +36,7 @@ dao run <workflow> <issue> [options]
 | `issue` | positional (int) | ○ | GitHub Issue番号 |
 | `--from STEP_ID` | option (str) | × | 指定ステップから再開 |
 | `--step STEP_ID` | option (str) | × | 単一ステップのみ実行 |
-| `--workdir DIR` | option (str) | × | 作業ディレクトリ（デフォルト: カレントディレクトリ） |
+| `--workdir DIR` | option (str) | × | エージェント CLI の作業ディレクトリ（デフォルト: カレントディレクトリ）。状態ファイル・ログの保存先には影響しない（後述） |
 | `--quiet` | flag | × | エージェント出力のストリーミング表示を抑制 |
 
 `--from` と `--step` は排他（同時指定はエラー）。
@@ -64,6 +71,18 @@ dao run workflows/design.yaml 67 --workdir ../dao-feat-67 --quiet
 - エラーハンドリングは `HarnessError` 階層をそのまま活用
 - exit code は意味を持たせる（スクリプトからの呼び出しを想定）
 
+### `--workdir` と状態保存場所の関係
+
+`--workdir` はエージェント CLI の `cwd` のみを制御する。状態ファイルとログは `dao run` を実行したプロセスのカレントディレクトリ基準で保存される:
+
+| 対象 | 保存先 | `--workdir` の影響 |
+|------|--------|-------------------|
+| `SessionState` | `test-artifacts/<issue>/state.json`（プロセス cwd 基準） | なし |
+| 実行ログ | `test-artifacts/<issue>/runs/<timestamp>/`（プロセス cwd 基準） | なし |
+| エージェント CLI の `cwd` | `--workdir` で指定されたディレクトリ | **あり** |
+
+この分離は `WorkflowRunner` の既存設計に従ったもの。`runner.py` で `run_dir` はプロセス cwd 基準、`execute_cli()` の `cwd=workdir` はエージェント実行先のみを指す。
+
 ## 方針
 
 ### 1. `cli_main.py` への `run` サブコマンド追加
@@ -97,14 +116,30 @@ def cmd_run(args) -> int:
 
 ### 3. exit code マッピング
 
-| 例外 | exit code |
-|------|-----------|
-| 正常終了 | 0 |
-| ABORT verdict | 1 |
-| `WorkflowValidationError` | 2 |
-| `CLIExecutionError` / `CLINotFoundError` / `StepTimeoutError` | 3 |
-| `MissingResumeSessionError` / `InvalidTransition` | 3 |
-| その他の予期しない例外 | 1 |
+既知の `HarnessError` サブクラスを網羅的にマッピングする。`HarnessError` を基底で catch することで、将来追加されるサブクラスも「既知エラー」として扱う。
+
+| exit code | 意味 | 対応する例外 |
+|-----------|------|-------------|
+| 0 | 正常終了 | — |
+| 1 | ワークフロー ABORT | ABORT verdict で終了した場合 |
+| 2 | 定義エラー（実行前に検出） | `WorkflowValidationError`, `SkillNotFound`, `SecurityError` |
+| 3 | 実行時エラー（ステップ実行中に発生） | `CLIExecutionError`, `CLINotFoundError`, `StepTimeoutError`, `MissingResumeSessionError`, `InvalidTransition`, `VerdictNotFound`, `VerdictParseError`, `InvalidVerdictValue` |
+| 1 | 予期しないエラー | `HarnessError` の未知サブクラス、または `HarnessError` 以外の例外 |
+
+**実装方針**: 個別の例外クラスを列挙するのではなく、`HarnessError` の catch 内で分類する:
+
+```python
+try:
+    ...
+except WorkflowValidationError | SkillNotFound | SecurityError as e:
+    # 定義エラー → exit 2
+except HarnessError as e:
+    # その他の既知実行時エラー → exit 3
+except Exception as e:
+    # 予期しないエラー → exit 1
+```
+
+**ユーザー向けメッセージ**: 全ての `HarnessError` は `str(e)` で人間可読なメッセージを提供済み（`errors.py` の各 `__init__` で設定）。CLI は `stderr` にそのまま出力する。
 
 ## テスト戦略
 
@@ -114,7 +149,8 @@ def cmd_run(args) -> int:
 
 - `--from` と `--step` の排他バリデーション
 - 引数パース: 各オプションが正しく `WorkflowRunner` のパラメータにマッピングされること
-- exit code マッピング: 各例外クラスが正しい exit code に変換されること
+- exit code マッピング: 全 `HarnessError` サブクラス（`WorkflowValidationError`, `SkillNotFound`, `SecurityError`, `CLIExecutionError`, `CLINotFoundError`, `StepTimeoutError`, `MissingResumeSessionError`, `InvalidTransition`, `VerdictNotFound`, `VerdictParseError`, `InvalidVerdictValue`）が正しい exit code に変換されること
+- `HarnessError` 以外の予期しない例外 → exit 1
 - サマリー出力のフォーマット
 
 ### Medium テスト

--- a/draft/design/issue-67-cli-run.md
+++ b/draft/design/issue-67-cli-run.md
@@ -136,10 +136,13 @@ def cmd_run(args) -> int:
 | ドキュメント | 影響の有無 | 理由 |
 |-------------|-----------|------|
 | docs/adr/ | なし | 新しい技術選定なし（argparse は #65 で選定済み） |
-| docs/ARCHITECTURE.md | なし | アーキテクチャ変更なし |
-| docs/dev/ | なし | ワークフロー手順変更なし |
-| docs/cli-guides/ | あり | `dao run` の使い方ガイドを追加または更新 |
-| CLAUDE.md | なし | `dao run` の使い方は既に記載済み |
+| docs/ARCHITECTURE.md | 軽微 | L108-113 で `dao run` の `--from` 再開を既に記述済み。新フラグ (`--workdir`, `--quiet`) の追記が必要な可能性 |
+| docs/dev/workflow-authoring.md | 更新 | L170-181 で `dao run` コマンド例を既に記述済み。新フラグの追記 + exit code の説明追加 |
+| docs/dev/skill-authoring.md | なし | コンテキスト変数の変更なし |
+| docs/dev/development_workflow.md | なし | スキルライフサイクルの記述であり CLI ハーネスは無関係 |
+| docs/cli-guides/ | なし | claude/codex/gemini 各 CLI のリファレンスであり `dao` CLI は対象外 |
+| README.md | 更新 | ワークフロー実行方法のセクションが未記載。`dao run` の基本的な使い方を追加 |
+| CLAUDE.md | 軽微 | `dao run` の基本3パターンは記載済み。`--workdir` / `--quiet` を追記する可能性 |
 
 ## 参照情報（Primary Sources）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dev = [
     "mypy>=1.10.0",
 ]
 
-# [project.scripts]
+[project.scripts]
+dao = "dao_harness.cli_main:main"
 
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -440,10 +440,15 @@ class TestCLILarge:
     """Large: real subprocess execution of dao CLI."""
 
     @pytest.mark.large
-    def test_dao_run_help_available(self) -> None:
-        """After pip install, `dao run --help` should work."""
+    def test_dao_entrypoint_help(self) -> None:
+        """The `dao` console script entrypoint should be functional."""
+        import shutil
+
+        dao_path = shutil.which("dao")
+        if dao_path is None:
+            pytest.skip("dao entrypoint not installed (run pip install -e .)")
         result = subprocess.run(
-            [sys.executable, "-m", "dao_harness.cli_main", "run", "--help"],
+            ["dao", "run", "--help"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -455,17 +460,29 @@ class TestCLILarge:
         assert "--quiet" in result.stdout
 
     @pytest.mark.large
-    def test_dao_run_with_valid_workflow_missing_agent(
-        self, workflow_file: Path, workdir: Path
+    def test_dao_run_with_valid_workflow_missing_agent_cli(
+        self,
+        tmp_path: Path,
     ) -> None:
-        """Running a valid workflow without agent CLI installed should fail with exit 3."""
+        """With a valid workflow and skill, missing agent CLI should yield exit 3."""
+        # Create workflow YAML referencing a skill
+        wf = tmp_path / "workflow.yaml"
+        wf.write_text(MINIMAL_WORKFLOW_YAML)
+
+        # Create minimal skill directory so skill validation passes
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        skill_dir = workdir / ".claude" / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Test Skill\n")
+
         result = subprocess.run(
             [
                 sys.executable,
                 "-m",
                 "dao_harness.cli_main",
                 "run",
-                str(workflow_file),
+                str(wf),
                 "999",
                 "--workdir",
                 str(workdir),
@@ -474,9 +491,10 @@ class TestCLILarge:
             text=True,
             timeout=30,
         )
-        # Should fail because the agent CLI (claude/codex/gemini) is not available,
-        # or skill validation fails. Either way, non-zero exit.
-        assert result.returncode != 0
+        # Should fail with exit 3 (runtime error) because the agent CLI
+        # (claude) is not installed in the test environment.
+        assert result.returncode == 3
+        assert "not found" in result.stderr.lower() or "cli" in result.stderr.lower()
 
 
 # ============================================================

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,0 +1,491 @@
+"""Tests for dao_harness.cli_main — dao run CLI entrypoint."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dao_harness.cli_main import cmd_run, create_parser, main
+from dao_harness.errors import (
+    CLIExecutionError,
+    CLINotFoundError,
+    HarnessError,
+    InvalidTransition,
+    InvalidVerdictValue,
+    MissingResumeSessionError,
+    SecurityError,
+    SkillNotFound,
+    StepTimeoutError,
+    VerdictNotFound,
+    VerdictParseError,
+    WorkflowValidationError,
+)
+from dao_harness.models import Verdict
+
+# ============================================================
+# Fixtures
+# ============================================================
+
+MINIMAL_WORKFLOW_YAML = """\
+name: test
+description: test workflow
+steps:
+  - id: step1
+    skill: test-skill
+    agent: claude
+    on:
+      PASS: end
+      ABORT: end
+"""
+
+
+@pytest.fixture()
+def workflow_file(tmp_path: Path) -> Path:
+    """Create a minimal valid workflow YAML file."""
+    p = tmp_path / "workflow.yaml"
+    p.write_text(MINIMAL_WORKFLOW_YAML)
+    return p
+
+
+@pytest.fixture()
+def workdir(tmp_path: Path) -> Path:
+    """Create a temporary working directory."""
+    d = tmp_path / "workdir"
+    d.mkdir()
+    return d
+
+
+# ============================================================
+# Small tests — argument parsing
+# ============================================================
+
+
+class TestParserSmall:
+    """Small: argparse argument parsing."""
+
+    @pytest.mark.small
+    def test_run_subcommand_basic_args(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(["run", "workflow.yaml", "42"])
+        assert args.workflow == Path("workflow.yaml")
+        assert args.issue == 42
+        assert args.from_step is None
+        assert args.single_step is None
+        assert args.quiet is False
+
+    @pytest.mark.small
+    def test_run_subcommand_all_options(self, tmp_path: Path) -> None:
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "w.yaml",
+                "99",
+                "--from",
+                "step-a",
+                "--workdir",
+                str(tmp_path),
+                "--quiet",
+            ]
+        )
+        assert args.from_step == "step-a"
+        assert args.workdir == Path(str(tmp_path))
+        assert args.quiet is True
+
+    @pytest.mark.small
+    def test_run_subcommand_step_option(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(["run", "w.yaml", "1", "--step", "impl"])
+        assert args.single_step == "impl"
+
+    @pytest.mark.small
+    def test_no_subcommand_shows_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        parser = create_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args([])
+        assert exc_info.value.code != 0
+
+
+# ============================================================
+# Small tests — --from / --step mutual exclusion
+# ============================================================
+
+
+class TestMutualExclusionSmall:
+    """Small: --from and --step are mutually exclusive."""
+
+    @pytest.mark.small
+    def test_from_and_step_exclusive(self, workflow_file: Path, workdir: Path) -> None:
+        exit_code = cmd_run_with_args(
+            str(workflow_file),
+            "1",
+            "--from",
+            "a",
+            "--step",
+            "b",
+            "--workdir",
+            str(workdir),
+        )
+        assert exit_code == 2
+
+    @pytest.mark.small
+    def test_from_alone_is_valid(self, workflow_file: Path, workdir: Path) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = MagicMock(
+                last_transition_verdict=Verdict("PASS", "", "", "")
+            )
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--from",
+                "step1",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == 0
+
+    @pytest.mark.small
+    def test_step_alone_is_valid(self, workflow_file: Path, workdir: Path) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = MagicMock(
+                last_transition_verdict=Verdict("PASS", "", "", "")
+            )
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--step",
+                "step1",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == 0
+
+
+# ============================================================
+# Small tests — --workdir validation
+# ============================================================
+
+
+class TestWorkdirValidationSmall:
+    """Small: --workdir pre-validation."""
+
+    @pytest.mark.small
+    def test_nonexistent_workdir(self, workflow_file: Path) -> None:
+        exit_code = cmd_run_with_args(
+            str(workflow_file),
+            "1",
+            "--workdir",
+            "/nonexistent/path/abc",
+        )
+        assert exit_code == 2
+
+    @pytest.mark.small
+    def test_file_as_workdir(self, workflow_file: Path) -> None:
+        exit_code = cmd_run_with_args(
+            str(workflow_file),
+            "1",
+            "--workdir",
+            str(workflow_file),  # file, not dir
+        )
+        assert exit_code == 2
+
+
+# ============================================================
+# Small tests — exit code mapping
+# ============================================================
+
+
+class TestExitCodeMappingSmall:
+    """Small: exception → exit code mapping."""
+
+    @pytest.mark.small
+    @pytest.mark.parametrize(
+        "exception,expected_code",
+        [
+            (WorkflowValidationError("bad"), 2),
+            (SkillNotFound("missing"), 2),
+            (SecurityError("traversal"), 2),
+            (CLIExecutionError("s", 1, "err"), 3),
+            (CLINotFoundError("not found"), 3),
+            (StepTimeoutError("s", 30), 3),
+            (MissingResumeSessionError("s", "t"), 3),
+            (InvalidTransition("s", "v"), 3),
+            (VerdictNotFound("no verdict"), 3),
+            (VerdictParseError("bad parse"), 3),
+            (InvalidVerdictValue("bad value"), 3),
+        ],
+        ids=[
+            "WorkflowValidationError",
+            "SkillNotFound",
+            "SecurityError",
+            "CLIExecutionError",
+            "CLINotFoundError",
+            "StepTimeoutError",
+            "MissingResumeSessionError",
+            "InvalidTransition",
+            "VerdictNotFound",
+            "VerdictParseError",
+            "InvalidVerdictValue",
+        ],
+    )
+    def test_harness_error_exit_codes(
+        self,
+        workflow_file: Path,
+        workdir: Path,
+        exception: HarnessError,
+        expected_code: int,
+    ) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.side_effect = exception
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == expected_code
+
+    @pytest.mark.small
+    def test_unexpected_exception_exit_code(self, workflow_file: Path, workdir: Path) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.side_effect = RuntimeError("boom")
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == 1
+
+    @pytest.mark.small
+    def test_abort_verdict_exit_code(self, workflow_file: Path, workdir: Path) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = MagicMock(
+                last_transition_verdict=Verdict("ABORT", "reason", "ev", "sug")
+            )
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == 1
+
+
+# ============================================================
+# Medium tests — integration with file I/O and mocked runner
+# ============================================================
+
+
+class TestCmdRunMedium:
+    """Medium: cmd_run with real files + mocked WorkflowRunner."""
+
+    @pytest.mark.medium
+    def test_successful_run(
+        self, workflow_file: Path, workdir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = MagicMock(
+                last_transition_verdict=Verdict("PASS", "done", "all good", "")
+            )
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "42",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "42" in captured.out  # issue number in summary
+
+    @pytest.mark.medium
+    def test_invalid_yaml_exit_2(
+        self, tmp_path: Path, workdir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bad_yaml = tmp_path / "bad.yaml"
+        bad_yaml.write_text("steps: not_a_list")
+        exit_code = cmd_run_with_args(
+            str(bad_yaml),
+            "1",
+            "--workdir",
+            str(workdir),
+        )
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert captured.err  # error message in stderr
+
+    @pytest.mark.medium
+    def test_nonexistent_workflow_file(
+        self, workdir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cmd_run_with_args(
+            "/no/such/file.yaml",
+            "1",
+            "--workdir",
+            str(workdir),
+        )
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower() or "No such file" in captured.err
+
+    @pytest.mark.medium
+    def test_cli_execution_error_exit_3(
+        self, workflow_file: Path, workdir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.side_effect = CLIExecutionError("s1", 1, "fail")
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == 3
+        captured = capsys.readouterr()
+        assert captured.err
+
+    @pytest.mark.medium
+    def test_abort_verdict_exit_1(
+        self, workflow_file: Path, workdir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = MagicMock(
+                last_transition_verdict=Verdict("ABORT", "blocked", "ev", "sug")
+            )
+            exit_code = cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--workdir",
+                str(workdir),
+            )
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "ABORT" in captured.err or "blocked" in captured.err
+
+    @pytest.mark.medium
+    def test_workdir_nonexistent_exit_2_with_message(
+        self, workflow_file: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = cmd_run_with_args(
+            str(workflow_file),
+            "1",
+            "--workdir",
+            "/nonexistent/dir",
+        )
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert "workdir" in captured.err.lower() or "directory" in captured.err.lower()
+
+    @pytest.mark.medium
+    def test_quiet_flag_passed_to_runner(self, workflow_file: Path, workdir: Path) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = MagicMock(
+                last_transition_verdict=Verdict("PASS", "", "", "")
+            )
+            cmd_run_with_args(
+                str(workflow_file),
+                "1",
+                "--workdir",
+                str(workdir),
+                "--quiet",
+            )
+            call_kwargs = mock_runner.call_args
+            assert call_kwargs.kwargs.get("verbose") is False or (
+                len(call_kwargs.args) > 0 and not call_kwargs.kwargs.get("verbose", True)
+            )
+
+
+class TestMainMedium:
+    """Medium: main() function integration."""
+
+    @pytest.mark.medium
+    def test_main_returns_exit_code(self, workflow_file: Path, workdir: Path) -> None:
+        with patch("dao_harness.cli_main.WorkflowRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = MagicMock(
+                last_transition_verdict=Verdict("PASS", "", "", "")
+            )
+            exit_code = main(
+                [
+                    "run",
+                    str(workflow_file),
+                    "1",
+                    "--workdir",
+                    str(workdir),
+                ]
+            )
+        assert exit_code == 0
+
+    @pytest.mark.medium
+    def test_help_output(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "dao_harness.cli_main", "run", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "workflow" in result.stdout.lower()
+        assert "issue" in result.stdout.lower()
+
+
+# ============================================================
+# Large tests — real subprocess execution
+# ============================================================
+
+
+class TestCLILarge:
+    """Large: real subprocess execution of dao CLI."""
+
+    @pytest.mark.large
+    def test_dao_run_help_available(self) -> None:
+        """After pip install, `dao run --help` should work."""
+        result = subprocess.run(
+            [sys.executable, "-m", "dao_harness.cli_main", "run", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "--from" in result.stdout
+        assert "--step" in result.stdout
+        assert "--workdir" in result.stdout
+        assert "--quiet" in result.stdout
+
+    @pytest.mark.large
+    def test_dao_run_with_valid_workflow_missing_agent(
+        self, workflow_file: Path, workdir: Path
+    ) -> None:
+        """Running a valid workflow without agent CLI installed should fail with exit 3."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "dao_harness.cli_main",
+                "run",
+                str(workflow_file),
+                "999",
+                "--workdir",
+                str(workdir),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        # Should fail because the agent CLI (claude/codex/gemini) is not available,
+        # or skill validation fails. Either way, non-zero exit.
+        assert result.returncode != 0
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def cmd_run_with_args(*args: str) -> int:
+    """Parse args and call cmd_run, returning exit code."""
+    parser = create_parser()
+    parsed = parser.parse_args(["run", *args])
+    return cmd_run(parsed)

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -476,6 +476,12 @@ class TestCLILarge:
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("# Test Skill\n")
 
+        # Restrict PATH to only the Python executable's directory so that
+        # agent CLIs (claude, codex, gemini) are guaranteed not to be found,
+        # regardless of the host environment.
+        python_dir = str(Path(sys.executable).parent)
+        env = {**__import__("os").environ, "PATH": python_dir}
+
         result = subprocess.run(
             [
                 sys.executable,
@@ -490,11 +496,12 @@ class TestCLILarge:
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
         )
         # Should fail with exit 3 (runtime error) because the agent CLI
-        # (claude) is not installed in the test environment.
+        # (claude) cannot be found on the restricted PATH.
         assert result.returncode == 3
-        assert "not found" in result.stderr.lower() or "cli" in result.stderr.lower()
+        assert "not found" in result.stderr.lower()
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

`dao run` サブコマンドを実装し、ワークフローをCLIから実行可能にする。CLI基盤（argparse サブコマンドパーサー + `pyproject.toml` の `[project.scripts]`）も本PRで構築。

Closes #67

## Changes

- `dao_harness/cli_main.py`: argparse サブコマンドパーサー + `run` サブコマンド + exit code マッピング
- `pyproject.toml`: `[project.scripts]` 有効化（`dao` エントリポイント追加）
- `tests/test_cli_main.py`: 33テスト（S/M/L）
- `CLAUDE.md`: `--workdir` / `--quiet` フラグ追記
- `README.md`: 「ワークフロー実行」セクション追加
- `docs/dev/workflow-authoring.md`: 新フラグ + 終了コード表追加

## Test Plan

- [x] 既存テスト 352 passed, 1 skipped
- [x] 新規テスト 33件追加（Small: 引数パース・exit codeマッピング、Medium: モックRunner統合、Large: 実subprocess実行）
- [x] ruff / mypy 全パス