### PR TITLE
docs: kamo2 から Python 品質規約 6 本を docs/reference/python/ へ移植 (#141)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,12 @@ kaji validate <workflow.yaml>...                    # Validate workflow YAML(s)
 | AI Strategy | docs/concepts/ai-driven-strategy.md |
 | AI Docs Management | docs/concepts/ai-docs-management.md |
 | Label Standardization | docs/rfc/github-labels-standardization.md |
+| Python Style | docs/reference/python/python-style.md |
+| Naming Conventions | docs/reference/python/naming-conventions.md |
+| Type Hints | docs/reference/python/type-hints.md |
+| Docstring Style | docs/reference/python/docstring-style.md |
+| Error Handling | docs/reference/python/error-handling.md |
+| Logging (RunLogger) | docs/reference/python/logging.md |
 
 ## Development Skills
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,17 @@ kaji のドキュメント一覧。[Diataxis フレームワーク](https://diat
 | [テストサイズ判断ガイド](reference/testing-size-guide.md) | S/M/L の境界ケース判断基準 |
 | [CLI ガイド](cli-guides/) | CLI 操作リファレンス |
 
+### Python 品質規約
+
+| ドキュメント | 概要 |
+|-------------|------|
+| [Python スタイル規約](reference/python/python-style.md) | フォーマット・インポート・クラス設計の規約 |
+| [命名規則](reference/python/naming-conventions.md) | 変数・関数・kaji 固有語の命名パターン |
+| [型ヒント](reference/python/type-hints.md) | 型アノテーション・dataclass の書き方 |
+| [docstring スタイル](reference/python/docstring-style.md) | Google style docstring の記述規約 |
+| [エラーハンドリング](reference/python/error-handling.md) | HarnessError 階層と例外処理パターン |
+| [ロギング](reference/python/logging.md) | RunLogger JSONL 契約とイベント仕様 |
+
 ## Explanation（コンセプト）
 
 | ドキュメント | 概要 |

--- a/docs/reference/python/docstring-style.md
+++ b/docs/reference/python/docstring-style.md
@@ -1,0 +1,246 @@
+# docstring スタイル規約
+
+kaji における docstring・コメントの記述規約。Google Style docstring を採用する。
+
+一次情報: [Google Python Style Guide §3.8](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
+
+## 基本方針
+
+- **Google Style 準拠**: CLAUDE.md 既定の「Google docstrings」に従う
+- **型ヒントと重複しない**: 型情報は型アノテーションで表現し、docstring では意味・制約を記述する
+- **AI エージェントが参照する規約**: grep しやすく、機械的に適用できる粒度で記述する
+- **モジュール冒頭の docstring は必須**（PEP 257 準拠）
+
+## モジュールの docstring
+
+全モジュールに 1 行以上の docstring を付与する。
+
+```python
+"""Run logger for kaji_harness.
+
+JSONL format execution logger with immediate flush.
+"""
+```
+
+複数行が必要な場合は 1 行サマリー → 空行 → 詳細の順。
+
+```python
+"""Workflow execution engine for kaji_harness.
+
+Reads a workflow YAML, resolves steps and cycles, and executes them
+in order. Resumes from a specific step if --from is specified.
+"""
+```
+
+## 関数・メソッドの docstring
+
+### 基本構造
+
+```python
+def parse_verdict(output: str) -> Verdict:
+    """ステップ出力から verdict ブロックを解析する。
+
+    ---VERDICT--- / ---END_VERDICT--- の間のテキストを抽出し、
+    status / reason / evidence / suggestion を返す。
+
+    Args:
+        output: ステップの標準出力全体。
+
+    Returns:
+        解析した Verdict オブジェクト。
+
+    Raises:
+        VerdictNotFound: ---VERDICT--- ブロックが存在しない場合。
+        VerdictParseError: 必須フィールドが欠損している場合。
+    """
+    ...
+```
+
+### 各セクションのルール
+
+| セクション | 必須 | 説明 |
+|---------|------|------|
+| 1 行サマリー | 必須 | 動詞で始める。末尾に `。` |
+| 詳細説明 | 任意 | サマリーで伝わらない前提・挙動を記述 |
+| `Args:` | 必須（引数があれば） | 各引数の意味・制約 |
+| `Returns:` | 必須（None 以外を返す関数） | 戻り値の意味。型は型ヒントに任せる |
+| `Raises:` | 必須（raise する例外がある場合） | どの例外をいつ raise するか |
+| `Example:` | 任意 | 使用例（doctest 形式は不要） |
+| `Note:` | 任意 | 注意事項・制約・非自明な挙動 |
+
+### Args セクション
+
+型情報は型ヒントで表現するため、Args では意味・制約を記述する。
+
+```python
+def run_step(
+    step: Step,
+    issue: int,
+    workdir: Path,
+    timeout: int = 300,
+) -> Verdict:
+    """ステップを実行し verdict を返す。
+
+    Args:
+        step: 実行対象のステップ定義。
+        issue: GitHub Issue 番号。スキルへの引数として渡される。
+        workdir: ステップを実行するディレクトリ。存在しない場合は raise。
+        timeout: タイムアウト秒数。0 以下の場合は無制限。
+
+    Returns:
+        ステップ出力から解析した Verdict。
+
+    Raises:
+        WorkdirNotFoundError: workdir が存在しない場合。
+        StepTimeoutError: timeout 秒を超えた場合。
+        VerdictNotFound: 出力に ---VERDICT--- ブロックがない場合。
+    """
+```
+
+引数が 1 つの場合でも Args セクションを付ける。
+
+### Returns セクション
+
+複数の値を返す場合は内容を明示する。
+
+```python
+def extract_session_id(output: str) -> str | None:
+    """出力から Claude session ID を抽出する。
+
+    Returns:
+        session_id 文字列。出力に含まれない場合は None。
+    """
+```
+
+### Raises セクション
+
+`HarnessError` の具体的なサブクラスを記述する。`Exception` のような基底クラスは使わない。
+
+```python
+    Raises:
+        ConfigNotFoundError: .kaji/config.toml が見つからない場合。
+        ConfigLoadError: TOML の解析・検証に失敗した場合。
+```
+
+## クラスの docstring
+
+クラス docstring は `__init__` に書かず、クラス本体に書く。`Attributes:` セクションで主要な属性を説明する。
+
+```python
+@dataclass
+class RunLogger:
+    """JSONL 形式の実行ログを出力するクラス。
+
+    ファイルへの書き込みは即時 flush する（プロセスが途中終了しても
+    ログが残るようにするため）。
+
+    Attributes:
+        log_path: JSONL ファイルの書き込み先パス。
+    """
+
+    log_path: Path
+```
+
+```python
+@dataclass
+class WorkflowRunner:
+    """ワークフロー実行エンジン。
+
+    Attributes:
+        config: .kaji/config.toml の設定。
+        logger: 実行ログの出力先。None の場合はログを出力しない。
+    """
+
+    config: KajiConfig
+    logger: RunLogger | None = None
+```
+
+## 短い関数の docstring
+
+5 行以下の関数は 1 行 docstring で十分。
+
+```python
+def is_terminal_status(status: str) -> bool:
+    """status が終端（以降のステップなし）かどうかを返す。"""
+    return status in ("END", "ABORT")
+```
+
+ただし `Raises` がある場合は複数行に展開する。
+
+```python
+def find_step(self, step_id: str) -> Step:
+    """ID でステップを検索する。
+
+    Raises:
+        KeyError: step_id に対応するステップが存在しない場合。
+    """
+    ...
+```
+
+## インラインコメント
+
+コードで表現できない「なぜ」のみ書く。「何をしているか」はコードと docstring で伝える。
+
+```python
+# SIGTERM 後に SIGKILL を送る（プロセスが SIGTERM を catch している場合への対処）
+process.kill()
+
+# step.on が空の場合は workflow 終了（None を返すことで呼び出し側が END と判断）
+return None
+```
+
+一時的な制約は TODO + 理由で記録する。
+
+```python
+# TODO: claude-code が --no-cache をサポートしたら削除 (#123)
+env.pop("CLAUDE_CODE_CACHE", None)
+```
+
+## 型情報と重複しない書き方
+
+型ヒントで伝わる情報を Args に繰り返さない。
+
+```python
+# ❌ 型ヒントと重複
+def get_step(step_id: str) -> Step | None:
+    """ステップを取得する。
+
+    Args:
+        step_id (str): ステップ ID。  # 型ヒントで明らか
+    Returns:
+        Step | None: ステップまたは None。  # 型ヒントで明らか
+    """
+
+# ✅ 意味・制約のみ記述
+def get_step(step_id: str) -> Step | None:
+    """ステップを取得する。
+
+    Args:
+        step_id: workflow 内で一意なステップ ID。
+
+    Returns:
+        見つかった Step。存在しない場合は None（raise しない）。
+    """
+```
+
+## チェックリスト
+
+### 実装時チェック
+
+- [ ] モジュール冒頭に docstring があるか
+- [ ] 全クラス・全公開関数に docstring があるか
+- [ ] 1 行サマリーが動詞で始まるか
+- [ ] `Args:` / `Returns:` / `Raises:` が必要な場合に記載されているか
+- [ ] 型情報の重複がないか（型は型ヒントに任せているか）
+
+### レビュー時チェック
+
+- [ ] docstring がコードの内容と一致しているか
+- [ ] `Raises:` に具体的な例外クラスが記載されているか（`HarnessError` のサブクラス）
+- [ ] 非自明な挙動・制約が `Note:` または本文に記載されているか
+
+## 関連ドキュメント
+
+- [Python スタイル規約](./python-style.md) — 全般的なコーディング規約
+- [命名規則](./naming-conventions.md) — 関数・変数名の命名パターン
+- [型ヒント](./type-hints.md) — 型アノテーションとの分担

--- a/docs/reference/python/error-handling.md
+++ b/docs/reference/python/error-handling.md
@@ -1,0 +1,253 @@
+# エラーハンドリング規約
+
+kaji における例外処理の統一規約。`kaji_harness/errors.py` の HarnessError 階層を基礎とする。
+
+## 基本原則
+
+1. **階層的例外クラスを使用する** — 全カスタム例外は `HarnessError` を継承する
+2. **握り潰し禁止** — `except Exception: pass` は書かない
+3. **情報を付与して raise する** — 文脈情報（step_id, path 等）を例外に含める
+4. **適切な粒度で wrap する** — 外部例外は内部例外に変換して re-raise する
+
+## HarnessError 階層
+
+`kaji_harness/errors.py` に定義された例外クラス。新規コードでは必ずこの階層内の例外を使用する。
+
+```
+HarnessError                        # 基底例外
+├── ConfigNotFoundError             # .kaji/config.toml が見つからない
+├── ConfigLoadError                 # config の読み込み・検証失敗
+├── WorkflowValidationError         # ワークフロー YAML の静的検証エラー
+├── SkillNotFound                   # スキルファイルが見つからない
+├── SecurityError                   # パストラバーサル等のセキュリティ違反
+├── CLIExecutionError               # CLI プロセスが非ゼロ終了
+├── CLINotFoundError                # CLI コマンドが見つからない
+├── StepTimeoutError                # ステップがタイムアウト
+├── WorkdirNotFoundError            # 指定された workdir が存在しない
+├── MissingResumeSessionError       # resume 指定でセッション ID が見つからない
+├── VerdictNotFound                 # 出力に ---VERDICT--- ブロックがない
+├── VerdictParseError               # 必須フィールド欠損
+├── InvalidVerdictValue             # on に未定義の status 値
+└── InvalidTransition               # verdict.status に対応する遷移先がない
+```
+
+## 例外クラスの選択
+
+実装時は以下の基準で例外クラスを選ぶ。
+
+| 状況 | 使用する例外 |
+|------|------------|
+| 設定ファイルが見つからない | `ConfigNotFoundError` |
+| YAML の構文・スキーマ違反 | `WorkflowValidationError` |
+| スキルファイルが存在しない | `SkillNotFound` |
+| CLI が exit 非ゼロで終了 | `CLIExecutionError` |
+| CLI コマンドが見つからない | `CLINotFoundError` |
+| ステップがタイムアウト | `StepTimeoutError` |
+| verdict ブロックがない | `VerdictNotFound` |
+| verdict フィールドが欠損 | `VerdictParseError` |
+| 不正な status 値 | `InvalidVerdictValue` |
+| 既存クラスで表現できない新規エラー | 新クラスを `HarnessError` から派生 |
+
+## 例外処理パターン
+
+### 基本パターン：wrap して re-raise
+
+```python
+def load_skill(skill_name: str, skills_dir: Path) -> Path:
+    """スキルファイルのパスを解決する。"""
+    skill_path = skills_dir / skill_name
+
+    try:
+        resolved = skill_path.resolve(strict=True)
+    except FileNotFoundError:
+        raise SkillNotFound(f"Skill not found: {skill_name}") from None
+
+    # パストラバーサル検証
+    if not str(resolved).startswith(str(skills_dir)):
+        raise SecurityError(f"Path traversal detected: {skill_name}")
+
+    return resolved
+```
+
+### CLI 実行エラーの処理
+
+```python
+def execute_cli(cmd: list[str], step_id: str, timeout: int) -> CLIResult:
+    """CLI コマンドを実行する。"""
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        raise CLINotFoundError(f"Command not found: {cmd[0]}") from None
+    except subprocess.TimeoutExpired:
+        raise StepTimeoutError(step_id, timeout)
+
+    if proc.returncode != 0:
+        raise CLIExecutionError(step_id, proc.returncode, proc.stderr)
+
+    return CLIResult(full_output=proc.stdout, stderr=proc.stderr)
+```
+
+### Verdict エラーの処理
+
+Verdict エラー（`VerdictNotFound` / `VerdictParseError` / `InvalidVerdictValue`）は回復不能なため、リトライせずに上位に伝播させる。
+
+```python
+def parse_verdict(output: str) -> Verdict:
+    """出力から verdict を解析する。"""
+    match = VERDICT_PATTERN.search(output)
+    if match is None:
+        raise VerdictNotFound("---VERDICT--- block not found in output")
+
+    block = match.group(1)
+    data = _parse_yaml_block(block)
+
+    if "status" not in data:
+        raise VerdictParseError("Required field 'status' missing from verdict")
+
+    return Verdict(
+        status=data["status"],
+        reason=data.get("reason", ""),
+        evidence=data.get("evidence", ""),
+        suggestion=data.get("suggestion", ""),
+    )
+```
+
+### 上位での集約
+
+`WorkflowRunner.run()` 等の最上位では全 `HarnessError` を catch してログ出力し、再 raise する。
+
+```python
+def run(self, workflow: Workflow, issue: int) -> None:
+    """ワークフローを実行する。"""
+    self.logger.log_workflow_start(issue, workflow.name)
+    try:
+        self._run_steps(workflow, issue)
+    except HarnessError as e:
+        self.logger.log_workflow_end(
+            status="error",
+            cycle_counts={},
+            total_duration_ms=0,
+            total_cost=None,
+            error=str(e),
+        )
+        raise
+```
+
+## 禁止パターン
+
+### 握り潰し
+
+```python
+# ❌ 禁止
+try:
+    result = parse_verdict(output)
+except Exception:
+    pass  # 黙って無視
+
+# ✅ 少なくともログを出力し、可能なら re-raise
+try:
+    result = parse_verdict(output)
+except VerdictNotFound:
+    self.logger.log_step_end(step.id, ...)
+    raise
+```
+
+### 情報なし re-raise
+
+```python
+# ❌ 文脈情報が失われる
+try:
+    skill_path = resolve_skill(step.skill)
+except FileNotFoundError:
+    raise HarnessError("error")  # step_id もパスも不明
+
+# ✅ 文脈を付与する
+try:
+    skill_path = resolve_skill(step.skill)
+except FileNotFoundError:
+    raise SkillNotFound(f"Skill '{step.skill}' not found for step '{step.id}'") from None
+```
+
+### 広すぎる catch
+
+```python
+# ❌ すべての例外を同一視
+try:
+    result = run_step(step)
+except Exception as e:
+    logger.error(str(e))
+
+# ✅ 期待する例外のみを catch
+try:
+    result = run_step(step)
+except StepTimeoutError:
+    logger.warning(f"Step {step.id} timed out, proceeding to timeout handler")
+    return _handle_timeout(step)
+except CLIExecutionError as e:
+    logger.error(f"Step {step.id} CLI failed: exit={e.returncode}")
+    raise
+```
+
+## 新規例外クラスの追加
+
+既存クラスで表現できない新規エラーが必要な場合、以下のルールで追加する。
+
+1. `HarnessError` またはその適切なサブクラスから派生する
+2. `__init__` で文脈情報（step_id / path 等）を属性として保持する
+3. エラーメッセージは英語で記述する（日本語 UI はないため）
+
+```python
+class WorkdirNotFoundError(HarnessError):
+    """ステップ実行時に指定された workdir が存在しない。"""
+
+    def __init__(self, step_id: str, workdir: Path):
+        self.step_id = step_id
+        self.workdir = workdir
+        super().__init__(f"Step '{step_id}' workdir does not exist: {workdir}")
+```
+
+## テストでのエラー検証
+
+```python
+import pytest
+from kaji_harness.errors import VerdictNotFound, CLIExecutionError
+
+
+def test_parse_verdict_missing_block() -> None:
+    with pytest.raises(VerdictNotFound):
+        parse_verdict("no verdict block here")
+
+
+def test_cli_exit_nonzero() -> None:
+    with pytest.raises(CLIExecutionError) as exc_info:
+        execute_cli(["false"], step_id="test", timeout=10)
+    assert exc_info.value.returncode == 1
+    assert exc_info.value.step_id == "test"
+```
+
+## チェックリスト
+
+### 実装時チェック
+
+- [ ] カスタム例外は `HarnessError` 階層から派生しているか
+- [ ] `except Exception: pass` がないか
+- [ ] 外部例外を catch する場合、文脈情報を付与して re-raise しているか
+- [ ] Verdict エラーをリトライしていないか（回復不能）
+- [ ] 新規例外クラスに `step_id` / `path` 等の属性が含まれているか
+
+### レビュー時チェック
+
+- [ ] catch する例外の粒度が適切か（広すぎないか）
+- [ ] エラーメッセージに十分な文脈情報があるか
+- [ ] `from e` / `from None` の使い分けが適切か
+
+## 関連ドキュメント
+
+- [Python スタイル規約](./python-style.md) — 全般的なコーディング規約
+- [ロギング](./logging.md) — エラー発生時のログ出力
+- `kaji_harness/errors.py` — 例外クラスの実装

--- a/docs/reference/python/logging.md
+++ b/docs/reference/python/logging.md
@@ -1,0 +1,236 @@
+# ロギング規約
+
+kaji における実行ログの規約。`kaji_harness/logger.py` の `RunLogger` JSONL 契約を文書化する。
+
+> このドキュメントは Python 標準 `logging` モジュールの使い方ガイドではない。
+> `RunLogger` は JSONL を直接書き出す専用実装であり、標準 `logging` を使用しない。
+
+## RunLogger の概要
+
+`RunLogger` は `kaji_harness/logger.py` に定義された dataclass。ワークフロー実行中のイベントを JSONL 形式でファイルに記録する。
+
+```python
+from kaji_harness.logger import RunLogger
+from pathlib import Path
+
+logger = RunLogger(log_path=Path(".kaji/run.jsonl"))
+```
+
+各イベントは JSON オブジェクト 1 行として書き込まれ、即時 `flush()` される。プロセスが途中終了してもログが失われない。
+
+## JSONL フォーマット
+
+### 全イベント共通フィールド
+
+すべてのイベントに必ず含まれるフィールド:
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `ts` | `str` | UTC タイムスタンプ（ISO 8601 形式: `"2025-04-22T00:00:00.000000+00:00"`） |
+| `event` | `str` | イベント名（下記参照） |
+
+### イベント別フィールド
+
+#### `workflow_start`
+
+ワークフロー実行開始時に記録。
+
+| フィールド | 型 |
+|-----------|-----|
+| `issue` | `int` |
+| `workflow` | `str` |
+
+```json
+{"ts": "2025-04-22T01:00:00+00:00", "event": "workflow_start", "issue": 141, "workflow": "feature_development.yaml"}
+```
+
+#### `step_start`
+
+ステップ実行開始時に記録。
+
+| フィールド | 型 |
+|-----------|-----|
+| `step_id` | `str` |
+| `agent` | `str` |
+| `model` | `str \| null` |
+| `effort` | `str \| null` |
+| `session_id` | `str \| null` |
+
+```json
+{"ts": "2025-04-22T01:00:01+00:00", "event": "step_start", "step_id": "implement", "agent": "claude", "model": "claude-sonnet-4-6", "effort": null, "session_id": null}
+```
+
+#### `step_end`
+
+ステップ終了時に記録（正常終了・タイムアウト・エラーを問わず）。
+
+| フィールド | 型 |
+|-----------|-----|
+| `step_id` | `str` |
+| `verdict` | `dict` |
+| `duration_ms` | `int` |
+| `cost` | `dict \| null` |
+
+`verdict` の構造:
+
+```json
+{"status": "PASS", "reason": "...", "evidence": "...", "suggestion": "..."}
+```
+
+`cost` の構造（利用可能な場合のみ）:
+
+```json
+{"usd": 0.012, "input_tokens": 1500, "output_tokens": 800}
+```
+
+```json
+{"ts": "2025-04-22T01:05:00+00:00", "event": "step_end", "step_id": "implement", "verdict": {"status": "PASS", "reason": "実装完了", "evidence": "pytest 全パス", "suggestion": ""}, "duration_ms": 240000, "cost": {"usd": 0.015, "input_tokens": 2000, "output_tokens": 1200}}
+```
+
+#### `cycle_iteration`
+
+サイクル内の各イテレーション開始時に記録。
+
+| フィールド | 型 |
+|-----------|-----|
+| `cycle_name` | `str` |
+| `iteration` | `int` |
+| `max_iterations` | `int` |
+
+```json
+{"ts": "2025-04-22T01:10:00+00:00", "event": "cycle_iteration", "cycle_name": "review_fix_loop", "iteration": 2, "max_iterations": 5}
+```
+
+#### `workflow_end`
+
+ワークフロー終了時に記録。
+
+| フィールド | 型 | 備考 |
+|-----------|-----|------|
+| `status` | `str` | `"completed"` / `"error"` 等 |
+| `cycle_counts` | `dict[str, int]` | サイクル名 → 実行回数 |
+| `total_duration_ms` | `int` | |
+| `total_cost` | `float \| null` | USD。利用不可の場合は null |
+| `error` | `str` | エラー発生時のみ存在 |
+
+```json
+{"ts": "2025-04-22T01:30:00+00:00", "event": "workflow_end", "status": "completed", "cycle_counts": {"review_fix_loop": 2}, "total_duration_ms": 1800000, "total_cost": 0.085}
+```
+
+## RunLogger の呼び出し場所
+
+各メソッドを呼ぶタイミングを明記する。
+
+| メソッド | いつ呼ぶか |
+|---------|-----------|
+| `log_workflow_start(issue, workflow)` | ワークフロー開始直後 |
+| `log_step_start(step_id, agent, model, effort, session_id)` | CLI 実行前 |
+| `log_step_end(step_id, verdict, duration_ms, cost)` | CLI 終了・verdict 解析後 |
+| `log_cycle_iteration(cycle_name, iteration, max_iter)` | サイクル内の各反復開始時 |
+| `log_workflow_end(status, cycle_counts, total_duration_ms, total_cost, error)` | ワークフロー終了時（正常・異常問わず） |
+
+```python
+# 典型的な呼び出し順序
+logger.log_workflow_start(issue=141, workflow="feature_development.yaml")
+logger.log_step_start("design", "claude", "claude-sonnet-4-6", None, None)
+# ... CLI 実行 ...
+logger.log_step_end("design", verdict, duration_ms=60000, cost=cost_info)
+logger.log_cycle_iteration("review_fix_loop", iteration=1, max_iter=5)
+logger.log_step_start("review", "claude", None, None, session_id)
+# ... CLI 実行 ...
+logger.log_step_end("review", verdict, duration_ms=30000, cost=None)
+logger.log_workflow_end("completed", {"review_fix_loop": 1}, 90000, 0.025)
+```
+
+## 新規イベントを追加する場合のガイドライン
+
+`RunLogger` に新しいイベントを追加する場合は以下のルールに従う。
+
+### イベント名の命名規則
+
+`{noun}_{verb_past}` または `{noun}_{state}` の snake_case。
+
+```python
+# ✅ 良い例
+"step_skipped"
+"cycle_exhausted"
+"budget_exceeded"
+
+# ❌ 避けるべき
+"skipStep"        # camelCase
+"step-skip"       # kebab-case
+"skip"            # 短すぎる・名詞なし
+```
+
+### フィールド設計のルール
+
+1. **共通フィールド（`ts` / `event`）は `_write()` が自動付与するため、イベント固有フィールドだけを `**kwargs` に渡す**
+2. **フィールド名は snake_case**
+3. **None を許容するフィールドは `str | None` 等で型を明示する**
+4. **金額は `float`（USD）、期間は `int`（ミリ秒）で統一する**
+
+```python
+def log_budget_exceeded(self, step_id: str, budget_usd: float, spent_usd: float) -> None:
+    """予算超過イベントを記録。"""
+    self._write(
+        "budget_exceeded",
+        step_id=step_id,
+        budget_usd=budget_usd,
+        spent_usd=spent_usd,
+    )
+```
+
+### 後方互換性の維持
+
+既存フィールドの削除・型変更は禁止。新フィールドの追加は `| None` として optional にする。
+
+## 禁止事項
+
+### 標準 logging の直接使用
+
+```python
+# ❌ 禁止
+import logging
+logging.info("step started")
+
+# ✅ RunLogger を使う
+self.logger.log_step_start(step.id, step.agent, step.model, step.effort, session_id)
+```
+
+### 文字列フォーマットでのイベント記述
+
+```python
+# ❌ 禁止: JSON に埋め込む場合に構造が失われる
+self._write("step_end", message=f"step {step_id} ended with {status}")
+
+# ✅ 各値を独立したフィールドとして渡す
+self._write("step_end", step_id=step_id, verdict=asdict(verdict), ...)
+```
+
+### 機密情報の記録
+
+API キー・トークン・認証情報をフィールドとして記録しない。
+
+```python
+# ❌ 禁止
+self._write("step_start", api_key=config.api_key)
+
+# ✅ ID や存在フラグのみ
+self._write("step_start", agent=step.agent, model=step.model, ...)
+```
+
+## チェックリスト
+
+### 実装時チェック
+
+- [ ] `RunLogger` のメソッドを正しいタイミングで呼んでいるか
+- [ ] `log_workflow_end` が正常・異常終了どちらのパスでも呼ばれているか（`try/finally` 等）
+- [ ] 新規イベントのフィールド名が snake_case か
+- [ ] 標準 `logging` モジュールを直接使用していないか
+- [ ] 機密情報がフィールドに含まれていないか
+
+## 関連ドキュメント
+
+- `kaji_harness/logger.py` — RunLogger の実装（フィールド仕様のソースオブトゥルース）
+- [エラーハンドリング](./error-handling.md) — エラー発生時の RunLogger 呼び出しパターン
+- [Python スタイル規約](./python-style.md) — 全般的なコーディング規約

--- a/docs/reference/python/naming-conventions.md
+++ b/docs/reference/python/naming-conventions.md
@@ -1,0 +1,206 @@
+# 命名規則
+
+kaji における統一的な命名規則。Python コード・ファイル・設定項目をカバーする。
+
+## 基本原則
+
+- **明確性**: 名前から目的・役割が即座に理解できる
+- **一貫性**: プロジェクト全体で統一したパターンを使用する
+- **検索性**: grep / IDE 検索で容易に発見できる（略語・独自語を避ける）
+- **簡潔性**: 必要十分な長さ。ただし省略しすぎて意味が失われるより冗長な方を取る
+
+## Python コード命名
+
+### 基本パターン
+
+| 対象 | 規則 | 例 | 備考 |
+|------|------|-----|------|
+| 変数 | `snake_case` | `step_id`, `session_state` | 名詞・名詞句 |
+| 関数 | `snake_case` | `execute_step()`, `parse_verdict()` | 動詞で開始 |
+| クラス | `PascalCase` | `WorkflowRunner`, `SessionState` | 名詞・名詞句 |
+| 定数 | `UPPER_SNAKE_CASE` | `DEFAULT_TIMEOUT`, `MAX_RETRIES` | モジュールレベルのみ |
+| モジュール | `snake_case` | `workflow.py`, `verdict.py` | 短く・明確に |
+| パッケージ | `snake_case` | `kaji_harness/` | ハイフン不可 |
+
+### プライベート・保護
+
+```python
+# モジュール内プライベート（外部から使わない）
+def _internal_helper() -> None:
+    ...
+
+_INTERNAL_CONSTANT = 42
+
+# クラス内プライベート（サブクラスは触ってよい）
+class RunLogger:
+    def _write(self, event: str, **kwargs: Any) -> None:
+        ...
+```
+
+名前マングリング（`__double_leading`）は禁止。テストやモックが著しく困難になる。
+
+### 動詞の使い分け
+
+Python 標準ライブラリ・広く採用されている命名慣習に合わせる。
+
+#### データ取得
+
+```python
+def get_step(step_id: str) -> Step | None:                # ID 指定で単一取得（失敗時 None）
+def find_cycle_for_step(step_id: str) -> Cycle | None:    # 条件検索
+def load_workflow(path: Path) -> Workflow:                # ファイルから読み込み
+```
+
+#### データ作成・処理
+
+```python
+def create_session(step_id: str) -> SessionState:         # 新規作成
+def run_step(step: Step, issue: int) -> Verdict:          # 実行・処理（副作用あり）
+def execute_cli(cmd: list[str]) -> CLIResult:             # 外部プロセス実行
+def build_command(step: Step, issue: int) -> list[str]:   # オブジェクト構築（副作用なし）
+```
+
+#### 解析・変換
+
+```python
+def parse_verdict(output: str) -> Verdict:                # テキストから構造体へ
+def extract_session_id(output: str) -> str | None:        # 特定情報の抽出
+def format_step_summary(step: Step) -> str:               # 表示用文字列へ
+```
+
+#### 判定・検証
+
+```python
+def is_terminal_status(status: str) -> bool:              # 状態判定（bool）
+def validate_workflow(workflow: Workflow) -> None:         # 検証（失敗時 raise）
+def has_cycle(workflow: Workflow, step_id: str) -> bool:  # 存在確認
+```
+
+## kaji 固有語の統一
+
+kaji ドメインで使用する語彙は以下に統一する。AI エージェントが一貫して使用すること。
+
+| 概念 | 統一語 | 禁止・非推奨 |
+|------|--------|------------|
+| ワークフロー実行単位 | `step` | task, job, operation |
+| ステップ判定結果 | `verdict` | result, outcome, decision |
+| 繰り返し実行 | `cycle` | loop, iteration（変数名としての `iteration` は可） |
+| スキルファイル | `skill` | script, prompt, template |
+| 実行エンジン | `harness` | runner（クラス名 `WorkflowRunner` は可） |
+| ワークフロー定義 | `workflow` | pipeline, process |
+| セッション状態 | `session_state` | context, state（単独の `state` は可） |
+
+### 使用例
+
+```python
+# step 関連
+step_id: str
+current_step: Step
+find_step(step_id: str) -> Step | None
+
+# verdict 関連
+verdict: Verdict
+parse_verdict(output: str) -> Verdict
+verdict_status: str  # "PASS", "FAIL", "ABORT" 等
+
+# cycle 関連
+cycle: CycleDefinition
+cycle_count: int
+max_iterations: int  # cycle 内の反復回数は iterations が自然
+
+# skill 関連
+skill_path: Path
+resolve_skill(name: str) -> Path
+
+# workflow 関連
+workflow: Workflow
+workflow_name: str
+load_workflow(path: Path) -> Workflow
+```
+
+## ファイル・ディレクトリ命名
+
+### kaji_harness/ モジュール構造
+
+```
+kaji_harness/
+├── __init__.py
+├── cli.py              # CLI エントリポイント
+├── runner.py           # WorkflowRunner 実装
+├── workflow.py         # Workflow 解析・検証
+├── executor.py         # Step 実行ロジック
+├── verdict.py          # Verdict 解析
+├── logger.py           # RunLogger 実装
+├── models.py           # dataclass 定義
+├── errors.py           # 例外クラス定義
+└── config.py           # 設定読み込み
+```
+
+### テストファイル
+
+テストファイルは `tests/test_[module].py` の形式。
+
+```
+tests/
+├── test_runner.py
+├── test_workflow.py
+├── test_verdict.py
+└── conftest.py
+```
+
+### ワークフロー・スキルファイル
+
+```
+workflows/
+├── feature_development.yaml
+└── bugfix.yaml
+
+.claude/skills/
+├── issue-start/
+│   └── ...
+└── issue-implement/
+    └── ...
+```
+
+## 略語・頭字語
+
+### 推奨される略語
+
+```python
+id          # identifier
+cli         # command-line interface
+yaml        # YAML Ain't Markup Language
+cfg         # config（設定オブジェクトの変数名のみ）
+```
+
+### 避けるべき略語
+
+```python
+# ❌ 理解困難な略語
+mgr         # manager → manager のまま
+proc        # process → process のまま
+tmp         # temporary → temp または temporary
+wf          # workflow → workflow のまま
+```
+
+## チェックリスト
+
+### 実装時チェック
+
+- [ ] 名前から目的・役割が明確か
+- [ ] kaji 固有語が統一されているか（上記テーブル参照）
+- [ ] 動詞の使い分けが一貫しているか（`get_` / `find_` / `parse_` 等）
+- [ ] プライベートメソッドが `_` 始まりか
+- [ ] 略語が推奨リスト内か
+
+### レビュー時チェック
+
+- [ ] 同じ概念に対して異なる名前を使っていないか
+- [ ] grep・IDE 検索で発見しやすいか
+- [ ] kaji 固有語が統一されているか
+
+## 関連ドキュメント
+
+- [Python スタイル規約](./python-style.md) — 基本的なコーディングスタイル
+- [型ヒント](./type-hints.md) — 型名・変数名の型注釈
+- [docstring スタイル](./docstring-style.md) — docstring での命名記述

--- a/docs/reference/python/python-style.md
+++ b/docs/reference/python/python-style.md
@@ -1,0 +1,179 @@
+# Python スタイル規約
+
+kaji における Python コードのスタイル規約。PEP 8 を基本とし、プロジェクト固有の要件を追加する。
+
+## 基本方針
+
+- **明示性 > 暗黙性 > 簡潔性** の優先順位
+- **型安全性**を重視（型ヒントは必須。詳細は [type-hints.md](./type-hints.md)）
+- **AI 協調開発**を意識した、grep しやすい明確な規約
+- **ruff / mypy / pytest による自動チェックで担保**（手動では守れない規約は書かない）
+
+手動フォーマットや個別のスタイル議論は許容しない。すべて `make check` 経由で機械的に判定する。
+
+## フォーマット規則
+
+ruff が自動適用する。以下は規約としての意図を説明するもので、手で整える必要はない。
+
+### インデント・行長
+
+- インデント: スペース 4 つ（タブ禁止）
+- 行長: 100 文字（`pyproject.toml` の `[tool.ruff] line-length = 100`）
+- 文字列のエスケープを避けるため、ダブルクォート `"` を優先
+
+```python
+def execute_step(
+    step: Step,
+    state: SessionState,
+    config: KajiConfig,
+) -> Verdict:
+    """ステップを実行し verdict を返す。"""
+    ...
+```
+
+長い文字列は括弧で囲んで連結する。`+` 連結や改行文字の埋め込みは避ける。
+
+```python
+message = (
+    f"Step '{step.id}' failed after {duration_ms}ms: "
+    f"exit code {returncode}, stderr: {stderr[:200]}"
+)
+```
+
+### インポート順序
+
+ruff の `I` ルールで自動整列される。手動で整える必要はないが、規約上は以下の 3 分類。
+
+```python
+"""モジュール docstring（必須）."""
+
+from __future__ import annotations
+
+# 1. 標準ライブラリ（アルファベット順）
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# 2. サードパーティライブラリ（アルファベット順）
+import yaml
+
+# 3. 自プロジェクトのインポート（相対パス禁止）
+from kaji_harness.errors import HarnessError, VerdictNotFound
+from kaji_harness.models import Step, Verdict
+
+# 4. モジュールレベル定数
+DEFAULT_TIMEOUT = 300
+MAX_RETRY_COUNT = 3
+```
+
+`from __future__ import annotations` は全モジュールに付与する。前方参照エラーを防ぎ、型アノテーションの評価を遅延させる。
+
+## 命名規則
+
+詳細は [naming-conventions.md](./naming-conventions.md) を参照。基本パターンのみ掲載する。
+
+| 対象 | 規則 | 例 |
+|------|------|-----|
+| 変数・関数 | `snake_case` | `step_id`, `parse_verdict()` |
+| クラス | `PascalCase` | `WorkflowRunner`, `SessionState` |
+| 定数 | `UPPER_SNAKE_CASE` | `DEFAULT_TIMEOUT` |
+| モジュール | `snake_case` | `workflow.py`, `runner.py` |
+
+## コメント・文字列
+
+コメントはコードで表現できない「なぜ」のみ書く。動作の説明はコードと docstring で行う。
+
+```python
+# SIGTERM 後に SIGKILL を送る（プロセスが catch している場合への対処）
+process.kill()
+```
+
+一時的な制限は TODO とともに理由・期限を明記する。
+
+```python
+# TODO: claude-code が --no-cache をサポートしたら削除
+if not use_cache:
+    env["DISABLE_CACHE"] = "1"
+```
+
+## 関数・クラス設計
+
+### 単一責任
+
+1 つの関数は 1 つのことだけ行う。引数が 5 個を超えたら dataclass にまとめる。
+
+```python
+@dataclass
+class StepRunConfig:
+    step: Step
+    issue: int
+    workdir: Path
+    timeout: int = 300
+    quiet: bool = False
+
+def run_step(config: StepRunConfig) -> Verdict:
+    """ステップを実行し verdict を返す。"""
+    ...
+```
+
+### 継承よりコンポジション
+
+```python
+@dataclass
+class WorkflowRunner:
+    """ワークフロー実行エンジン。"""
+
+    config: KajiConfig
+    logger: RunLogger
+
+    def run(self, workflow: Workflow, issue: int) -> None:
+        """ワークフローを実行する。"""
+        self.logger.log_workflow_start(issue, workflow.name)
+        ...
+```
+
+## エラーハンドリング
+
+詳細は [error-handling.md](./error-handling.md) を参照。概要のみ掲載する。
+
+- カスタム例外は `HarnessError` 階層を使用する
+- 例外の握り潰しは禁止
+- 上位概念の例外で catch して下位概念に wrap する
+
+```python
+try:
+    result = _call_cli(step)
+except FileNotFoundError as e:
+    raise CLINotFoundError(f"CLI not found: {step.agent}") from e
+```
+
+## ロギング
+
+詳細は [logging.md](./logging.md) を参照。`RunLogger` 経由でのみ JSONL ログを出力する。標準 `logging` モジュールの直接使用は避ける。
+
+## チェックリスト
+
+### コーディング完了時
+
+- [ ] `from __future__ import annotations` が先頭にあるか
+- [ ] 全ての関数・クラスに型ヒントが付与されているか
+- [ ] docstring が Google style で記述されているか（詳細: [docstring-style.md](./docstring-style.md)）
+- [ ] 例外処理が適切に実装されているか
+- [ ] `make check` が全パスするか
+
+### コードレビュー時
+
+- [ ] [命名規則](./naming-conventions.md) に従っているか
+- [ ] 関数の責任が明確で単一か
+- [ ] エラーハンドリングが網羅されているか
+- [ ] `Any` 型の使用が最小限か
+
+## 関連ドキュメント
+
+- [型ヒント](./type-hints.md) — 型注釈の詳細ガイド
+- [命名規則](./naming-conventions.md) — より詳細な命名パターン
+- [docstring スタイル](./docstring-style.md) — docstring の書き方
+- [エラーハンドリング](./error-handling.md) — 例外処理の実装パターン
+- [ロギング](./logging.md) — RunLogger の使い方

--- a/docs/reference/python/type-hints.md
+++ b/docs/reference/python/type-hints.md
@@ -1,0 +1,289 @@
+# 型ヒント
+
+kaji における型ヒント（Type Hints）の規約。Python 3.11+ を前提とする。
+
+## 基本原則
+
+- **全関数・メソッドに型ヒント必須**（引数・戻り値ともに）
+- **`Any` 型の使用を避ける**（本当に不可避の場合はコメントで理由を記載）
+- **`from __future__ import annotations` を全モジュールに付与する**
+- **mypy が通ることを品質基準とする**（`make check` で確認）
+
+## 基本的な型ヒント
+
+### プリミティブ型
+
+Python 3.11+ 記法を標準とする。`typing.Optional` / `typing.Union` は使わない。
+
+```python
+from __future__ import annotations
+
+# プリミティブ型
+step_id: str = "review"
+timeout: int = 300
+cost_usd: float = 0.05
+is_quiet: bool = False
+
+# None を許可する型（X | None を使用）
+session_id: str | None = None
+model: str | None = None
+```
+
+### コレクション型
+
+```python
+from __future__ import annotations
+
+# Python 3.9+ 組み込み型を使用（typing.List 等は使わない）
+step_ids: list[str] = ["design", "implement"]
+transitions: dict[str, str] = {"PASS": "next", "FAIL": "fix"}
+unique_agents: set[str] = {"claude", "codex"}
+
+# タプル（固定長）
+point: tuple[int, int] = (1, 2)
+
+# より抽象的な型（読み取り専用の場合）
+from collections.abc import Sequence, Mapping
+
+def process_steps(steps: Sequence[Step]) -> None: ...  # list, tuple 両方受け入れ
+def read_config(cfg: Mapping[str, str]) -> None: ...   # dict の読み取り専用版
+```
+
+### Any 型
+
+```python
+from __future__ import annotations
+from typing import Any
+
+# ❌ 避けるべき
+def _write(self, event: str, **kwargs: Any) -> None: ...  # kwargs は Any が不可避
+
+# ✅ 不可避な場合はコメントで理由を記載
+def _write(self, event: str, **kwargs: Any) -> None:
+    # JSONL の値型は多様（str/int/float/None/dict）のため Any
+    entry: dict[str, Any] = {"event": event, **kwargs}
+```
+
+## dataclass パターン
+
+kaji は Pydantic を使用しない。データクラスには `@dataclass` を使用する。
+
+### 基本 dataclass
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Step:
+    """ワークフロー内の 1 ステップ定義。"""
+
+    id: str
+    skill: str
+    agent: str
+    model: str | None = None
+    effort: str | None = None
+    max_budget_usd: float | None = None
+    max_turns: int | None = None
+    timeout: int | None = None
+    workdir: str | None = None
+    resume: str | None = None
+    inject_verdict: bool = False
+    on: dict[str, str] = field(default_factory=dict)
+```
+
+### mutable default は field(default_factory=...) を使う
+
+```python
+# ❌ NG: mutable default は共有される
+@dataclass
+class Workflow:
+    steps: list[Step] = []  # mypy / dataclass が警告
+
+# ✅ OK
+@dataclass
+class Workflow:
+    steps: list[Step] = field(default_factory=list)
+```
+
+### dataclass の比較・ハッシュ
+
+```python
+from dataclasses import dataclass
+
+@dataclass(eq=True, frozen=True)  # イミュータブルにする場合
+class VerdictKey:
+    step_id: str
+    status: str
+```
+
+## Union 型・Literal 型
+
+```python
+from __future__ import annotations
+from typing import Literal
+
+# Literal: 特定の値のみ許可
+VerdictStatus = Literal["PASS", "FAIL", "ABORT", "RETRY", "BACK"]
+
+def next_step(status: VerdictStatus, on: dict[str, str]) -> str | None:
+    return on.get(status)
+
+# Union: 複数の型を許可（Python 3.10+ の | 記法）
+StepRef = str | Step  # 名前または Step オブジェクト
+```
+
+## Callable 型
+
+```python
+from __future__ import annotations
+from collections.abc import Callable
+
+# コールバック型
+StepHook = Callable[[Step, Verdict], None]
+
+def run_with_hook(step: Step, hook: StepHook | None = None) -> Verdict:
+    verdict = _execute(step)
+    if hook is not None:
+        hook(step, verdict)
+    return verdict
+```
+
+## TypeAlias（Python 3.10+）
+
+複雑な型を分かりやすくする。
+
+```python
+from __future__ import annotations
+from typing import TypeAlias
+
+# 型エイリアス定義
+StepId: TypeAlias = str
+VerdictStatus: TypeAlias = str
+TransitionMap: TypeAlias = dict[str, str]  # {verdict_status: next_step_id}
+
+def find_transition(step_id: StepId, status: VerdictStatus, on: TransitionMap) -> StepId | None:
+    return on.get(status)
+```
+
+## Protocol（構造的サブタイピング）
+
+```python
+from __future__ import annotations
+from typing import Protocol
+
+
+class Runnable(Protocol):
+    """実行可能なオブジェクトのプロトコル。"""
+
+    def run(self, issue: int) -> None: ...
+
+
+class WorkflowRunner:
+    def run(self, issue: int) -> None:
+        ...  # Runnable に適合
+```
+
+## Generic 型
+
+```python
+from __future__ import annotations
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Result(Generic[T]):
+    """成功・失敗を表す汎用型。"""
+
+    def __init__(self, value: T | None, error: Exception | None = None) -> None:
+        self._value = value
+        self._error = error
+
+    @property
+    def ok(self) -> bool:
+        return self._error is None
+
+    def unwrap(self) -> T:
+        if self._error is not None:
+            raise self._error
+        assert self._value is not None
+        return self._value
+```
+
+## mypy 設定
+
+kaji の `pyproject.toml` で設定済み。追加の設定が必要な場合のみ変更する。
+
+```toml
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+```
+
+厳格モードを有効化しているため、以下が暗黙的に適用される:
+
+- `disallow_untyped_defs = true` — 型ヒントのない関数定義を禁止
+- `disallow_any_generics = true` — `list` / `dict` をパラメータなしで使用禁止
+- `warn_redundant_casts = true` — 冗長な `cast()` に警告
+
+## よくある型エラーと対処法
+
+### None チェックの漏れ
+
+```python
+# ❌ mypy エラー: session_id が str | None なのに None チェックなし
+def resume_from(session_id: str | None) -> str:
+    return session_id.upper()  # error: Item "None" of "str | None" has no attribute "upper"
+
+# ✅ 明示的な None チェック
+def resume_from(session_id: str | None) -> str:
+    if session_id is None:
+        return ""
+    return session_id.upper()
+```
+
+### dict の値型
+
+```python
+# ❌ 型が曖昧
+def get_field(cfg: dict, key: str):
+    return cfg.get(key)
+
+# ✅ 具体的な型
+def get_field(cfg: dict[str, str], key: str) -> str | None:
+    return cfg.get(key)
+```
+
+### cast() の使用
+
+外部ライブラリ等で型が `Any` になる場合は `cast()` で型を明示する。ただし乱用しない。
+
+```python
+from typing import cast
+import yaml
+
+raw = yaml.safe_load(text)
+data = cast(dict[str, Any], raw)  # yaml.safe_load の戻り値は Any
+```
+
+## チェックリスト
+
+### 実装時チェック
+
+- [ ] `from __future__ import annotations` がモジュール先頭にあるか
+- [ ] 全ての関数に引数・戻り値の型ヒントがあるか
+- [ ] `Optional[X]` ではなく `X | None` を使用しているか
+- [ ] `list[X]` / `dict[K, V]` 等の組み込み記法を使用しているか（`typing.List` 等を使っていないか）
+- [ ] mutable default に `field(default_factory=...)` を使用しているか
+- [ ] `mypy` がエラーなしで通るか（`make check`）
+
+## 関連ドキュメント
+
+- [Python スタイル規約](./python-style.md) — 基本的なコーディング規約
+- [命名規則](./naming-conventions.md) — 型名・変数名の命名パターン
+- [docstring スタイル](./docstring-style.md) — docstring での型情報記述

--- a/draft/design/issue-141-python-reference-docs.md
+++ b/draft/design/issue-141-python-reference-docs.md
@@ -1,0 +1,160 @@
+# [設計] Python 品質規約 6 本を docs/reference/python/ へ移植
+
+Issue: #141
+
+## 概要
+
+kamo2 の `docs/reference/backend/` に整備された Python コード品質規約 6 本を、kaji 固有の実装・ツール・ドメインに適応させて `docs/reference/python/` へ移植する。
+
+## 背景・目的
+
+kaji には `docs/dev/testing-convention.md` と `docs/reference/testing-size-guide.md` があるが、Python コード本体（スタイル・命名・型ヒント・docstring・エラー処理・ロギング）の規約が未整備である。AI エージェントが一貫性のないコードを書く原因になっており、成文化による品質担保が目的。
+
+## インターフェース
+
+### 入力
+
+- 移植元: `/home/aki/dev/kamo2/docs/reference/backend/` 以下の 6 ファイル
+- 退避済みドラフト: `/tmp/kaji-python-docs/` （`python-style.md`・`naming-conventions.md` の 2 本）
+- kaji 実装参照: `kaji_harness/errors.py`, `kaji_harness/logger.py`, `kaji_harness/models.py`
+
+### 出力
+
+| # | ファイル | 移植元 |
+|---|---------|--------|
+| 1 | `docs/reference/python/python-style.md` | `python-style.md` |
+| 2 | `docs/reference/python/naming-conventions.md` | `naming-conventions.md` |
+| 3 | `docs/reference/python/type-hints.md` | `type-hints.md` |
+| 4 | `docs/reference/python/docstring-style.md` | `documentation.md` |
+| 5 | `docs/reference/python/error-handling.md` | `error-handling-conventions.md` |
+| 6 | `docs/reference/python/logging.md` | `logging-conventions.md` |
+
+追加更新:
+- `docs/README.md` — Reference セクションに 6 本追記
+- `CLAUDE.md` — Documentation 表に 6 本追記
+
+### 使用例
+
+AI エージェントが実装時に参照する:
+
+```
+kaji_harness/ のコードを書く際に docs/reference/python/naming-conventions.md を参照し、
+動詞の使い分け・プライベート命名・kaji 固有語のルールを確認する。
+```
+
+## 制約・前提条件
+
+- `docs/dev/testing-convention.md` / `docs/reference/testing-size-guide.md` は変更しない（スコープ外）
+- `kaji_harness/errors.py` / `kaji_harness/logger.py` 実装コードは変更しない（規約策定のみ）
+- kamo2 固有語（kamo2 / FastAPI / 金融 / Decimal / JPX / 株価）を残存させない
+- Pydantic ではなく dataclass ベースで記述（kaji は dataclass のみ使用）
+- 非同期（async/await）の記述を含めない（kaji は同期モデル）
+- Python 3.11+ 記法で統一（`list[str]`、`X | None`、`from __future__ import annotations`）
+- line-length は 100 文字（`pyproject.toml` の `[tool.ruff] line-length = 100` に準拠）
+- コード例は `kaji_harness/` 実装からの実例に差し替える
+
+## 方針
+
+### 共通適応アルゴリズム
+
+各ファイルに対して以下の順序で処理する:
+
+1. **削除**: kamo2/FastAPI/金融/DB/Decimal/JPX/株価に関するセクション・例を除去
+2. **置換**: kamo2 の例 → kaji 実例（WorkflowRunner, SessionState, Verdict, Step, RunLogger 等）
+3. **追加**: kaji 固有概念（verdict, step_id, cycle, workflow, skill, harness）の命名規則・使用例
+4. **検証**: `grep -iE "(kamo2|fastapi|金融|stock|JPX|株価|Decimal)" <file>` でゼロヒットを確認
+
+### ファイル別の主な適応内容
+
+**python-style.md** （退避済みドラフトを使用）:
+- 行長 100 文字（88 → 100）
+- FastAPI / Decimal / 金融例を kaji 例に置換済み
+- 退避済みドラフトをベースにレビュー・補完する
+
+**naming-conventions.md** （退避済みドラフトを使用）:
+- kaji 採用語（step/verdict/cycle/workflow/skill）の統一規則を明記済み
+- 退避済みドラフトをベースにレビュー・補完する
+
+**type-hints.md** （新規適応）:
+- Pydantic の `BaseModel` / `Field` を `@dataclass` に置換
+- `Decimal` 型エイリアスを削除
+- `from __future__ import annotations` を標準として冒頭に記載
+- kaji_harness/models.py の実例を使用
+
+**docstring-style.md** （新規適応）:
+- ファイル名を `documentation.md` → `docstring-style.md` に変更
+- Sphinx / mkdocstrings セクションを削除
+- 金融ドメイン例を kaji 例（Step, Verdict, RunLogger）に差し替え
+
+**error-handling.md** （新規適応）:
+- `kaji_harness/errors.py` の HarnessError 階層（HarnessError → ConfigNotFoundError / WorkflowValidationError / VerdictNotFound 等）を基礎に記述
+- FastAPI 例外ハンドラ節・HTTP ステータス対応節を削除
+- CLI 出力エラー（CLIExecutionError）・verdict エラー（VerdictNotFound / VerdictParseError）の処理規約を追加
+
+**logging.md** （新規適応）:
+- `kaji_harness/logger.py` の RunLogger（JSONL 形式）と `_write()` パターンを基礎に記述
+- structlog 前提を標準 `logging` モジュールに変更
+- フィールド: `ts`, `event`, `step_id`, `verdict`, `cost`, `session_id` を標準フィールドとして定義
+- 株価関連フィールドを kaji 固有フィールドに差し替え
+
+### インデックス更新
+
+- `docs/README.md`: Reference セクションに `docs/reference/python/` 以下 6 本を追記
+- `CLAUDE.md`: Documentation 表に 6 本を追記
+
+## テスト戦略
+
+> **CRITICAL**: 変更タイプに応じて妥当な検証方針を定義すること。
+
+### 変更タイプ
+- **docs-only**（実行時コード変更なし）
+
+### 変更固有検証
+
+1. **kamo2 固有語の残存チェック**:
+   ```bash
+   grep -rniE "(kamo2|fastapi|金融|stock|JPX|株価|Decimal)" docs/reference/python/
+   ```
+   ゼロヒットであることを確認
+
+2. **リンク整合性確認**:
+   ```bash
+   make verify-docs
+   ```
+   `docs/reference/python/` 内の相互リンクおよび `docs/README.md` / `CLAUDE.md` からのリンクがすべて解決することを確認
+
+3. **完了条件チェックリスト確認**: Issue の完了条件 6 項目をすべて満たすことを確認
+
+### 恒久テストを追加しない理由
+
+以下の 4 条件をすべて満たすため、新規の恒久回帰テストは追加しない:
+
+1. 独自ロジックの追加・変更をほぼ含まない（Markdown ドキュメントの新規作成のみ）
+2. 想定される不具合パターン（リンク切れ・不整合）は既存の `make verify-docs` で捕捉済み
+3. 新規テストを追加しても回帰検出情報がほとんど増えない（規約文書の内容変化は自動検出不能）
+4. テスト未追加の理由を上記のとおりレビュー可能な形で説明できる
+
+## 影響ドキュメント
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | なし | 新規技術選定なし（既存ツール構成の文書化） |
+| docs/ARCHITECTURE.md | なし | アーキテクチャ変更なし |
+| docs/dev/ | なし | 開発ワークフロー・手順変更なし |
+| docs/cli-guides/ | なし | CLI 仕様変更なし |
+| CLAUDE.md | あり | Documentation 表に 6 本追記（規約参照先として必要） |
+| docs/README.md | あり | Reference セクションに 6 本追記 |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| kamo2 移植元ドキュメント群 | `/home/aki/dev/kamo2/docs/reference/backend/` | 移植元 6 ファイル。kaji 環境で `ls` / `cat` で直接参照可能 |
+| 退避済みドラフト | `/tmp/kaji-python-docs/` | `python-style.md` / `naming-conventions.md` の kaji 適応済みドラフト |
+| kaji errors.py | `kaji_harness/errors.py` | HarnessError 階層の実装。error-handling.md の主要一次情報 |
+| kaji logger.py | `kaji_harness/logger.py` | RunLogger の JSONL 実装。logging.md の主要一次情報 |
+| kaji models.py | `kaji_harness/models.py` | dataclass 実例（Step, Verdict, CostInfo 等）。type-hints.md / naming-conventions.md の実例基礎 |
+| pyproject.toml ruff 設定 | `pyproject.toml` L1〜（`[tool.ruff]` セクション） | `line-length = 100`, `target-version = "py311"` — スタイル規約の根拠 |
+| PEP 484 — Type Hints | https://peps.python.org/pep-0484/ | Python 型ヒント仕様。type-hints.md の一次情報 |
+| PEP 257 — Docstring Conventions | https://peps.python.org/pep-0257/ | Google スタイル docstring の根拠。docstring-style.md の一次情報 |
+| Python logging HOWTO | https://docs.python.org/3/howto/logging.html | 標準 logging モジュール。logging.md の一次情報 |

--- a/draft/design/issue-141-python-reference-docs.md
+++ b/draft/design/issue-141-python-reference-docs.md
@@ -10,13 +10,27 @@ kamo2 の `docs/reference/backend/` に整備された Python コード品質規
 
 kaji には `docs/dev/testing-convention.md` と `docs/reference/testing-size-guide.md` があるが、Python コード本体（スタイル・命名・型ヒント・docstring・エラー処理・ロギング）の規約が未整備である。AI エージェントが一貫性のないコードを書く原因になっており、成文化による品質担保が目的。
 
+### 期待読者と目的
+
+6 本すべて **AI エージェント（Claude 等）が `kaji_harness/` コードを実装・修正する際に参照する規約** を主目的とする。人間開発者も参照するが、AI エージェントが機械的にルールを適用できる粒度での記述を優先する。
+
+| ドキュメント | AI エージェントが使う場面 |
+|---|---|
+| python-style.md | フォーマット・インポート順・文字列クォート等の実装時チェック |
+| naming-conventions.md | 変数名・関数名・kaji 固有語の一貫した命名 |
+| type-hints.md | 型アノテーションパターン・dataclass の書き方 |
+| docstring-style.md | Google style docstring の書き方・必須/省略可セクションの判断 |
+| error-handling.md | 例外クラス選択・raise の場所・握り潰し禁止ルール |
+| logging.md | RunLogger を呼ぶ場所・新規イベント追加時のフィールド設計 |
+
 ## インターフェース
 
 ### 入力
 
-- 移植元: `/home/aki/dev/kamo2/docs/reference/backend/` 以下の 6 ファイル
-- 退避済みドラフト: `/tmp/kaji-python-docs/` （`python-style.md`・`naming-conventions.md` の 2 本）
+- 移植元: `/home/aki/dev/kamo2/docs/reference/backend/` 以下の 6 ファイル（レビュー可能な恒久パス）
 - kaji 実装参照: `kaji_harness/errors.py`, `kaji_harness/logger.py`, `kaji_harness/models.py`
+
+> **注記**: 作業途中の `/tmp/kaji-python-docs/` に存在するドラフト 2 本（`python-style.md` / `naming-conventions.md`）は一時作業物であり一次情報ではない。実装時に参照する場合は、kamo2 移植元と kaji 実装を正として手元でレビュー・補完すること。設計上の根拠には使用しない。
 
 ### 出力
 
@@ -66,14 +80,14 @@ kaji_harness/ のコードを書く際に docs/reference/python/naming-conventio
 
 ### ファイル別の主な適応内容
 
-**python-style.md** （退避済みドラフトを使用）:
-- 行長 100 文字（88 → 100）
-- FastAPI / Decimal / 金融例を kaji 例に置換済み
-- 退避済みドラフトをベースにレビュー・補完する
+**python-style.md** （kamo2 移植元から新規適応）:
+- 行長 100 文字（88 → 100 に変更）
+- FastAPI / Decimal / 金融例を kaji 例（Step, Verdict, WorkflowRunner 等）に置換
+- kaji 採用ツール（ruff / mypy / pytest）の説明に統一
 
-**naming-conventions.md** （退避済みドラフトを使用）:
-- kaji 採用語（step/verdict/cycle/workflow/skill）の統一規則を明記済み
-- 退避済みドラフトをベースにレビュー・補完する
+**naming-conventions.md** （kamo2 移植元から新規適応）:
+- kaji 採用語（step/verdict/cycle/workflow/skill）の統一規則を明記
+- 金融ドメイン節・API/DB 節を削除
 
 **type-hints.md** （新規適応）:
 - Pydantic の `BaseModel` / `Field` を `@dataclass` に置換
@@ -83,8 +97,11 @@ kaji_harness/ のコードを書く際に docs/reference/python/naming-conventio
 
 **docstring-style.md** （新規適応）:
 - ファイル名を `documentation.md` → `docstring-style.md` に変更
+- スタイル: **Google style docstring を採用**（CLAUDE.md 既定の「Google docstrings」に準拠）
+- 一次情報: Google Python Style Guide §3.8 (https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
 - Sphinx / mkdocstrings セクションを削除
 - 金融ドメイン例を kaji 例（Step, Verdict, RunLogger）に差し替え
+- PEP 257 は「モジュール冒頭 docstring 必須」「1行サマリー」等の一般規約として補足参照にとどめる
 
 **error-handling.md** （新規適応）:
 - `kaji_harness/errors.py` の HarnessError 階層（HarnessError → ConfigNotFoundError / WorkflowValidationError / VerdictNotFound 等）を基礎に記述
@@ -92,10 +109,17 @@ kaji_harness/ のコードを書く際に docs/reference/python/naming-conventio
 - CLI 出力エラー（CLIExecutionError）・verdict エラー（VerdictNotFound / VerdictParseError）の処理規約を追加
 
 **logging.md** （新規適応）:
-- `kaji_harness/logger.py` の RunLogger（JSONL 形式）と `_write()` パターンを基礎に記述
-- structlog 前提を標準 `logging` モジュールに変更
-- フィールド: `ts`, `event`, `step_id`, `verdict`, `cost`, `session_id` を標準フィールドとして定義
-- 株価関連フィールドを kaji 固有フィールドに差し替え
+- **目的**: 現行 `kaji_harness/logger.py` の RunLogger JSONL 契約の文書化（一般的な Python logging 規約ではない）
+- `RunLogger` は Python 標準 `logging` モジュールを使用しない。`_write()` で JSONL を直接書き出す専用実装であり、文書はこの契約を記述する
+- 全イベント共通フィールド: `ts`（ISO 8601 UTC）, `event`（文字列）のみ
+- イベント別フィールド（実装から導出）:
+  - `workflow_start`: `issue` (int), `workflow` (str)
+  - `step_start`: `step_id`, `agent`, `model`, `effort`, `session_id`（各 str | None）
+  - `step_end`: `step_id` (str), `verdict` (dict), `duration_ms` (int), `cost` (dict | None)
+  - `cycle_iteration`: `cycle_name` (str), `iteration` (int), `max_iterations` (int)
+  - `workflow_end`: `status` (str), `cycle_counts` (dict), `total_duration_ms` (int), `total_cost` (float | None), `error` (str, 条件付き)
+- kamo2 移植元の structlog 前提・株価関連フィールドは完全削除
+- 規約として追加するのは「新規イベントを追加する際の命名・フィールド設計ガイドライン」に限定
 
 ### インデックス更新
 
@@ -149,12 +173,11 @@ kaji_harness/ のコードを書く際に docs/reference/python/naming-conventio
 
 | 情報源 | URL/パス | 根拠（引用/要約） |
 |--------|----------|-------------------|
-| kamo2 移植元ドキュメント群 | `/home/aki/dev/kamo2/docs/reference/backend/` | 移植元 6 ファイル。kaji 環境で `ls` / `cat` で直接参照可能 |
-| 退避済みドラフト | `/tmp/kaji-python-docs/` | `python-style.md` / `naming-conventions.md` の kaji 適応済みドラフト |
-| kaji errors.py | `kaji_harness/errors.py` | HarnessError 階層の実装。error-handling.md の主要一次情報 |
-| kaji logger.py | `kaji_harness/logger.py` | RunLogger の JSONL 実装。logging.md の主要一次情報 |
+| kamo2 移植元ドキュメント群 | `/home/aki/dev/kamo2/docs/reference/backend/` | 移植元 6 ファイル。kaji 環境で `ls` / `cat` で直接参照可能な恒久パス |
+| kaji errors.py | `kaji_harness/errors.py` | HarnessError 階層（HarnessError → ConfigNotFoundError / VerdictNotFound 等）の実装。error-handling.md のソースオブトゥルース |
+| kaji logger.py | `kaji_harness/logger.py` | RunLogger の JSONL 実装。logging.md のソースオブトゥルース。イベント定義・フィールド仕様はすべてここを参照 |
 | kaji models.py | `kaji_harness/models.py` | dataclass 実例（Step, Verdict, CostInfo 等）。type-hints.md / naming-conventions.md の実例基礎 |
 | pyproject.toml ruff 設定 | `pyproject.toml` L1〜（`[tool.ruff]` セクション） | `line-length = 100`, `target-version = "py311"` — スタイル規約の根拠 |
 | PEP 484 — Type Hints | https://peps.python.org/pep-0484/ | Python 型ヒント仕様。type-hints.md の一次情報 |
-| PEP 257 — Docstring Conventions | https://peps.python.org/pep-0257/ | Google スタイル docstring の根拠。docstring-style.md の一次情報 |
-| Python logging HOWTO | https://docs.python.org/3/howto/logging.html | 標準 logging モジュール。logging.md の一次情報 |
+| Google Python Style Guide §3.8 | https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings | Google style docstring の規約本体。docstring-style.md の主要一次情報（CLAUDE.md「Google docstrings」の根拠） |
+| PEP 257 — Docstring Conventions | https://peps.python.org/pep-0257/ | docstring 一般規約（モジュール冒頭 docstring 必須・1行サマリー等）。Google style の補足参照 |


### PR DESCRIPTION
## Summary

kaji の Python コード品質規約（スタイル・命名・型ヒント・docstring・エラー処理・ロギング）が未整備だったため、kamo2 の既存規約を kaji 固有実装に適応させて 6 本移植する。

Closes #141

## Changes

- `docs/reference/python/python-style.md` — フォーマット・インポート・クラス設計規約
- `docs/reference/python/naming-conventions.md` — 変数・関数・kaji 固有語の命名パターン
- `docs/reference/python/type-hints.md` — dataclass ベースの型アノテーション規約
- `docs/reference/python/docstring-style.md` — Google style docstring 規約
- `docs/reference/python/error-handling.md` — HarnessError 階層と例外処理パターン
- `docs/reference/python/logging.md` — RunLogger JSONL 契約とイベント別フィールド仕様

## Documentation

- `docs/README.md` — Reference セクションに「Python 品質規約」グループを追加
- `CLAUDE.md` — Documentation 表に 6 本を追記

## Verification

- [x] kamo2 固有語（kamo2/FastAPI/金融/stock/JPX/株価/Decimal）残存なし (`grep` ゼロヒット)
- [x] `make verify-docs` — All Markdown links valid (56 files)
- [x] `ruff check` / `ruff format --check` / `mypy` — 全パス
- [x] `pytest` — 652 passed, 1 skipped（既存テスト回帰なし）