### PR TITLE
feat: コンソール出力にタイムスタンプを追加する (#101)

### DIFF
--- a/draft/design/issue-101-console-timestamp.md
+++ b/draft/design/issue-101-console-timestamp.md
@@ -86,9 +86,9 @@ def _now_stamp() -> str:
 
 ### Large テスト
 
-### スキップするサイズ（該当する場合のみ）
-
-- Large: `kaji run` の E2E テストには実際の agent CLI（claude/codex/gemini）のインストールが必要であり、CI 環境にこれらを用意する手段が存在しない。Medium テストでサブプロセス結合まで検証するため、タイムスタンプ表示の検証としては十分。
+- `kaji run` を実サブプロセスとして実行し、stdout に `[YYYY-MM-DDTHH:MM:SS] [step_id]` 形式のタイムスタンプが出力されることを検証
+- 方式: `tests/test_cli_main.py::TestCLILarge` と同様のパターンで、有効な JSONL を出力するモック CLI スクリプトを `tmp_path` に作成し PATH 先頭に配置する。`kaji run` を `subprocess.run` で実行し、stdout を正規表現で検証する
+- `--quiet` フラグ使用時にはタイムスタンプが出力されないことも検証
 
 ## 影響ドキュメント
 
@@ -109,3 +109,4 @@ def _now_stamp() -> str:
 | Python datetime.isoformat | https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat | `timespec="seconds"` で `YYYY-MM-DDTHH:MM:SS` 形式を得る。Issue 要件の「ISO 8601、タイムゾーン表記なし」に合致 |
 | 対象コード | `kaji_harness/cli.py` L78-140 (`stream_and_log`) | `print(f"[{step_id}] {text}")` が L110, L123 の 2 箇所に存在。これらがタイムスタンプ追加の対象 |
 | Issue #101 | GitHub Issue #101 | フォーマット仕様: `[YYYY-MM-DDTHH:MM:SS] [step_id] テキスト` |
+| 既存 Large テストパターン | `tests/test_cli_main.py` L459-527 (`TestCLILarge`) | `kaji run` を `subprocess.run` で実行し、mock workflow + 制御された PATH で E2E 検証する手法。今回の Large テストでも同パターンを踏襲し、JSONL を出力する mock CLI スクリプトを PATH に配置する |

--- a/draft/design/issue-101-console-timestamp.md
+++ b/draft/design/issue-101-console-timestamp.md
@@ -1,0 +1,111 @@
+# [設計] コンソール出力にタイムスタンプを追加する
+
+Issue: #101
+
+## 概要
+
+`kaji run` のコンソール出力（`stream_and_log` の `print` 呼び出し）にタイムスタンプを追加し、各イベントの発生時刻を把握できるようにする。
+
+## 背景・目的
+
+kaji のコンソール出力は `stream-json` のイベント単位で表示されるため、リアルタイム感が薄い（#100 参照）。タイムスタンプを付与することで、各ステップの所要時間や進捗の時間感覚を低コストで補える。
+
+## インターフェース
+
+### 入力
+
+変更なし。既存の `stream_and_log` 関数のシグネチャは維持する。
+
+### 出力
+
+ターミナル出力（`print`）のフォーマットが変更される。
+
+**変更前:**
+
+```
+[step_id] テキスト
+```
+
+**変更後:**
+
+```
+[2026-03-13T15:04:23] [step_id] テキスト
+```
+
+### 使用例
+
+```python
+# 変更は内部実装のみ。ユーザーコードへの影響なし。
+# kaji run workflow.yaml 42 実行時のターミナル出力が変わる。
+```
+
+## 制約・前提条件
+
+- タイムスタンプフォーマット: `YYYY-MM-DDTHH:MM:SS`（ISO 8601、ローカルタイム、タイムゾーン表記なし）
+- タイムスタンプと step_id は別ブラケットで分離（パース容易性・既存出力との互換性）
+- `CLIResult.full_output` にはタイムスタンプを含めない（下流のパーサー、特に verdict パーサーに影響を与えないため）
+- `console.log` ファイルにもタイムスタンプを含めない（Issue の対象は `print` 呼び出しのみ）
+- `stdout.log` は生の JSONL をそのまま記録するため変更しない
+
+## 方針
+
+`stream_and_log` 関数内の 2 箇所の `print` 呼び出し（L110, L123）にタイムスタンプを追加する。
+
+```python
+from datetime import datetime
+
+# タイムスタンプ生成（ヘルパー関数）
+def _now_stamp() -> str:
+    """現在時刻を ISO 8601 形式（秒精度、タイムゾーンなし）で返す。"""
+    return datetime.now().isoformat(timespec="seconds")
+
+# print 呼び出しの変更（2箇所）
+# 変更前: print(f"[{step_id}] {text}")
+# 変更後: print(f"[{_now_stamp()}] [{step_id}] {text}")
+```
+
+変更対象:
+- `kaji_harness/cli.py` の `_now_stamp` ヘルパー追加（モジュールプライベート）
+- `stream_and_log` 内の `print` 2 箇所のフォーマット変更
+
+## テスト戦略
+
+> **CRITICAL**: S/M/L すべてのサイズのテスト方針を定義すること。
+
+### Small テスト
+
+- `_now_stamp()` の戻り値フォーマット検証: ISO 8601 形式（`YYYY-MM-DDTHH:MM:SS`）であること
+- `_now_stamp()` が `datetime.now()` を使用していること（`freezegun` または `unittest.mock.patch` で固定時刻を注入し、期待値と一致することを検証）
+
+### Medium テスト
+
+- `stream_and_log` の `verbose=True` 時、`print` 出力にタイムスタンプが含まれること（`capsys` でキャプチャし、`[YYYY-MM-DDTHH:MM:SS]` パターンを正規表現で検証）
+- `stream_and_log` の `verbose=True` 時、非JSON行の `print` 出力にもタイムスタンプが含まれること
+- `CLIResult.full_output` にタイムスタンプが含まれ**ない**こと（既存テストの暗黙的保証だが、明示的に検証）
+- `console.log` にタイムスタンプが含まれ**ない**こと
+
+### Large テスト
+
+### スキップするサイズ（該当する場合のみ）
+
+- Large: `kaji run` の E2E テストには実際の agent CLI（claude/codex/gemini）のインストールが必要であり、CI 環境にこれらを用意する手段が存在しない。Medium テストでサブプロセス結合まで検証するため、タイムスタンプ表示の検証としては十分。
+
+## 影響ドキュメント
+
+この変更により更新が必要になる可能性のあるドキュメントを列挙する。
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | なし | 新しい技術選定なし |
+| docs/ARCHITECTURE.md | なし | アーキテクチャ変更なし |
+| docs/dev/ | なし | ワークフロー・開発手順変更なし |
+| docs/cli-guides/ | なし | CLI の引数・サブコマンド仕様に変更なし（出力フォーマットのみ） |
+| CLAUDE.md | なし | 規約変更なし |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| Python datetime.isoformat | https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat | `timespec="seconds"` で `YYYY-MM-DDTHH:MM:SS` 形式を得る。Issue 要件の「ISO 8601、タイムゾーン表記なし」に合致 |
+| 対象コード | `kaji_harness/cli.py` L78-140 (`stream_and_log`) | `print(f"[{step_id}] {text}")` が L110, L123 の 2 箇所に存在。これらがタイムスタンプ追加の対象 |
+| Issue #101 | GitHub Issue #101 | フォーマット仕様: `[YYYY-MM-DDTHH:MM:SS] [step_id] テキスト` |

--- a/kaji_harness/cli.py
+++ b/kaji_harness/cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import subprocess
 import threading
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,11 @@ from .errors import CLIExecutionError, CLINotFoundError, StepTimeoutError
 from .models import CLIResult, CostInfo, Step
 
 DEFAULT_TIMEOUT = 1800  # 30 minutes
+
+
+def _now_stamp() -> str:
+    """現在時刻を ISO 8601 形式（秒精度、タイムゾーンなし）で返す。"""
+    return datetime.now().isoformat(timespec="seconds")
 
 
 def build_cli_args(
@@ -107,7 +113,7 @@ def stream_and_log(
                     f_con.write(stripped + "\n")
                     f_con.flush()
                     if verbose:
-                        print(f"[{step_id}] {stripped}")
+                        print(f"[{_now_stamp()}] [{step_id}] {stripped}")
                 continue
 
             sid = adapter.extract_session_id(event)
@@ -120,7 +126,7 @@ def stream_and_log(
                 f_con.write(text + "\n")
                 f_con.flush()
                 if verbose:
-                    print(f"[{step_id}] {text}")
+                    print(f"[{_now_stamp()}] [{step_id}] {text}")
 
             c = adapter.extract_cost(event)
             if c:

--- a/tests/test_cli_timestamp.py
+++ b/tests/test_cli_timestamp.py
@@ -1,0 +1,362 @@
+"""Tests for timestamp feature in stream_and_log console output.
+
+Issue #101: kaji run コンソール出力にタイムスタンプを追加する
+
+S/M/L テスト戦略:
+- Small: _now_stamp() のフォーマット検証・時刻固定テスト
+- Medium: stream_and_log の print 出力タイムスタンプ検証、full_output/console.log 無混入確認
+- Large: kaji run サブプロセスで stdout タイムスタンプ検証、--quiet 時の非出力確認
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kaji_harness.adapters import ClaudeAdapter
+from kaji_harness.cli import _now_stamp, stream_and_log
+
+TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")
+CONSOLE_LINE_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\] \[.+\] .+")
+
+MINIMAL_WORKFLOW_YAML = """\
+name: test
+description: test workflow
+steps:
+  - id: step1
+    skill: test-skill
+    agent: claude
+    on:
+      PASS: end
+      ABORT: end
+"""
+
+
+# ============================================================
+# Small tests: _now_stamp()
+# ============================================================
+
+
+@pytest.mark.small
+class TestNowStampSmall:
+    """Small: _now_stamp() のフォーマットと時刻固定テスト。"""
+
+    def test_format_is_iso8601_seconds(self) -> None:
+        """戻り値が YYYY-MM-DDTHH:MM:SS 形式であること。"""
+        stamp = _now_stamp()
+        assert TIMESTAMP_RE.match(stamp), f"Expected ISO 8601 seconds format, got: {stamp!r}"
+
+    def test_returns_fixed_time_when_mocked(self) -> None:
+        """datetime.now() をモックした場合、期待値と一致すること。"""
+        with patch("kaji_harness.cli.datetime") as mock_dt:
+            mock_dt.now.return_value.isoformat.return_value = "2026-03-13T15:04:23"
+            stamp = _now_stamp()
+        assert stamp == "2026-03-13T15:04:23"
+        mock_dt.now.assert_called_once()
+
+    def test_no_timezone_suffix(self) -> None:
+        """タイムゾーン表記（+XX:XX や Z）が含まれないこと。"""
+        stamp = _now_stamp()
+        assert "+" not in stamp
+        assert stamp.endswith(stamp[-2:])  # just a length sanity check
+        # フォーマット検証で十分だが明示的に確認
+        assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", stamp)
+
+
+# ============================================================
+# Medium tests: stream_and_log のタイムスタンプ挙動
+# ============================================================
+
+
+def _create_mock_script(path: Path, jsonl_lines: list[str]) -> Path:
+    """JSONL を出力する mock CLI スクリプトを作成して返す。"""
+    script = path / "mock_cli.sh"
+    output = "\n".join(f"echo '{line}'" for line in jsonl_lines)
+    script.write_text(f"#!/bin/bash\n{output}\nexit 0\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return script
+
+
+@pytest.mark.medium
+class TestStreamAndLogTimestampMedium:
+    """Medium: stream_and_log のタイムスタンプ混入確認。"""
+
+    def test_verbose_true_json_line_has_timestamp(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """verbose=True 時、JSON 行の print 出力にタイムスタンプが含まれること。"""
+        jsonl_lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hello"}]},
+                }
+            ),
+        ]
+        script = _create_mock_script(tmp_path, jsonl_lines)
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        process = subprocess.Popen(
+            [str(script)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        adapter = ClaudeAdapter()
+        stream_and_log(process, adapter, "design", log_dir, verbose=True)
+        process.wait()
+
+        captured = capsys.readouterr()
+        assert CONSOLE_LINE_RE.match(captured.out.strip()), (
+            f"Expected timestamp in output, got: {captured.out!r}"
+        )
+        assert "[design]" in captured.out
+        assert "hello" in captured.out
+
+    def test_verbose_true_non_json_line_has_timestamp(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """verbose=True 時、非 JSON 行の print 出力にもタイムスタンプが含まれること。"""
+        script = tmp_path / "mock_plain.sh"
+        script.write_text("#!/bin/bash\necho 'plain text line'\nexit 0\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        process = subprocess.Popen(
+            [str(script)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        adapter = ClaudeAdapter()
+        stream_and_log(process, adapter, "implement", log_dir, verbose=True)
+        process.wait()
+
+        captured = capsys.readouterr()
+        assert CONSOLE_LINE_RE.match(captured.out.strip()), (
+            f"Expected timestamp in non-JSON output, got: {captured.out!r}"
+        )
+        assert "[implement]" in captured.out
+        assert "plain text line" in captured.out
+
+    def test_verbose_false_no_print_output(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """verbose=False 時、print 出力がないこと（タイムスタンプも含めて）。"""
+        jsonl_lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "quiet"}]},
+                }
+            ),
+        ]
+        script = _create_mock_script(tmp_path, jsonl_lines)
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        process = subprocess.Popen(
+            [str(script)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        adapter = ClaudeAdapter()
+        stream_and_log(process, adapter, "step", log_dir, verbose=False)
+        process.wait()
+
+        captured = capsys.readouterr()
+        assert captured.out == "", f"Expected no output when verbose=False, got: {captured.out!r}"
+
+    def test_full_output_has_no_timestamp(self, tmp_path: Path) -> None:
+        """CLIResult.full_output にタイムスタンプが含まれないこと。"""
+        jsonl_lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "result text"}]},
+                }
+            ),
+        ]
+        script = _create_mock_script(tmp_path, jsonl_lines)
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        process = subprocess.Popen(
+            [str(script)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        adapter = ClaudeAdapter()
+        result = stream_and_log(process, adapter, "step", log_dir, verbose=True)
+        process.wait()
+
+        assert "result text" in result.full_output
+        assert not re.search(r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\]", result.full_output), (
+            f"Timestamp must not appear in full_output, got: {result.full_output!r}"
+        )
+
+    def test_console_log_has_no_timestamp(self, tmp_path: Path) -> None:
+        """console.log ファイルにタイムスタンプが含まれないこと。"""
+        jsonl_lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "log text"}]},
+                }
+            ),
+        ]
+        script = _create_mock_script(tmp_path, jsonl_lines)
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        process = subprocess.Popen(
+            [str(script)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        adapter = ClaudeAdapter()
+        stream_and_log(process, adapter, "step", log_dir, verbose=True)
+        process.wait()
+
+        console_content = (log_dir / "console.log").read_text()
+        assert "log text" in console_content
+        assert not re.search(r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\]", console_content), (
+            f"Timestamp must not appear in console.log, got: {console_content!r}"
+        )
+
+
+# ============================================================
+# Large tests: kaji run サブプロセス E2E
+# ============================================================
+
+
+def _build_e2e_env(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
+    """E2E テスト用のワークフロー・プロジェクト・環境変数を構築する。"""
+    wf = tmp_path / "workflow.yaml"
+    wf.write_text(MINIMAL_WORKFLOW_YAML)
+
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    config_dir = workdir / ".kaji"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("")
+    skill_dir = workdir / ".claude" / "skills" / "test-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Test Skill\n")
+
+    return wf, workdir
+
+
+def _create_mock_claude_script(bin_dir: Path) -> Path:
+    """JSONL を出力する mock claude スクリプトを bin_dir に作成する。"""
+    claude = bin_dir / "claude"
+    jsonl_lines = [
+        json.dumps({"type": "system", "subtype": "init", "session_id": "sess-e2e"}),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "---VERDICT---\\nstatus: PASS\\nreason: ok\\nevidence: |\\n  ok\\n---END_VERDICT---",
+                        }
+                    ]
+                },
+            }
+        ),
+        json.dumps({"type": "result", "result": "Done", "total_cost_usd": 0.01}),
+    ]
+    lines_sh = "\n".join(f"printf '%s\\n' '{line}'" for line in jsonl_lines)
+    claude.write_text(f"#!/bin/bash\n{lines_sh}\nexit 0\n")
+    claude.chmod(claude.stat().st_mode | stat.S_IEXEC)
+    return claude
+
+
+@pytest.mark.large
+class TestKajiRunTimestampLarge:
+    """Large: kaji run サブプロセスで stdout タイムスタンプを検証。"""
+
+    def test_stdout_contains_timestamp(self, tmp_path: Path) -> None:
+        """kaji run 実行時、stdout の各行に [YYYY-MM-DDTHH:MM:SS] が含まれること。"""
+        wf, workdir = _build_e2e_env(tmp_path)
+
+        # mock claude を PATH 先頭に配置
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _create_mock_claude_script(bin_dir)
+
+        # Python venv の bin も PATH に含める（kaji モジュール実行のため）
+        python_dir = str(Path(sys.executable).parent)
+        env = {**os.environ, "PATH": f"{bin_dir}:{python_dir}"}
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kaji_harness.cli_main",
+                "run",
+                str(wf),
+                "101",
+                "--workdir",
+                str(workdir),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+        # kaji run の stdout は agent output 行（[timestamp] [step_id] text 形式）と
+        # "Workflow '...' completed ..." のような summary 行が混在する。
+        # ここでは step_id ブラケットを含む agent output 行のみを検証対象とする。
+        agent_lines = [
+            line
+            for line in result.stdout.splitlines()
+            if line.strip() and re.search(r"\[step\d*\]|\[step1\]", line)
+        ]
+        assert agent_lines, (
+            f"Expected agent output lines in stdout, got none. "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+        for line in agent_lines:
+            assert re.match(r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\] \[.+\]", line), (
+                f"Agent output line missing timestamp: {line!r}"
+            )
+
+    def test_quiet_flag_suppresses_timestamp_output(self, tmp_path: Path) -> None:
+        """--quiet フラグ使用時、タイムスタンプ付き出力が stdout に出ないこと。"""
+        wf, workdir = _build_e2e_env(tmp_path)
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _create_mock_claude_script(bin_dir)
+
+        python_dir = str(Path(sys.executable).parent)
+        env = {**os.environ, "PATH": f"{bin_dir}:{python_dir}"}
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kaji_harness.cli_main",
+                "run",
+                str(wf),
+                "101",
+                "--workdir",
+                str(workdir),
+                "--quiet",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+        timestamp_lines = [
+            line
+            for line in result.stdout.splitlines()
+            if re.match(r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\]", line)
+        ]
+        assert not timestamp_lines, (
+            f"Expected no timestamp lines with --quiet, got: {timestamp_lines}"
+        )

--- a/tests/test_cli_timestamp.py
+++ b/tests/test_cli_timestamp.py
@@ -305,6 +305,10 @@ class TestKajiRunTimestampLarge:
             env=env,
         )
 
+        assert result.returncode == 0, (
+            f"kaji run failed with returncode={result.returncode}\nstderr={result.stderr!r}"
+        )
+
         # kaji run の stdout は agent output 行（[timestamp] [step_id] text 形式）と
         # "Workflow '...' completed ..." のような summary 行が混在する。
         # ここでは step_id ブラケットを含む agent output 行のみを検証対象とする。
@@ -350,6 +354,10 @@ class TestKajiRunTimestampLarge:
             text=True,
             timeout=30,
             env=env,
+        )
+
+        assert result.returncode == 0, (
+            f"kaji run --quiet failed with returncode={result.returncode}\nstderr={result.stderr!r}"
         )
 
         timestamp_lines = [


### PR DESCRIPTION
## Summary

`kaji run` のコンソール出力（`[step_id] テキスト` 形式）に ISO 8601 形式のタイムスタンプを追加し、各イベントの発生時刻と所要時間を把握できるようにする。

Closes #101

## Changes

- `kaji_harness/cli.py` の `stream_and_log` 関数にタイムスタンプ出力を追加
- 出力形式: `[YYYY-MM-DDTHH:MM:SS] [step_id] テキスト`

## Test Plan

- [x] 既存テストがパス
- [x] 新規テスト追加: `tests/test_cli.py` にタイムスタンプ形式の検証を追加