### PR TITLE
feat: pytest-xdist による並列テスト実行 (#108)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",
+    "pytest-xdist>=3.0.0",
     "ruff>=0.4.0",
     "mypy>=1.10.0",
     "setuptools>=68.0",
@@ -59,7 +60,7 @@ warn_unused_ignores = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -n auto"
 markers = [
     "small: Small tests - no external dependencies",
     "medium: Medium tests - file I/O, mock processes",


### PR DESCRIPTION
## Summary

`pytest-xdist` を導入し、`-n auto` で並列テスト実行を有効化する。

Closes #108

## Changes

- `pyproject.toml`: `pytest-xdist>=3.0.0` を dev 依存に追加
- `pyproject.toml`: `addopts` に `-n auto` を追加

## Test Plan

- [x] 並列実行（`-n auto`, 20 workers）: 498 passed, 1 skipped
- [x] 逐次実行との比較: 全テストパス、競合・不整合なし
- [x] pre-commit checks（ruff / mypy）パス