### PR TITLE
feat: デフォルトワークフローをPRまでに変更（マージ・closeは手動実行） (#93)

### DIFF
--- a/docs/dev/development_workflow.md
+++ b/docs/dev/development_workflow.md
@@ -24,7 +24,7 @@ flowchart TB
     D4 --> D2
     D2 -->|Yes| DC
 
-    DC["/issue-doc-check"] --> E["/issue-pr"] --> F["/issue-close"]
+    DC["/issue-doc-check"] --> E["/issue-pr"] --> F["end"]
 ```
 
 ## フェーズ概要
@@ -36,7 +36,7 @@ flowchart TB
 | 3. 設計 | `/issue-design` | `draft/design/` に設計書 |
 | 4. 実装 | `/issue-implement` | コード + テスト |
 | 5. PR作成 | `/issue-pr` | PR作成 |
-| 6. 完了 | `/issue-close` | 設計書アーカイブ + PRマージ + worktree削除 |
+| 6. 完了 | `/issue-close` | 設計書アーカイブ + PRマージ + worktree削除（※手動実行） |
 
 ## 詳細フロー
 
@@ -116,10 +116,11 @@ flowchart TB
 │ • git absorb（コミット履歴の整理）                                  │
 │ • git push                                                          │
 │ • gh pr create                                                      │
+│ • ここでワークフロー自動実行は終了                                  │
 └─────────────────────────────────────────────────────────────────────┘
                                   ↓
 ┌─────────────────────────────────────────────────────────────────────┐
-│ Phase 6: 完了                                                       │
+│ Phase 6: 完了（※ワークフロー外。手動で実行）                        │
 │ /issue-close <issue-number>                                         │
 ├─────────────────────────────────────────────────────────────────────┤
 │ • draft/design/ → Issue本文に設計書をアーカイブ（<details>タグ）    │

--- a/draft/design/issue-93-workflow-stop-at-pr.md
+++ b/draft/design/issue-93-workflow-stop-at-pr.md
@@ -1,0 +1,107 @@
+# [設計] デフォルトワークフローをPR作成までに縮小
+
+Issue: #93
+
+## 概要
+
+`feature-development.yaml` の自動実行範囲を PR 作成までに縮小し、`close` ステップを削除する。
+
+## 背景・目的
+
+- PR 作成後のマージ判断は人間が行うべき（レビュー確認、CI 結果確認、マージタイミング）
+- 自動マージ・close は意図しないマージ事故のリスクがある
+- `issue-close` は worktree 削除や `git pull origin main` を伴い、Codex 実行時の CWD / セッション継続挙動に依存する不安定要素がある（#70 の `kaji-run-verify` で観測済み）
+- PR 作成を自然な「一時停止ポイント」とすることで、ワークフローの安全性を高める
+
+## インターフェース
+
+### 入力
+
+変更対象ファイル: `workflows/feature-development.yaml`
+
+### 出力
+
+ワークフロー実行時の動作変更:
+- **Before**: `pr` → PASS → `close` → PASS → `end`
+- **After**: `pr` → PASS → `end`
+
+### 使用例
+
+```bash
+# 変更後もワークフロー実行コマンドは同じ
+kaji run workflows/feature-development.yaml 99
+
+# PR作成で自動実行が終了する
+# close は手動で実行する
+/issue-close 99
+```
+
+## 制約・前提条件
+
+- `kaji validate` が変更後も通ること（`on` ターゲットの参照先存在チェック）
+- 既存テストが通ること
+- `close` ステップを参照している他のステップが存在しないこと（`pr` の `PASS` のみ）
+
+## 方針
+
+3箇所の変更のみで完結する最小限の修正:
+
+1. **`pr` ステップの `PASS` 遷移先を `close` → `end` に変更**
+   ```yaml
+   # Before
+   on:
+     PASS: close
+   # After
+   on:
+     PASS: end
+   ```
+
+2. **`close` ステップ定義を削除**（L114-L121 の 8 行）
+
+3. **`description` を更新**
+   ```yaml
+   # Before
+   description: |
+     Issue の設計から PR クローズまでの開発ワークフロー。
+   # After
+   description: |
+     Issue の設計から PR 作成までの開発ワークフロー。
+   ```
+
+## テスト戦略
+
+> **CRITICAL**: S/M/L すべてのサイズのテスト方針を定義すること。
+
+### Small テスト
+- 変更後の YAML を `load_workflow_from_str()` でパースし、`validate_workflow()` がエラーなしで通ることを検証
+- `pr` ステップの `on.PASS` が `"end"` であることを検証
+- `close` ステップが存在しないことを検証
+- description が更新されていることを検証
+
+### Medium テスト
+- `kaji validate workflows/feature-development.yaml` CLI コマンドが正常終了することを検証（ファイルI/O + バリデーション結合）
+
+### Large テスト
+- `kaji run` で実際にワークフローを実行し、PR作成ステップで `end` に遷移して終了することを検証
+
+### スキップするサイズ（該当する場合のみ）
+- Large: ワークフロー実行には実際の GitHub Issue・エージェント接続が必要であり、テスト環境で物理的に再現不可能。変更は YAML の静的構造のみであるため、Small + Medium で十分にカバーされる。
+
+## 影響ドキュメント
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | なし | 新しい技術選定なし |
+| docs/ARCHITECTURE.md | なし | アーキテクチャ変更なし |
+| docs/dev/development_workflow.md | あり | ワークフローフロー図・フェーズ概要に `close` の自動実行が含まれている |
+| docs/cli-guides/ | なし | CLI 仕様変更なし |
+| CLAUDE.md | なし | 規約変更なし |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| 変更対象ファイル | `workflows/feature-development.yaml` | `pr` ステップの `on.PASS: close` と `close` ステップ定義（L105-L121） |
+| ワークフローバリデーション | `kaji_harness/workflow.py` L231-235 | `on` ターゲットが存在するステップID or `"end"` であることを検証。`close` 削除時に `pr.on.PASS` を `end` に変更しないとバリデーションエラー |
+| #70 の観測 | Issue #93 本文「補足観測」 | close verdict に手動 `cd` + `git pull` が必要だった事実。SKILL の前提と実行環境のずれが原因 |
+| 開発ワークフロー | `docs/dev/development_workflow.md` | フロー図に `close` が自動ステップとして含まれており、ドキュメント更新が必要 |

--- a/draft/design/issue-93-workflow-stop-at-pr.md
+++ b/draft/design/issue-93-workflow-stop-at-pr.md
@@ -10,7 +10,7 @@ Issue: #93
 
 - PR 作成後のマージ判断は人間が行うべき（レビュー確認、CI 結果確認、マージタイミング）
 - 自動マージ・close は意図しないマージ事故のリスクがある
-- `issue-close` は worktree 削除や `git pull origin main` を伴い、Codex 実行時の CWD / セッション継続挙動に依存する不安定要素がある（#70 の `kaji-run-verify` で観測済み）
+- `issue-close` は worktree 削除や `git pull origin main` を伴い、Codex 実行時の CWD / セッション継続挙動に依存する不安定要素がある（[#70 kaji-run-verify 実行結果](https://github.com/apokamo/kaji/issues/70#issuecomment-4047582273) で観測）
 - PR 作成を自然な「一時停止ポイント」とすることで、ワークフローの安全性を高める
 
 ## インターフェース
@@ -44,7 +44,7 @@ kaji run workflows/feature-development.yaml 99
 
 ## 方針
 
-3箇所の変更のみで完結する最小限の修正:
+YAML 変更 3 箇所 + ドキュメント更新 1 箇所:
 
 1. **`pr` ステップの `PASS` 遷移先を `close` → `end` に変更**
    ```yaml
@@ -68,6 +68,11 @@ kaji run workflows/feature-development.yaml 99
      Issue の設計から PR 作成までの開発ワークフロー。
    ```
 
+4. **`docs/dev/development_workflow.md` を更新**
+   - フロー図（mermaid）から `close` の自動遷移を削除し、`pr` → `end` に変更
+   - フェーズ概要テーブルの「6. 完了」行の説明を「手動実行（`/issue-close`）」に変更
+   - 詳細フロー（ASCII）の Phase 6 に「※ワークフロー外。手動で実行」の注記を追加
+
 ## テスト戦略
 
 > **CRITICAL**: S/M/L すべてのサイズのテスト方針を定義すること。
@@ -82,10 +87,8 @@ kaji run workflows/feature-development.yaml 99
 - `kaji validate workflows/feature-development.yaml` CLI コマンドが正常終了することを検証（ファイルI/O + バリデーション結合）
 
 ### Large テスト
-- `kaji run` で実際にワークフローを実行し、PR作成ステップで `end` に遷移して終了することを検証
-
-### スキップするサイズ（該当する場合のみ）
-- Large: ワークフロー実行には実際の GitHub Issue・エージェント接続が必要であり、テスト環境で物理的に再現不可能。変更は YAML の静的構造のみであるため、Small + Medium で十分にカバーされる。
+- 実装完了後、`/kaji-run-verify workflows/feature-development.yaml <issue>` で実機検証を行い、ワークフローが `pr` ステップ完了後に正常終了することを確認する
+- 検証結果は Issue コメントとして記録する（#70 での実績: [kaji-run-verify 実行結果](https://github.com/apokamo/kaji/issues/70#issuecomment-4047582273)）
 
 ## 影響ドキュメント
 
@@ -103,5 +106,5 @@ kaji run workflows/feature-development.yaml 99
 |--------|----------|-------------------|
 | 変更対象ファイル | `workflows/feature-development.yaml` | `pr` ステップの `on.PASS: close` と `close` ステップ定義（L105-L121） |
 | ワークフローバリデーション | `kaji_harness/workflow.py` L231-235 | `on` ターゲットが存在するステップID or `"end"` であることを検証。`close` 削除時に `pr.on.PASS` を `end` に変更しないとバリデーションエラー |
-| #70 の観測 | Issue #93 本文「補足観測」 | close verdict に手動 `cd` + `git pull` が必要だった事実。SKILL の前提と実行環境のずれが原因 |
+| #70 の観測 | [#70 kaji-run-verify 実行結果](https://github.com/apokamo/kaji/issues/70#issuecomment-4047582273) | close verdict に手動 `cd` + `git pull` が必要だった事実。SKILL の前提と実行環境のずれが原因 |
 | 開発ワークフロー | `docs/dev/development_workflow.md` | フロー図に `close` が自動ステップとして含まれており、ドキュメント更新が必要 |

--- a/tests/test_feature_development_workflow.py
+++ b/tests/test_feature_development_workflow.py
@@ -1,0 +1,90 @@
+"""Tests for feature-development.yaml workflow structure.
+
+Verifies the workflow stops at PR creation (no auto close step).
+Issue: #93
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kaji_harness.cli_main import main
+from kaji_harness.workflow import load_workflow, validate_workflow
+
+WORKFLOW_PATH = Path(__file__).resolve().parent.parent / "workflows" / "feature-development.yaml"
+
+
+# ============================================================
+# Small tests — YAML structure verification
+# ============================================================
+
+
+class TestFeatureDevelopmentWorkflowSmall:
+    """Small: verify workflow YAML structure after #93 changes."""
+
+    @pytest.mark.small
+    def test_pr_step_pass_transitions_to_end(self) -> None:
+        """pr step PASS should transition to 'end', not 'close'."""
+        wf = load_workflow(WORKFLOW_PATH)
+        pr_step = wf.find_step("pr")
+        assert pr_step is not None
+        assert pr_step.on["PASS"] == "end"
+
+    @pytest.mark.small
+    def test_close_step_does_not_exist(self) -> None:
+        """close step should not exist in the workflow."""
+        wf = load_workflow(WORKFLOW_PATH)
+        assert wf.find_step("close") is None
+
+    @pytest.mark.small
+    def test_description_says_pr_creation(self) -> None:
+        """description should reference PR creation, not PR close."""
+        wf = load_workflow(WORKFLOW_PATH)
+        assert "PR 作成まで" in wf.description
+        assert "クローズ" not in wf.description
+
+    @pytest.mark.small
+    def test_workflow_passes_validation(self) -> None:
+        """Changed workflow must pass validate_workflow."""
+        wf = load_workflow(WORKFLOW_PATH)
+        validate_workflow(wf)
+
+
+# ============================================================
+# Medium tests — CLI validation integration
+# ============================================================
+
+
+class TestFeatureDevelopmentWorkflowMedium:
+    """Medium: validate via CLI with real file I/O."""
+
+    @pytest.mark.medium
+    def test_kaji_validate_feature_development(self) -> None:
+        """kaji validate should pass for the modified workflow."""
+        exit_code = main(["validate", str(WORKFLOW_PATH)])
+        assert exit_code == 0
+
+
+# ============================================================
+# Large tests — subprocess execution
+# ============================================================
+
+
+class TestFeatureDevelopmentWorkflowLarge:
+    """Large: real subprocess execution of kaji validate."""
+
+    @pytest.mark.large
+    def test_kaji_validate_subprocess(self) -> None:
+        """kaji validate via subprocess should exit 0."""
+        result = subprocess.run(
+            [sys.executable, "-m", "kaji_harness.cli_main", "validate", str(WORKFLOW_PATH)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "✓" in result.stdout

--- a/tests/test_feature_development_workflow.py
+++ b/tests/test_feature_development_workflow.py
@@ -6,8 +6,6 @@ Issue: #93
 
 from __future__ import annotations
 
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -70,21 +68,9 @@ class TestFeatureDevelopmentWorkflowMedium:
 
 
 # ============================================================
-# Large tests — subprocess execution
+# Large tests — /kaji-run-verify による実機検証
 # ============================================================
-
-
-class TestFeatureDevelopmentWorkflowLarge:
-    """Large: real subprocess execution of kaji validate."""
-
-    @pytest.mark.large
-    def test_kaji_validate_subprocess(self) -> None:
-        """kaji validate via subprocess should exit 0."""
-        result = subprocess.run(
-            [sys.executable, "-m", "kaji_harness.cli_main", "validate", str(WORKFLOW_PATH)],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        assert result.returncode == 0
-        assert "✓" in result.stdout
+# Large 検証は pytest ではなく /kaji-run-verify による手動実行で実施する。
+# 検証コマンド: /kaji-run-verify workflows/feature-development.yaml <issue>
+# 検証結果は Issue コメントとして記録される。
+# 設計書: draft/design/issue-93-workflow-stop-at-pr.md (Large テスト節)

--- a/workflows/feature-development.yaml
+++ b/workflows/feature-development.yaml
@@ -1,6 +1,6 @@
 name: feature-development
 description: |
-  Issue の設計から PR クローズまでの開発ワークフロー。
+  Issue の設計から PR 作成までの開発ワークフロー。
   issue-create / issue-start は事前に手動実行済みであることが前提。
 execution_policy: auto
 
@@ -107,15 +107,6 @@ steps:
     agent: claude
     model: sonnet
     on:
-      PASS: close
-      RETRY: pr
-      ABORT: end
-
-  - id: close
-    skill: issue-close
-    agent: claude
-    model: sonnet
-    on:
       PASS: end
-      RETRY: close
+      RETRY: pr
       ABORT: end


### PR DESCRIPTION
## Summary

デフォルトワークフロー (`feature-development.yaml`) の自動実行範囲を PR 作成までに縮小し、マージと close を手動実行に変更する。

Closes #93

## Changes

- `pr` ステップの `PASS` 遷移先を `close` → `end` に変更
- `close` ステップをワークフローから削除
- ワークフロー `description` を「PR 作成まで」に更新
- `docs/dev/development_workflow.md` のフロー図・フェーズ説明を更新（Phase 6 を手動実行として明記）

## Test Plan

- [x] 既存テストがパス
- [x] `kaji validate` 通過確認済み
- [x] `feature-development.yaml` の `pr` ステップが `end` に遷移することを確認