### PR TITLE
fix: add setuptools and types-PyYAML to dev deps (#82)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.4.0",
     "mypy>=1.10.0",
+    "setuptools>=68.0",
+    "types-PyYAML>=6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

`pip install -e ".[dev]"` で構築したフレッシュな venv に `setuptools` と `types-PyYAML` が含まれておらず、`TestPackageDiscovery` テストと `mypy` が失敗する問題を修正します。

Closes #82

## Changes

- `pyproject.toml`: dev extras に `setuptools>=68.0` と `types-PyYAML>=6.0` を追加

## Test Plan

- [x] 既存テスト全 pass（455 passed, 3 skipped）
- [x] フレッシュ venv で mypy・pytest が正常終了することを確認