### PR TITLE
chore: パッケージ管理を pip から uv に統一する (#128)

### DIFF
--- a/.claude/skills/issue-implement/SKILL.md
+++ b/.claude/skills/issue-implement/SKILL.md
@@ -139,7 +139,7 @@ cat [worktree-absolute-path]/draft/design/issue-[number]-*.md
 > - ❌ 実行時コード変更なのに「実行時間が長い」を理由に M/L を省略する
 > - ❌ 実行時コード変更なのに「Small で十分」と決め打ちする
 > - ❌ docs-only / metadata-only / packaging-only 変更に無理やり S/M/L テストを新設する
-> - ❌ `pip install -e .` など副作用のある検証を shared 環境へ常設する
+> - ❌ `uv pip install -e .` など副作用のある検証を shared 環境へ常設する
 
 設計書の「テスト戦略」セクションに基づき、変更タイプに応じた検証を実施する。
 

--- a/.claude/skills/issue-start/SKILL.md
+++ b/.claude/skills/issue-start/SKILL.md
@@ -108,10 +108,10 @@ gh issue edit [issue-number] --body "$NEW_BODY"
 ### 注意事項
 
 ⚠️ `.venv` は main のシンボリックリンクです:
-- `pip install` は main に影響します
+- `uv pip install` は main に影響します
 - pyproject.toml を変更する場合は個別 venv を作成してください:
   ```bash
-  rm .venv && python -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+  rm .venv && uv venv .venv && uv sync
   ```
 
 ### 次のステップ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,8 @@ make check
 
 ```bash
 # Setup
-python -m venv .venv
+uv sync                               # Install dependencies + create .venv
 source .venv/bin/activate
-make setup                            # pip install -e ".[dev]"
 
 # Quality checks (run before commit)
 make check                            # lint → format → typecheck → test
@@ -47,7 +46,7 @@ make test-large                       # pytest -m large
 
 # Change-type specific verification
 make verify-docs                      # Doc link checker
-make verify-packaging                 # Isolated pip install + metadata check
+make verify-packaging                 # Isolated uv install + metadata check
 
 # CLI harness
 kaji run <workflow.yaml> <issue>                    # Run a workflow

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ verify-packaging:
 	@scripts/verify-packaging.sh
 
 setup:
-	pip install -e ".[dev]"
+	uv sync

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ AI-driven software development workflow orchestrator. Claude Code / Codex / Gemi
 ## セットアップ（開発者向け）
 
 ```bash
-python -m venv .venv
+uv sync
 source .venv/bin/activate
-pip install -e ".[dev]"
 ```
 
 ## 開発ワークフロー
@@ -144,7 +143,7 @@ make check                            # lint → format → typecheck → test
 
 ```bash
 make verify-docs                      # docs-only: リンク・参照整合チェック
-make verify-packaging                 # packaging/metadata: 隔離環境で pip install + metadata 確認
+make verify-packaging                 # packaging/metadata: 隔離環境で uv install + metadata 確認
 ```
 
 個別ターゲット: `make lint` / `make format` / `make typecheck` / `make test`

--- a/docs/dev/testing-convention.md
+++ b/docs/dev/testing-convention.md
@@ -146,7 +146,7 @@ repo にコミットし、今後も継続実行するテスト。以下を満た
 ### docs-only / metadata-only / packaging-only の場合
 
 #### 変更固有検証
-- (例: link check、`importlib.metadata` 確認、隔離環境での `pip install -e .`)
+- (例: link check、`importlib.metadata` 確認、隔離環境での `uv pip install -e .`)
 
 #### 恒久テストを追加しない理由
 - (上記 4 条件に沿って記載)
@@ -158,7 +158,7 @@ repo にコミットし、今後も継続実行するテスト。以下を満た
 - [ ] 変更タイプ（実行時コード変更 / docs-only / metadata-only / packaging-only）が明示されているか
 - [ ] 実行時コード変更なら Small / Medium / Large の検証観点が定義されているか
 - [ ] 恒久テストを追加しない場合、その理由が 4 条件に沿って説明されているか
-- [ ] `pip install -e .` など副作用のある検証を行う場合、隔離方針が定義されているか
+- [ ] `uv pip install -e .` など副作用のある検証を行う場合、隔離方針が定義されているか
 ```
 
 ## 既存テストの棚卸し基準

--- a/docs/dev/testing-convention.md
+++ b/docs/dev/testing-convention.md
@@ -76,14 +76,14 @@ repo にコミットし、今後も継続実行するテスト。以下を満た
 今回の変更の妥当性確認に必要だが、repo に恒久化する価値は低い検証。例:
 
 - `make verify-docs` — docs のリンク・参照整合チェック
-- `make verify-packaging` — 隔離 venv で `pip install -e .` → entry point・metadata 確認
+- `make verify-packaging` — 隔離 venv で `uv pip install -e .` → entry point・metadata 確認
 - `python -m build` や `importlib.metadata` を用いた一時確認
 
 この種の検証は、設計書や実装報告に「なぜ必要か」「なぜ恒久テストにしないか」を記録する。
 
-## `pip install -e .` の扱い
+## `uv pip install -e .` の扱い
 
-`pip install -e .` は packaging / metadata 変更で有効な検証手段になりうるが、shared 環境を汚染
+`uv pip install -e .` は packaging / metadata 変更で有効な検証手段になりうるが、shared 環境を汚染
 しやすい。以下を原則とする:
 
 - shared `.venv` を前提にした常設の恒久テストにはしない
@@ -92,9 +92,9 @@ repo にコミットし、今後も継続実行するテスト。以下を満た
 
 推奨される隔離手段:
 
-- 一時ディレクトリに作成した専用 virtualenv
+- 一時ディレクトリに作成した専用 virtualenv (`uv venv`)
 - CI のジョブごとに破棄される環境
-- `uv venv` / `python -m venv` 等で作る disposable 環境
+- `uv venv` 等で作る disposable 環境
 
 ## 省略してよい理由 / 省略してはいけない理由
 

--- a/docs/guides/git-worktree.md
+++ b/docs/guides/git-worktree.md
@@ -168,7 +168,7 @@ git branch -d feat/42
 ln -s /home/user/dev/kaji/.venv /home/user/dev/kaji-feat-42/.venv
 ```
 
-> **⚠️ 注意**: `.venv` を共有しているため、worktree 内での `pip install` はメインリポジトリの環境にも影響する。`pyproject.toml` の依存関係を変更する場合は、個別の venv を作成して検証すること。
+> **⚠️ 注意**: `.venv` を共有しているため、worktree 内での `uv pip install` はメインリポジトリの環境にも影響する。`pyproject.toml` の依存関係を変更する場合は、個別の venv を作成して検証すること。
 
 ## 運用ルール
 

--- a/draft/design/issue-128-uv-migration.md
+++ b/draft/design/issue-128-uv-migration.md
@@ -41,9 +41,61 @@ source .venv/bin/activate
 - CI/CD の変更なし（現時点で GitHub Actions なし）
 - `draft/` 配下の過去設計書アーカイブは修正スコープ外
 
+## dev 依存の扱い: optional-dependencies → dependency-groups 移行
+
+### 問題
+
+現行 `pyproject.toml` では開発依存が `[project.optional-dependencies].dev` に定義されている（25-34 行）。
+plain `uv sync` は optional-dependencies（extras）をデフォルトでインストールしない。
+このため、`uv sync` 単体では `pip install -e ".[dev]"` 相当にならない。
+
+### 選択肢
+
+| 選択肢 | コマンド | pyproject.toml 変更 | 評価 |
+|--------|---------|---------------------|------|
+| A: `--extra` フラグ | `uv sync --extra dev` | 不要 | Issue の「`uv sync` で完結」に反する |
+| B: dependency-groups 移行 | `uv sync` | `[project.optional-dependencies].dev` → `[dependency-groups].dev` | uv の推奨パターン。`uv sync` で dev グループが自動同期される |
+
+### 採用: B（dependency-groups 移行）
+
+**理由**:
+
+1. uv は `[dependency-groups].dev` をデフォルトで同期する（`--no-default-groups` で除外可能）
+2. 開発依存（pytest, ruff, mypy 等）は「ローカル開発専用の非公開依存」であり、
+   公開メタデータとして配布される optional-dependencies より dependency-groups が意味的に正確
+3. Issue の完了条件「`uv sync` でセットアップが完結する」を満たす
+4. build-backend（setuptools）は変更しない。`[dependency-groups]` は PEP 735 で定義された
+   ビルドシステム非依存の仕様であり、`[build-system]` には影響しない
+
+### pyproject.toml の変更内容
+
+```python
+# 削除
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    ...
+]
+
+# 追加
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    ...
+]
+```
+
+依存パッケージの一覧自体は変更しない。セクション名のみ移行する。
+
 ## 方針
 
 全修正をファイル種別で 4 カテゴリに分類し、順に対応する。
+
+### 0. pyproject.toml の依存定義移行
+
+| ファイル | 現状 | 修正後 |
+|---------|------|--------|
+| `pyproject.toml` | `[project.optional-dependencies].dev` | `[dependency-groups].dev` |
 
 ### 1. 実行に影響する修正
 
@@ -92,23 +144,47 @@ source .venv/bin/activate
 
 ### 変更タイプ
 
-- **実行に影響するコード変更**: `Makefile` の setup ターゲット、`scripts/verify-packaging.sh`
-- **docs-only**: その他全ファイル
+- **packaging-only**: `pyproject.toml`（dependency-groups 移行）、`Makefile`（setup ターゲット）、`scripts/verify-packaging.sh`
+- **docs-only**: その他全ファイル（CLAUDE.md, README.md, docs/*, スキルファイル, Serena 設定）
 
-実行に影響する変更は 2 ファイルのみで、いずれもシェルコマンドの置換であり、新規ロジックの追加ではない。
+`Makefile` の setup ターゲットと `scripts/verify-packaging.sh` はビルド・セットアップ基盤であり、
+kaji アプリケーションの実行時ロジック（`kaji_harness/` 配下の Python コード）には変更を加えない。
+シェルコマンドの pip → uv 置換のみであり、新規の Python ロジック追加は一切ない。
+
+### Small / Medium / Large の検証観点
+
+本変更は packaging-only + docs-only であり、`kaji_harness/` 配下の実行時コードに変更はない。
+各サイズの恒久テストを追加しない理由をサイズ別に記載する。
+
+#### Small テスト（恒久テスト追加なし）
+
+- 変更対象はシェルスクリプト・Makefile・ドキュメントのみ。pytest で検証可能な Python ロジックの追加・変更がない
+- 既存の Small テストは kaji_harness の単体ロジックを検証しており、本変更の回帰は検出対象外
+
+#### Medium テスト（恒久テスト追加なし）
+
+- ファイル I/O・DB・内部サービス結合に関わる変更がない
+- `scripts/verify-packaging.sh` は隔離環境でのパッケージインストールを行うが、
+  これ自体が packaging 検証ツールであり、テスト対象ではなく検証手段である
+
+#### Large テスト（恒久テスト追加なし）
+
+- 実 API 疎通・E2E データフローに関わる変更がない
+- `uv sync` → `make check` の実行が E2E 検証に相当するが、
+  これは CI/開発フローで常時実行されるゲートであり、専用の Large テストを新設する価値がない
 
 ### 変更固有検証
 
-- `uv sync` を実行し、`.venv` にパッケージがインストールされることを確認
+- `uv sync` を実行し、`.venv` に dev 依存（pytest, ruff, mypy 等）がインストールされることを確認
 - `make check` が通ることを確認（lint → format → typecheck → test）
 - `make verify-packaging` が uv ベースで動作することを確認
 - `make verify-docs` でドキュメントのリンク整合を確認
 
-### 恒久テストを追加しない理由
+### 恒久テストを追加しない理由（4 条件）
 
-1. **独自ロジックの追加・変更をほぼ含まない**: シェルコマンドの置換のみ
-2. **想定される不具合パターンが既存テストまたは既存品質ゲートで捕捉済み**: `make check` と `make verify-packaging` が既存ゲートとして機能
-3. **新規テストを追加しても回帰検出情報がほとんど増えない**: pip → uv の置換は一度完了すれば回帰しない性質
+1. **独自ロジックの追加・変更をほぼ含まない**: シェルコマンドの置換と pyproject.toml セクション名の変更のみ
+2. **想定される不具合パターンが既存テストまたは既存品質ゲートで捕捉済み**: `make check`（既存テスト全量実行）と `make verify-packaging`（隔離インストール検証）が既存ゲートとして機能
+3. **新規テストを追加しても回帰検出情報がほとんど増えない**: pip → uv の置換は一度完了すれば回帰しない性質。dependency-groups 移行も同様
 4. **テスト未追加の理由をレビュー可能な形で説明できる**: 上記の通り
 
 ## 影響ドキュメント
@@ -127,6 +203,7 @@ source .venv/bin/activate
 
 | 情報源 | URL/パス | 根拠（引用/要約） |
 |--------|----------|-------------------|
+| uv 公式ドキュメント: Dependencies | https://docs.astral.sh/uv/concepts/projects/dependencies/ | `uv sync` は `[dependency-groups].dev` をデフォルトで同期する。optional-dependencies はデフォルト同期されない。`tool.uv.default-groups` で制御可能 |
 | uv 公式ドキュメント: Getting Started | https://docs.astral.sh/uv/getting-started/features/ | `uv sync` は pyproject.toml と uv.lock に基づき依存を解決・インストールし、.venv を自動作成する |
 | uv 公式ドキュメント: pip interface | https://docs.astral.sh/uv/pip/ | `uv pip install` は pip 互換のインターフェースを提供し、隔離環境での検証に使用可能 |
 | uv 公式ドキュメント: uv venv | https://docs.astral.sh/uv/pip/environments/ | `uv venv` は `python -m venv` の代替として高速に仮想環境を作成する |

--- a/draft/design/issue-128-uv-migration.md
+++ b/draft/design/issue-128-uv-migration.md
@@ -1,0 +1,134 @@
+# [設計] パッケージ管理を pip から uv に統一する
+
+Issue: #128
+
+## 概要
+
+Makefile・ドキュメント・スキルファイルのセットアップ手順を pip/venv ベースから uv ベースに統一する。
+
+## 背景・目的
+
+uv.lock は既に存在し、実態として uv が使える状態にあるが、Makefile・ドキュメント・スキルファイルの記述が pip/venv のまま残っている。この乖離が AI エージェント・人間双方の作業にブレを生むため、記述を実態に合わせて uv に統一する。
+
+## インターフェース
+
+### 入力
+
+変更対象ファイル群（後述の修正対象一覧）。
+
+### 出力
+
+- `uv sync` でセットアップが完結する状態
+- 全ドキュメント・スキルの pip/venv 記述が uv に統一された状態
+
+### 使用例
+
+```bash
+# 変更前
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+# 変更後
+uv sync
+source .venv/bin/activate
+```
+
+## 制約・前提条件
+
+- build-backend は setuptools のまま変更しない（pyproject.toml の `[build-system]` は触らない）
+- `.venv` シンボリックリンク（worktree 共有）の仕組みは変更不要
+- CI/CD の変更なし（現時点で GitHub Actions なし）
+- `draft/` 配下の過去設計書アーカイブは修正スコープ外
+
+## 方針
+
+全修正をファイル種別で 4 カテゴリに分類し、順に対応する。
+
+### 1. 実行に影響する修正
+
+| ファイル | 現状 | 修正後 |
+|---------|------|--------|
+| `Makefile` setup ターゲット | `pip install -e ".[dev]"` | `uv sync` |
+| `scripts/verify-packaging.sh` | `python3 -m venv` + `pip install` | `uv venv` + `uv pip install` |
+
+### 2. ドキュメント修正
+
+| ファイル | 修正概要 |
+|---------|----------|
+| `CLAUDE.md` セットアップ手順 | `python -m venv .venv` + `make setup` → `uv sync` |
+| `CLAUDE.md` verify-packaging 説明 | pip → uv |
+| `README.md` セットアップ手順 | 同上 |
+| `README.md` verify-packaging 説明 | 同上 |
+| `docs/dev/testing-convention.md` | `pip install -e .` の扱いセクションを uv 前提に書き換え |
+| `docs/guides/git-worktree.md` | .venv 共有の警告文で pip → uv |
+| `docs/dev/workflow_feature_development.md` | セットアップ手順を uv に更新 |
+
+### 3. スキルファイル修正
+
+| ファイル | 修正概要 |
+|---------|----------|
+| `.claude/skills/issue-start/SKILL.md` | fallback の venv 作成コマンドを `uv venv` + `uv sync` に |
+| `.claude/skills/issue-implement/SKILL.md` | 禁止事項の `pip install -e .` → `uv pip install -e .` |
+
+### 4. Serena 設定
+
+| ファイル | 修正概要 |
+|---------|----------|
+| `.serena/memories/suggested_commands.md` | セットアップ手順を uv に |
+| `.serena/memories/task_completion.md` | venv activate 手順を更新 |
+
+**注意**: Serena 設定ファイルが存在しない場合は、Issue に存在しない旨をコメントしスキップする。
+
+### 修正方針の要点
+
+- 単純な文字列置換ではなく、各ファイルの文脈に合わせて記述を更新する
+- `uv sync` は `.venv` を自動作成するため、`python -m venv .venv` のステップは削除できる
+- `source .venv/bin/activate` は引き続き必要（シェル環境の PATH 設定のため）
+
+## テスト戦略
+
+> **CRITICAL**: 変更タイプに応じて妥当な検証方針を定義すること。
+
+### 変更タイプ
+
+- **実行に影響するコード変更**: `Makefile` の setup ターゲット、`scripts/verify-packaging.sh`
+- **docs-only**: その他全ファイル
+
+実行に影響する変更は 2 ファイルのみで、いずれもシェルコマンドの置換であり、新規ロジックの追加ではない。
+
+### 変更固有検証
+
+- `uv sync` を実行し、`.venv` にパッケージがインストールされることを確認
+- `make check` が通ることを確認（lint → format → typecheck → test）
+- `make verify-packaging` が uv ベースで動作することを確認
+- `make verify-docs` でドキュメントのリンク整合を確認
+
+### 恒久テストを追加しない理由
+
+1. **独自ロジックの追加・変更をほぼ含まない**: シェルコマンドの置換のみ
+2. **想定される不具合パターンが既存テストまたは既存品質ゲートで捕捉済み**: `make check` と `make verify-packaging` が既存ゲートとして機能
+3. **新規テストを追加しても回帰検出情報がほとんど増えない**: pip → uv の置換は一度完了すれば回帰しない性質
+4. **テスト未追加の理由をレビュー可能な形で説明できる**: 上記の通り
+
+## 影響ドキュメント
+
+この変更により更新が必要になる可能性のあるドキュメントを列挙する。
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | なし | 新しい技術選定ではない（uv は既に導入済み） |
+| docs/ARCHITECTURE.md | なし | アーキテクチャ変更なし |
+| docs/dev/ | あり | testing-convention.md, workflow_feature_development.md が修正対象 |
+| docs/cli-guides/ | なし | CLI 仕様変更なし |
+| CLAUDE.md | あり | セットアップ手順・verify-packaging 説明が修正対象 |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| uv 公式ドキュメント: Getting Started | https://docs.astral.sh/uv/getting-started/features/ | `uv sync` は pyproject.toml と uv.lock に基づき依存を解決・インストールし、.venv を自動作成する |
+| uv 公式ドキュメント: pip interface | https://docs.astral.sh/uv/pip/ | `uv pip install` は pip 互換のインターフェースを提供し、隔離環境での検証に使用可能 |
+| uv 公式ドキュメント: uv venv | https://docs.astral.sh/uv/pip/environments/ | `uv venv` は `python -m venv` の代替として高速に仮想環境を作成する |
+| 既存 uv.lock | `uv.lock`（リポジトリルート） | uv.lock が既に存在し、依存関係が解決済みであることが uv 移行の前提 |
+| pyproject.toml | `pyproject.toml`（リポジトリルート） | build-backend は setuptools のまま維持。`uv sync` は setuptools backend と互換 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",

--- a/scripts/verify-packaging.sh
+++ b/scripts/verify-packaging.sh
@@ -5,10 +5,10 @@ TMPDIR_PKG=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_PKG"' EXIT
 
 echo "==> Creating temporary venv in $TMPDIR_PKG/venv ..."
-python3 -m venv "$TMPDIR_PKG/venv"
+uv venv "$TMPDIR_PKG/venv"
 
 echo "==> Installing package in editable mode ..."
-"$TMPDIR_PKG/venv/bin/pip" install -e . --quiet
+uv pip install -e . --python "$TMPDIR_PKG/venv/bin/python" --quiet
 
 echo "==> Checking entry point (kaji --help) ..."
 "$TMPDIR_PKG/venv/bin/kaji" --help > /dev/null

--- a/uv.lock
+++ b/uv.lock
@@ -116,6 +116,15 @@ toml = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -126,29 +135,36 @@ wheels = [
 
 [[package]]
 name = "kaji"
-version = "0.2.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "setuptools" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+requires-dist = [{ name = "pyyaml", specifier = ">=6.0" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.10.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.0.0" },
+    { name = "ruff", specifier = ">=0.4.0" },
+    { name = "setuptools", specifier = ">=77.0.0" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "librt"
@@ -338,6 +354,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -418,6 +447,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -469,6 +507,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

pip/venv ベースのセットアップ手順を uv に統一する。Makefile・ドキュメント・スキルファイル等の記述が実態（uv.lock 存在）と乖離していたため修正。

Closes #128

## Changes

- `Makefile`: `pip install -e ".[dev]"` → `uv sync`
- `scripts/verify-packaging.sh`: `python3 -m venv` + `pip install` → `uv venv` + `uv pip install`
- `CLAUDE.md`, `README.md`: セットアップ手順を `uv sync` に統一
- `docs/dev/testing-convention.md`: pip 前提の記述を uv に更新
- `docs/guides/git-worktree.md`: .venv 共有説明で pip → uv
- `docs/dev/workflow_feature_development.md`: セットアップ手順更新
- `.claude/skills/issue-start/SKILL.md`, `issue-implement/SKILL.md`: pip 記述を uv に
- `.serena/memories/`: セットアップ手順を uv に統一

## Verification

- [ ] `uv sync` でセットアップが完結することを確認
- [ ] `make check` が通ることを確認
- [ ] 全対象ファイルの pip/venv 記述が uv に統一されていることを確認
- [ ] `scripts/verify-packaging.sh` が uv ベースで動作することを確認