### PR TITLE
feat: artifact-primary verdict resolution + attempt layout (#220)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,7 +138,33 @@ RunLogger は両経路を `dispatch` field で区別する。詳細は
 
 ## Verdict 判定機構
 
-エージェント出力から verdict を抽出する 3 段階フォールバック。V5/V6 の運用知見に基づく設計であり、V7 で復元（#77）。
+### verdict source 解決順（artifact → comment → stdout）
+
+Issue #220 以降、runner は各 step dispatch ごとに verdict を以下の順で解決する（`resolve_verdict()`）。
+
+```
+resolve_verdict(attempt_dir, full_output, valid_statuses, attempt_started_at, comment_loader, ai_formatter)
+  │
+  ├─ 1. artifact: attempt_dir/verdict.yaml が存在 → load_verdict_yaml（pure YAML）
+  │       存在するが壊れている → fail-loud（comment / stdout へ落ちない）。source="artifact"
+  │
+  ├─ 2. comment: artifact 不在時のみ comment_loader() を遅延呼び出し
+  │       created_at >= attempt_started_at の作業報告コメントのみを newest-first で走査し、
+  │       末尾の ---VERDICT--- block を採用。source="comment"
+  │       provider 取得失敗は WARN して stdout へ fallthrough
+  │
+  └─ 3. stdout: full_output に対する 3 段階フォールバック（後述）。source="stdout"
+```
+
+- **artifact primary**: 解決対象は常に「今 dispatch した attempt の dir」であり、`verdict.yaml` が存在すれば comment / stdout は **見ない**。stale comment が fresh artifact を上書きしない核心の不変条件。
+- **comment fallback の attempt scoping**: `attempt_started_at`（dispatch 直前に harness が記録するローカル時刻）を下限に、`created_at >= attempt_started_at` のコメントのみ対象にする。retry / resume で当該 attempt が verdict を出さなかった場合に、前 attempt の作業報告コメントを誤採用しない。下限を満たすコメントが無ければ古いコメントを拾わず stdout / `VerdictNotFound` へ落とす（false verdict より解決失敗を優先する fail-safe）。
+- **source != "artifact" の正規化保存**: comment / stdout で解決した場合、harness は同じ verdict を `attempt_dir/verdict.yaml` へ正規化保存する。未移行スキルが stdout しか出さなくても attempt 単位の `verdict.yaml` が必ず残る。解決経路は `run.log` の `verdict_source` イベントに記録される。
+
+artifact / log の layout は attempt 単位（`runs/<run_id>/steps/<step_id>/attempt-NNN/`、詳細は § 実行アーティファクトの layout）。
+
+### stdout フォールバック戦略
+
+エージェント stdout から verdict を抽出する 3 段階フォールバック。V5/V6 の運用知見に基づく設計であり、V7 で復元（#77）。上記解決順の Step 3（stdout 経路）にあたる。
 
 ### フォールバック戦略
 
@@ -259,6 +285,29 @@ kaji run workflows/feature-development.yaml 57 --from fix-code
 ```
 
 `--from` で指定したステップから再開し、`session-state.json` の `session_id` を使って CLI セッションを復元する。
+
+### 実行アーティファクトの layout
+
+run / step / attempt の成果物は attempt 単位で分離される（Issue #220）。
+
+```text
+<artifacts_dir>/<issue>/
+  session-state.json
+  progress.md
+  runs/<run_id>/
+    run.log                       # workflow 全体ログ
+    steps/<step_id>/
+      attempt-001/
+        prompt.txt                # agent step の build_prompt 結果（再現用）
+        stdout.log / console.log / stderr.log
+        verdict.yaml              # resolve 後に harness が正規化保存
+      attempt-002/ ...            # cycle / retry / resume の再 dispatch ごとに採番
+      latest -> attempt-002       # 最新 attempt への convenience symlink（best-effort）
+```
+
+- `run_id` は分（minute）精度（`%y%m%d%H%M`）。同一 step が同一 run 内で複数回 dispatch されても `attempt-NNN` で prompt / logs / verdict の対応が一意になる。
+- `latest` symlink は人間 / 外部ツール向けの利便性。harness の verdict 解決は in-memory で保持した attempt path を使い `latest` に依存しない（symlink 非対応 FS でも壊れない）。
+- 新規 run は新 layout を正とする。旧 `runs/<run_id>/<step_id>/`（attempt なしの flat 構造）が残っていても新 run はそれを温存したまま新 layout で完了する（migration は必須としない）。
 
 ---
 

--- a/docs/adr/005-artifact-primary-verdict.md
+++ b/docs/adr/005-artifact-primary-verdict.md
@@ -1,0 +1,41 @@
+# ADR 005: artifact `verdict.yaml` を primary とする verdict 受け渡し
+
+## ステータス
+
+承認 (2026-06-04)
+
+## コンテキスト
+
+kaji の harness は agent の stdout から verdict を抽出して workflow を遷移させてきた（`parse_verdict(result.full_output, ...)` が唯一の verdict source）。`docs/dev/skill-authoring.md` § verdict 出力規約 も「verdict は stdout にそのまま出力する」を唯一の契約としていた。
+
+この stdout-only 方式は、headless で agent CLI を起動し JSONL stdout を直接読む実行形態を前提にしている。今後 `kaji` から Claude Code / Codex を subscription の通常コンソール利用に近い形（別ターミナル起動 / 通常 interactive CLI / 人間による handoff）で動かす場合、harness は agent の stdout を直接保持できない。`draft/lab/headless-terminal-spawn/design.md` の PoC では別ターミナルで agent を起動し sentinel / output file で回収する方針が示されているが、workflow の正規 verdict 経路としては未実装だった。stdout に依存しない完了判定経路が必要になった（Issue #220）。
+
+あわせて、従来の step log layout（`runs/<run_id>/<step_id>/` への append）は、cycle / retry / resume で同一 step が同一 run 内に複数回 dispatch される場合に、prompt / logs / verdict と attempt の対応関係を一意に保てない弱さがあった。
+
+## 決定
+
+verdict の受け渡しを **artifact `verdict.yaml`（primary）→ 作業報告 Issue comment 末尾の `---VERDICT---` block（fallback）→ stdout parse（互換 fallback）** の順で解決する方式に変更する（Issue #220）。
+
+- agent / script は harness が注入する `verdict_path`（exec_script では env `KAJI_VERDICT_PATH`）へ pure YAML の `verdict.yaml`（`status` / `reason` / `evidence` / `suggestion`）を保存し、同じ verdict block を作業報告コメント末尾と stdout にも残す。
+- harness は `resolve_verdict()` で artifact → comment → stdout の順に解決する。artifact が存在すれば comment / stdout は見ない。comment fallback は当該 attempt の dispatch 直前に記録した `attempt_started_at` を下限に `created_at >= attempt_started_at` のコメントのみ対象とし、前 attempt の作業報告コメントを誤採用しない。
+- `verdict.yaml` が「存在するが壊れている」場合は fail-loud（comment / stdout へ fallthrough しない）。全 source 不在は従来どおり `VerdictNotFound`。
+- comment / stdout で解決した場合は harness が同じ verdict を `verdict.yaml` へ正規化保存し、未移行スキルでも attempt 単位の `verdict.yaml` が必ず残る。
+- artifact / log layout を `runs/<run_id>/steps/<step_id>/attempt-NNN/`（attempt 単位）へ移行する。`run.log` は `runs/<run_id>/` 直下に据え置く。新規 run は新 layout を正とし、旧 flat layout の読み取り互換は温存する（migration 必須化はしない）。
+
+stdout 経路は未移行スキル・既存 stdout ベーステストとの互換のため当面残す。全スキルが `verdict.yaml` を書く運用へ移行後、stdout 経路の段階廃止を別 Issue で検討する。
+
+## 影響
+
+- `docs/dev/skill-authoring.md` § verdict 出力規約 が stdout-only から 3 経路（artifact / comment / stdout）契約に変わる。`verdict_path` がコンテキスト変数に追加される。
+- runner の step log 出力先が `runs/<run_id>/steps/<step_id>/attempt-NNN/` に変わる（`docs/reference/python/logging.md` / `docs/ARCHITECTURE.md` § 実行アーティファクトの layout）。
+- workflow YAML / 遷移仕様 / `kaji run` の CLI IF（引数・exit code）は不変。
+- 既存の stdout verdict ベーステストは、stdout 互換経路の温存により破壊されない。
+
+## 代替案と却下理由
+
+| 代替案 | 却下理由 |
+|--------|----------|
+| Issue comment を verdict の primary source にする | comment は人間向け作業報告履歴であり、attempt 境界・取得タイミングが API 依存で不安定。primary には不適 |
+| verdict 専用 Issue comment を新規作成する | 作業報告 comment と分離すると投稿数が倍増し追跡性が下がる。既存作業報告 comment の末尾追記で十分 |
+| harness が stdout を parse して `verdict.yaml` を書くだけ（agent は書かない） | future の no-stdout runner では harness に stdout が無く成立しない。agent 側が書ける契約が前提 |
+| comment 本文に run/step/attempt marker を埋め込み attempt を識別する | agent 挙動依存で comment metadata を増やす方針に反する。harness 制御の `created_at` 下限で十分 |

--- a/docs/dev/shared_skill_rules.md
+++ b/docs/dev/shared_skill_rules.md
@@ -35,6 +35,10 @@ workflow 固有の最終判定は `i-dev-final-check` または `i-doc-final-che
 | 無関係な問題の報告 | `.claude/skills/_shared/report-unrelated-issues.md` | 作業中に発見した無関係な問題の報告手順 |
 | 設計書の昇格 | `.claude/skills/_shared/promote-design.md` | draft 設計書から恒久ドキュメントへの昇格手順 |
 
+## verdict 永続化（共通）
+
+すべての workflow スキルは作業完了時に verdict を **artifact `verdict.yaml`（primary）+ 作業報告 Issue comment 末尾の `---VERDICT---` block（fallback）+ stdout（互換）** の 3 経路で残す（Issue #220）。harness は `verdict_path`（exec_script では env `KAJI_VERDICT_PATH`）で保存先 attempt の絶対パスを注入し、解決順は artifact → comment → stdout。verdict 専用コメントは新設せず、既存の作業報告コメント末尾に block を追記するだけでよい。詳細・YAML 例・stdout 段階廃止方針は [skill-authoring.md](skill-authoring.md) § verdict 出力規約 を参照。
+
 ## スキル実体
 
 - 実体: `.claude/skills/`

--- a/docs/dev/skill-authoring.md
+++ b/docs/dev/skill-authoring.md
@@ -110,7 +110,7 @@ exec_script: kaji_harness.scripts.review_poll_entry
 
 ## verdict 出力規約
 
-すべてのスキルは最終出力として以下の形式の verdict ブロックを含めなければならない。
+すべてのスキルは作業完了時に、以下の verdict を **3 経路** で残さなければならない（Issue #220）。
 
 ```
 ---VERDICT---
@@ -124,11 +124,24 @@ suggestion: |
 ---END_VERDICT---
 ```
 
-verdict ブロックは **stdout にそのまま出力** すること。ハーネスは CLI の標準出力から verdict を抽出するため、`kaji issue comment --body` の引数や別コマンドの入力にだけ verdict を埋めても判定されない。
+1. **artifact `verdict.yaml`（primary）**: コンテキスト変数 `verdict_path`（exec_script では env `KAJI_VERDICT_PATH`）が指す絶対パスへ、`status` / `reason` / `evidence` / `suggestion` の **pure YAML**（`---VERDICT---` delimiter なし）を保存する。
+2. **作業報告 Issue comment 末尾（fallback）**: 作業報告コメントの末尾に、上記 `---VERDICT---` block をそのまま追記する。verdict 専用コメントを新設せず、既存の作業報告コメントの末尾に足すだけでよい。
+3. **stdout（互換 fallback）**: 同じ `---VERDICT---` block を stdout にも出力する。
 
-Issue コメントや Issue 本文更新は別途行ってよいが、それは verdict 出力の代替ではない。コメント投稿を行う場合でも、最終的な verdict ブロックは stdout に残すこと。
+ハーネスはこの 3 経路を **artifact → comment → stdout** の順で解決する（詳細は [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) § Verdict 判定機構）。`verdict_path` への保存が primary 経路であり、`kaji issue comment --body` の引数や別コマンドの入力にだけ verdict を埋めても、artifact / 作業報告コメント末尾 / stdout のいずれにも残っていなければ判定されない。
 
-**verdict 不在は fail-loud** (Issue #193): `---VERDICT---` delimiter が一切出力されないままセッションが終了した場合、ハーネスは AI formatter で穴埋めせず `VerdictNotFound` を `HarnessError` として raise する（`EXIT_RUNTIME_ERROR (= 3)` にマップ）。`ScheduleWakeup` 等で再起動を期待する場合でも、メインセッション終了時点で verdict ブロックを stdout に出力する責務はスキル側にある。詳細は [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) § Verdict 判定機構 を参照。
+`verdict.yaml` の例（pure YAML）:
+
+```yaml
+status: PASS
+reason: 設計書と整合し品質基準を満たす
+evidence: ruff / mypy / pytest すべて pass
+suggestion: ""
+```
+
+**verdict 不在は fail-loud** (Issue #193 / #220): artifact `verdict.yaml` も、現在 attempt 以降の作業報告コメント末尾 block も、stdout の `---VERDICT---` delimiter も一切無いままセッションが終了した場合、ハーネスは AI formatter で穴埋めせず `VerdictNotFound` を `HarnessError` として raise する（`EXIT_RUNTIME_ERROR (= 3)` にマップ）。逆に `verdict.yaml` が「存在するが壊れている / 必須欠落 / invalid status」場合も fail-loud（comment / stdout へは fallthrough しない）。`ScheduleWakeup` 等で再起動を期待する場合でも、メインセッション終了時点で verdict を上記 3 経路に残す責務はスキル側にある。
+
+> **stdout 経路の段階廃止方針**: stdout への verdict 出力は、未移行スキル・stdout ベースの既存テストとの互換のための fallback として当面残す。全スキルが `verdict.yaml` を書く運用に移行した後、stdout 経路の段階廃止を別 Issue で検討する。
 
 ### verdict の選択基準
 
@@ -172,6 +185,7 @@ suggestion: |
 | `issue_id` | str | 正規化済み Issue ID（GitHub 数値または local ID。例: `"153"` / `"local-pc1-1"`） |
 | `issue_ref` | str | 人間可読の Issue 参照（GitHub では `#<issue_id>`、local では bare ID。例: `"#153"` / `"local-pc1-1"`） |
 | `step_id` | str | 現在のステップ ID |
+| `verdict_path` | str | 当該 attempt の `verdict.yaml` 絶対パス（Issue #220）。スキルはここへ pure YAML の verdict を保存する。exec_script 経路では env `KAJI_VERDICT_PATH` として注入される |
 | `previous_verdict` | str | 前ステップの verdict 要約（resume ステップ等） |
 | `cycle_count` | int | 現在のサイクルイテレーション（サイクル内ステップのみ） |
 | `max_iterations` | int | サイクルの上限回数（サイクル内ステップのみ） |

--- a/docs/reference/python/logging.md
+++ b/docs/reference/python/logging.md
@@ -111,6 +111,20 @@ skill frontmatter `exec_script` による subprocess dispatch（Issue #204）。
 {"ts": "2025-04-22T01:10:00+00:00", "event": "cycle_iteration", "cycle_name": "review_fix_loop", "iteration": 2, "max_iterations": 5}
 ```
 
+#### `verdict_source`
+
+各 step の verdict 解決経路を記録（Issue #220）。`resolve_verdict()` 直後に呼ぶ。
+
+| フィールド | 型 | 備考 |
+|-----------|-----|------|
+| `step_id` | `str` | |
+| `source` | `str` | `"artifact"` / `"comment"` / `"stdout"` |
+| `attempt` | `str` | `attempt-NNN` ディレクトリ名 |
+
+```json
+{"ts": "2025-04-22T01:05:00+00:00", "event": "verdict_source", "step_id": "implement", "source": "artifact", "attempt": "attempt-001"}
+```
+
 #### `workflow_end`
 
 ワークフロー終了時に記録。
@@ -135,8 +149,11 @@ skill frontmatter `exec_script` による subprocess dispatch（Issue #204）。
 |---------|-----------|
 | `log_workflow_start(issue, workflow)` | ワークフロー開始直後 |
 | `log_step_start(step_id, agent, model, effort, session_id, dispatch="agent")` | CLI / subprocess 実行前。`exec_script` 経路では `dispatch="exec_script"` + `agent=model=effort=None` |
+| `log_verdict_source(step_id, source, attempt)` | `resolve_verdict()` 直後（verdict 解決経路の記録、Issue #220） |
 | `log_step_end(step_id, verdict, duration_ms, cost, dispatch="agent")` | CLI / subprocess 終了・verdict 解析後 |
 | `log_cycle_iteration(cycle_name, iteration, max_iter)` | サイクル内の各反復開始時 |
+
+> **step log の出力先（Issue #220）**: `stdout.log` / `console.log` / `stderr.log` / `run.log` 以外の step 単位ログ（`prompt.txt` 等）と verdict は、従来の `runs/<run_id>/<step_id>/` ではなく `runs/<run_id>/steps/<step_id>/attempt-NNN/` 配下に出力される。`run.log` は従来どおり `runs/<run_id>/` 直下。詳細は [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md) § 実行アーティファクトの layout。
 | `log_workflow_end(status, cycle_counts, total_duration_ms, total_cost, error)` | ワークフロー終了時（正常・異常問わず） |
 
 ```python

--- a/draft/design/issue-220-feat-issue-comment-verdict.md
+++ b/draft/design/issue-220-feat-issue-comment-verdict.md
@@ -120,16 +120,19 @@ harness は解決した `Verdict` で従来どおり workflow 遷移する。解
 ```python
 # runner 内部（擬似コード）
 attempt_dir = allocate_attempt_dir(run_dir, step.id)   # steps/<step_id>/attempt-NNN/
-write_prompt_txt(attempt_dir, prompt)                  # agent step のみ
-# build_prompt に verdict_path を渡し、出力要件に保存先を埋め込む
+# build_prompt に verdict_path を渡し、出力要件に保存先を埋め込む（prompt 生成が先）
 prompt = build_prompt(step, ..., verdict_path=str(attempt_dir / "verdict.yaml"))
+write_prompt_txt(attempt_dir, prompt)                  # 生成済み prompt を保存（agent step のみ）
+
+attempt_started_at = now()   # dispatch 直前に記録。comment fallback の lower bound
 result = execute_cli(step=step, prompt=prompt, log_dir=attempt_dir, ...)
 
 verdict, source = resolve_verdict(
     attempt_dir=attempt_dir,
     full_output=result.full_output,
     valid_statuses=set(step.on.keys()),
-    comment_loader=lambda: _load_comment_bodies(provider, issue_id),  # 遅延。artifact 不在時のみ呼ぶ
+    attempt_started_at=attempt_started_at,   # comment を現在 attempt 以降に scope
+    comment_loader=lambda: _load_comments(provider, issue_id),  # 遅延。artifact 不在時のみ呼ぶ。body+created_at を返す
     ai_formatter=formatter,
 )
 if source != "artifact":
@@ -151,7 +154,7 @@ if source != "artifact":
 
 - 既存 `kaji_harness/verdict.py` の parser（STRICT / RELAXED パターン、`_parse_yaml_fields`、`_validate`）を再利用し、新規 parser を作らない。
 - comment 取得は既存 `provider.view_issue(issue_id).comments` を再利用する。comment 投稿・metadata 詳細保存・代理投稿の新規実装はしない（Issue § 認識違いを避けるための明確化）。
-- comment は GitHub（`gh issue view --json comments`）/ local（comment ファイル）ともに **投稿順（時系列昇順）** で返る前提。resolver は newest-first に走査する。
+- comment は GitHub（`gh issue view --json comments`）/ local（comment ファイル）ともに **投稿順（時系列昇順）** で返る前提。resolver は `created_at >= attempt_started_at` の comment に絞った上で newest-first に走査する（comment fallback の attempt scoping。詳細は § 方針 2）。
 - artifact path 解決は既存 `resolve_artifacts_dir(config)`（main worktree 基準）を変えない。
 - run layout 参照は `runner.py` に限局している（`grep` で確認済。`workflow.py:75` の `steps` は workflow YAML 用で無関係）。layout 変更の影響範囲は runner と runner 系テストに収まる。
 - `run_id` の minute 精度衝突は本 Issue の scope 外（既存制約）。同一 run_id 内でも attempt-NNN で step 実行ごとに分離されるため、本機能の正しさには影響しない。
@@ -166,9 +169,9 @@ if source != "artifact":
 | ファイル | 変更内容 |
 |----------|----------|
 | `kaji_harness/verdict.py` | `load_verdict_yaml()` / `write_verdict_yaml()` / `parse_verdict_block()`（delimiter 抽出のみ、AI formatter 無し）を追加 |
-| `kaji_harness/runner.py` | attempt dir 採番 / prompt.txt 保存 / verdict 解決順（artifact→comment→stdout）/ 正規化保存 / layout を `steps/<step_id>/attempt-NNN/` へ |
+| `kaji_harness/runner.py` | attempt dir 採番 / prompt.txt 保存（build_prompt 後）/ dispatch 直前の `attempt_started_at` 記録 / verdict 解決順（artifact→comment→stdout）/ 正規化保存 / layout を `steps/<step_id>/attempt-NNN/` へ |
 | `kaji_harness/prompt.py` | `verdict_path` 引数追加。`## 出力要件` を「verdict.yaml 保存 + comment 末尾追記 + stdout 互換出力」に書き換え。`## コンテキスト変数` に `verdict_path` 追加 |
-| （新規 or runner 内） verdict resolver | `resolve_verdict()` と attempt 採番 helper。runner に閉じてよいが、単体テスト容易性のため純関数として切り出す |
+| （新規 or runner 内） verdict resolver | `resolve_verdict(attempt_dir, full_output, valid_statuses, attempt_started_at, comment_loader, ai_formatter)` と attempt 採番 helper。comment fallback を `created_at >= attempt_started_at` に scope。runner に閉じてよいが、単体テスト容易性のため純関数として切り出す |
 | `.claude/skills/` 共通契約 | 個別 skill は編集せず、prompt 注入（`prompt.py`）で契約を一元化。skill-authoring.md に契約を明記 |
 
 > kaji は Python 単一スタック。backend / frontend の scope 分岐は無い。
@@ -179,20 +182,26 @@ if source != "artifact":
 
 - `load_verdict_yaml(path, valid_statuses) -> Verdict`: `path` を読み、`_parse_yaml_fields` + `_validate` を通す（delimiter 無しの pure YAML）。
 - `write_verdict_yaml(path, verdict) -> None`: `Verdict` を `status/reason/evidence/suggestion` の pure YAML（`yaml.safe_dump`、block scalar 許容）で書く。round-trip 可能。
-- `parse_verdict_block(text, valid_statuses) -> Verdict | None`: comment 本文から STRICT→RELAXED delimiter を抽出し `_parse_yaml_fields`+`_validate`。block 不在は `None`（comment fallback は best-effort のため例外にしない）。
+- `parse_verdict_block(text, valid_statuses) -> Verdict | None`: comment 本文から STRICT→RELAXED delimiter を抽出し `_parse_yaml_fields`+`_validate`。comment 契約が「末尾に追記」のため、**本文中で成立する最後（末尾）の block** を採用する（引用・過去ログ中の古い block を誤採用しない）。block 不在は `None`（comment fallback は best-effort のため例外にしない）。
 
 ### 2. verdict 解決順（resolver）
 
 ```text
-resolve_verdict(attempt_dir, full_output, valid_statuses, comment_loader, ai_formatter):
+resolve_verdict(attempt_dir, full_output, valid_statuses, attempt_started_at, comment_loader, ai_formatter):
   1. (attempt_dir/verdict.yaml) が存在 → load_verdict_yaml（壊れていれば raise / fail-loud）, source="artifact"
-  2. else comment_loader() を呼び newest-first で parse_verdict_block → 最初に成立した block, source="comment"
+  2. else comments = comment_loader();
+     current = [c for c in comments if c.created_at >= attempt_started_at]   # 現在 attempt 以降に scope
+     current を newest-first で走査し parse_verdict_block で成立した最初の block, source="comment"
   3. else parse_verdict(full_output, ai_formatter=...)（既存 stdout 経路まるごと）, source="stdout"
 ```
 
-- attempt scoping により「古い attempt の verdict 誤採用」は構造的に起きない（解決対象は常に **今 dispatch した attempt の dir**）。
-- artifact が存在すれば comment / stdout は **見ない**。よって stale comment が fresh artifact を上書きすることはない（核心の不変条件）。
-- comment fallback の stale 可能性（attempt 跨ぎの古い comment を拾う）は best-effort と明記。primary が artifact である限り通常運用では発生しない。
+- **artifact による attempt scoping**: 解決対象は常に **今 dispatch した attempt の dir** であり、artifact が存在すれば comment / stdout は **見ない**。よって stale comment が fresh artifact を上書きすることはない（核心の不変条件）。
+- **comment fallback の attempt scoping（本修正の核心）**: artifact 不在時の comment fallback は、`attempt_started_at`（当該 attempt の dispatch 直前に harness が記録したローカル時刻）を lower bound とし、`Comment.created_at >= attempt_started_at` を満たす comment **のみ** を対象にする。これにより、retry / resume で当該 attempt が verdict.yaml も stdout verdict も出さなかった場合に、**前 attempt の作業報告 comment を誤採用しない**（Issue #220 完了条件「cycle / retry / resume 時に古い step verdict や別 attempt の verdict を誤採用しない」を comment 経路でも満たす）。
+  - 前 attempt の comment は当該 attempt の dispatch 前に投稿済みのため `created_at < attempt_started_at` となり、構造的に対象外になる。
+  - lower bound を満たす comment が 1 件も無ければ comment fallback は成立せず、stdout 経路（無ければ `VerdictNotFound`）へ進む。古い comment を拾うより「解決失敗」を選ぶ fail-safe 方針。
+  - clock skew の扱い: `attempt_started_at` はローカル時刻、`Comment.created_at` は provider（GitHub はサーバ時刻 / local は投稿時刻）。skew により **本来採用すべき現在 comment を取りこぼす**方向のリスクは残るが、その場合も誤った古い verdict を採るのではなく stdout / `VerdictNotFound` へ落ちるため、workflow 遷移の正しさは壊れない。誤った遷移（false verdict）よりも解決失敗（fail-safe）を優先する設計とする。
+  - comment 本文に run/step/attempt marker を埋め込む案は不採用。agent 挙動に依存し、Issue §「認識違いを避けるための明確化」の「comment metadata を増やさない」方針に反するため、harness 制御の `created_at` lower bound を採る。
+- **複数 verdict block の扱い**: 作業報告 comment の契約は「末尾に verdict block を追記」（§ インターフェース）。引用・過去ログを含む comment で誤採用しないよう、`parse_verdict_block` は comment 本文中で成立する **最後（末尾）の block** を採用する（先頭ではない）。stdout 経路の `parse_verdict` は既存挙動を変えない（互換 fallback のため）。
 
 ### 3. runner の layout 変更
 
@@ -237,10 +246,12 @@ stdout parse は当面の互換 fallback として残す。完全移行（全 ag
 
 - `load_verdict_yaml`: 正常 YAML → `Verdict`。必須欠落 / invalid status / ABORT・BACK で suggestion 空 → 各例外。
 - `write_verdict_yaml` → `load_verdict_yaml` の round-trip 一致（複数行 evidence の block scalar 含む）。
-- `parse_verdict_block`: block 有り → `Verdict`、block 無し → `None`、invalid status block → 例外、複数 block → 先頭採用の定義を検証。
+- `parse_verdict_block`: block 有り → `Verdict`、block 無し → `None`、invalid status block → 例外、複数 block → **末尾採用**（引用・過去ログ中の先頭 block を拾わない）の定義を検証。
 - `resolve_verdict` 優先順位:
   - artifact 有り → artifact 採用かつ `comment_loader` が **呼ばれない**（happy path で API hit しない不変条件）。
-  - artifact 無し + comment 有り → comment 採用。
+  - artifact 無し + 現在 attempt 以降の comment 有り（`created_at >= attempt_started_at`）→ comment 採用。
+  - **artifact 無し + 古い comment のみ（`created_at < attempt_started_at`）+ stdout 無し → 古い comment を採用せず `VerdictNotFound`**（comment fallback の attempt scoping 回帰テスト。Issue 完了条件の核心）。
+  - artifact 無し + 古い comment のみ + stdout 有り → stdout 採用（古い comment は無視）。
   - artifact 無し + comment 無し + stdout 有り → stdout 採用。
   - 全滅 → `VerdictNotFound`。
   - artifact が壊れている → fail-loud（comment/stdout に落ちない）。
@@ -251,7 +262,8 @@ stdout parse は当面の互換 fallback として残す。完全移行（全 ag
 - mock CLI が stdout verdict のみ返す（agent は verdict.yaml 未書き込み）→ harness が stdout で解決し `attempt-001/verdict.yaml` を正規化保存、遷移が正しい（= 既存 stdout 挙動の保全確認も兼ねる）。
 - attempt dir に事前 verdict.yaml がある（agent が書いた想定）→ artifact-primary で解決し、stdout と内容が異なっても **artifact を採用**。
 - **cycle / retry**: RETRY で同一 step が 2 回 dispatch → `attempt-001` と `attempt-002` が各々の `verdict.yaml` を持ち、遷移は **2 回目（attempt-002）** の verdict に従う（古い attempt を誤採用しないことの回帰テスト）。
-- comment fallback: mock provider.view_issue が verdict block 付き comment を返し、mock CLI は stdout verdict も verdict.yaml も出さない → comment で解決。
+- comment fallback（正常）: mock provider.view_issue が **現在 attempt 以降（`created_at >= attempt_started_at`）** の verdict block 付き comment を返し、mock CLI は stdout verdict も verdict.yaml も出さない → comment で解決。
+- **comment fallback の stale 防止（resume 含む / 本修正の回帰テスト）**: 前 attempt の verdict block 付き古い comment（`created_at < attempt_started_at`）のみが存在し、当該 attempt は verdict.yaml も stdout verdict も出さない状況で、(a) retry 経由の 2 回目 dispatch、(b) `--from` による resume 経由の dispatch の双方について、**古い comment を採用せず `VerdictNotFound`** になることを確認する（artifact / stdout が無ければ古い comment へ遷移しない）。
 - legacy layout 読み取り互換: `<issue>/runs/<旧run_id>/<step_id>/`（attempt 無し旧構造）が残存していても、新 run（新 run_id）が新 layout で正常完了し crash しない。
 
 ### Large テスト（large_local・real-agent 非依存）

--- a/draft/design/issue-220-feat-issue-comment-verdict.md
+++ b/draft/design/issue-220-feat-issue-comment-verdict.md
@@ -1,0 +1,290 @@
+# [設計] artifact verdict.yaml を primary とする verdict 受け渡し経路
+
+Issue: #220
+
+## 概要
+
+`kaji run` の各 agent / script step の verdict を、stdout 依存ではなく
+**artifact の `verdict.yaml`（primary）→ 作業報告 Issue comment の `---VERDICT---` block（fallback）→ stdout parse（互換 fallback）** の順で解決できるようにする。
+あわせて artifact/log layout を `runs/<run_id>/steps/<step_id>/attempt-NNN/` 構造へ移行し、verdict を attempt 単位で保存する。
+
+## 背景・目的
+
+### ユースケース
+
+- **kaji 利用者として**、agent が stdout を直接返さない実行方式（別ターミナル起動 / 通常 interactive CLI / 人間による handoff）でも、workflow step の verdict を artifact から確実に回収したい。
+- **workflow author として**、Claude / Codex / human handoff の違いに依らず、同じ artifact verdict 形式（`verdict.yaml`）で step 完了を表現したい。
+- **maintainer として**、各 step の作業報告と verdict が Issue 上にも履歴として残り、後から「なぜ PASS / RETRY / ABORT したか」を追跡したい。
+
+### 現状の問題
+
+現在の harness は agent stdout から verdict を抽出して workflow 遷移している
+（`kaji_harness/runner.py:519-523` の `parse_verdict(result.full_output, ...)` が唯一の verdict source）。
+`docs/dev/skill-authoring.md` § verdict 出力規約 でも「verdict は stdout にそのまま出力」が唯一の契約になっている。
+
+今後 `kaji` から Claude Code / Codex を subscription の通常コンソール利用に近い形で使うには、headless stdout を直接読む方式だけでは制約が強い。
+`draft/lab/headless-terminal-spawn/design.md` の PoC では別ターミナルで agent を起動し sentinel / output file で回収する方針が示されているが、workflow の正規 verdict 経路としては未実装である。stdout に依存しない完了判定経路が必要。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|--------|-----------|
+| Issue comment を verdict の primary source にする | comment は人間向け作業報告履歴であり、attempt 境界・取得タイミングが API 依存で不安定。primary には不適（Issue § 認識違いを避けるための明確化）|
+| verdict 専用 Issue comment を新規作成する | 作業報告 comment と分離すると投稿数が倍増し追跡性が下がる。既存作業報告 comment の末尾追記で十分（同上）|
+| harness が agent stdout を parse して verdict.yaml を書くだけ（agent は書かない） | future の no-stdout runner では harness に stdout が無く成立しない。agent 側が書ける契約が前提（§ 方針で両立させる）|
+
+## インターフェース
+
+### 入力
+
+#### `verdict.yaml`（artifact 保存形式 / 新規）
+
+attempt directory に置く **pure YAML**。`---VERDICT---` delimiter は付けない。
+
+```yaml
+status: PASS
+reason: |
+  設計書と整合し品質基準を満たす
+evidence: |
+  ruff / mypy / pytest すべて pass
+suggestion: ""
+```
+
+- `status`: 必須。当該 step の `on:` キー（valid_statuses）のいずれか。
+- `reason`: 必須（空文字不可）。
+- `evidence`: 必須（空文字不可）。
+- `suggestion`: `ABORT` / `BACK*` のとき必須。`PASS` / `RETRY` では任意（空文字可）。
+- run_id / step_id / attempt_id は **保存しない**（attempt path 自体が現在の run / step / attempt を表す。Issue § 認識違いを避けるための明確化）。
+
+検証規則は既存 stdout verdict と同一（`verdict.py:_validate` を再利用）。
+
+#### 作業報告 Issue comment 末尾の `---VERDICT---` block（fallback source / 契約変更）
+
+skill が投稿する作業報告 comment の末尾に、既存 stdout 形式と同じ block を追記する。
+
+```markdown
+（実施内容・確認結果・残課題などの作業報告本文）
+
+---VERDICT---
+status: PASS
+reason: |
+  ...
+evidence: |
+  ...
+suggestion: ""
+---END_VERDICT---
+```
+
+#### harness が agent に注入する保存先パス（新規 prompt 変数 / env）
+
+| 経路 | 注入方法 | 値 |
+|------|----------|-----|
+| agent step | prompt 変数 `verdict_path` | 当該 attempt の `verdict.yaml` 絶対パス |
+| exec_script step | env `KAJI_VERDICT_PATH` | 同上 |
+
+agent / script はこのパスへ `verdict.yaml` を書く。worktree 外（main worktree の `.kaji-artifacts/` 配下）の絶対パスになるため、相対パスでなく絶対パスで渡す。
+
+### 出力
+
+#### artifact/log layout（新構造）
+
+```text
+.kaji-artifacts/<issue>/
+  session-state.json
+  progress.md
+  runs/<run_id>/
+    run.log
+    steps/<step_id>/
+      attempt-001/
+        prompt.txt          # agent step のみ。build_prompt 結果を保存
+        stdout.log          # 生の CLI stdout（既存 stream_and_log 出力）
+        console.log         # decode 済みテキスト（既存）
+        stderr.log          # 既存
+        verdict.yaml        # resolve 後に harness が正規化保存（agent が書いていればそれを採用）
+      attempt-002/
+        ...
+      latest -> attempt-002  # 人間 / 外部ツール向け convenience symlink（best-effort）
+```
+
+- `run_id` は既存どおり `datetime.now().strftime("%y%m%d%H%M")`（minute 精度）。
+- step log は従来 `runs/<run_id>/<step_id>/` だったものを `runs/<run_id>/steps/<step_id>/attempt-NNN/` に移す。
+- attempt 番号は当該 run 内で step が cycle / retry により複数回 dispatch されるたびに増える（`steps/<step_id>/` 配下の既存 `attempt-*` 数 + 1）。
+- `latest` symlink は最新 attempt を指す **convenience**。harness の verdict 解決は in-memory で保持した attempt path を直接使い、`latest` には依存しない（symlink 非対応 FS でも解決が壊れない）。
+
+#### verdict 解決結果（戻り値・遷移）
+
+harness は解決した `Verdict` で従来どおり workflow 遷移する。解決経路（artifact / comment / stdout）を `run.log` に記録する。
+
+### 使用例
+
+```python
+# runner 内部（擬似コード）
+attempt_dir = allocate_attempt_dir(run_dir, step.id)   # steps/<step_id>/attempt-NNN/
+write_prompt_txt(attempt_dir, prompt)                  # agent step のみ
+# build_prompt に verdict_path を渡し、出力要件に保存先を埋め込む
+prompt = build_prompt(step, ..., verdict_path=str(attempt_dir / "verdict.yaml"))
+result = execute_cli(step=step, prompt=prompt, log_dir=attempt_dir, ...)
+
+verdict, source = resolve_verdict(
+    attempt_dir=attempt_dir,
+    full_output=result.full_output,
+    valid_statuses=set(step.on.keys()),
+    comment_loader=lambda: _load_comment_bodies(provider, issue_id),  # 遅延。artifact 不在時のみ呼ぶ
+    ai_formatter=formatter,
+)
+if source != "artifact":
+    write_verdict_yaml(attempt_dir / "verdict.yaml", verdict)  # 正規化保存
+```
+
+### エラー
+
+| 状況 | 挙動 |
+|------|------|
+| `verdict.yaml` が壊れた YAML / 必須欠落 / invalid status | `VerdictParseError` / `InvalidVerdictValue`。fail-loud（comment / stdout への自動 fallthrough はしない。artifact が存在する以上それが意図された source）|
+| `verdict.yaml` 不在 + comment に block 無し + stdout に delimiter 無し | 既存どおり `VerdictNotFound`（fabrication 防止。`verdict.py:294-298` の方針を維持）|
+| comment fallback で provider 取得失敗（GitHub API / local read エラー） | comment source を skip し stdout parse へ。取得失敗は WARN ログ。fail-loud は最終 stdout 経路が担う |
+| exec_script 経路 | AI formatter fallback は呼ばない（`runner.py:507-510` 維持）。verdict.yaml → comment → stdout(plain) の順で解決 |
+
+> **fail-loud の方針**: `verdict.yaml` が「存在するが壊れている」場合は誤魔化さず例外にする。これは Issue #193 で確立した「delimiter があるのに中身が verdict として不成立なら fail-loud」の artifact 版。
+
+## 制約・前提条件
+
+- 既存 `kaji_harness/verdict.py` の parser（STRICT / RELAXED パターン、`_parse_yaml_fields`、`_validate`）を再利用し、新規 parser を作らない。
+- comment 取得は既存 `provider.view_issue(issue_id).comments` を再利用する。comment 投稿・metadata 詳細保存・代理投稿の新規実装はしない（Issue § 認識違いを避けるための明確化）。
+- comment は GitHub（`gh issue view --json comments`）/ local（comment ファイル）ともに **投稿順（時系列昇順）** で返る前提。resolver は newest-first に走査する。
+- artifact path 解決は既存 `resolve_artifacts_dir(config)`（main worktree 基準）を変えない。
+- run layout 参照は `runner.py` に限局している（`grep` で確認済。`workflow.py:75` の `steps` は workflow YAML 用で無関係）。layout 変更の影響範囲は runner と runner 系テストに収まる。
+- `run_id` の minute 精度衝突は本 Issue の scope 外（既存制約）。同一 run_id 内でも attempt-NNN で step 実行ごとに分離されるため、本機能の正しさには影響しない。
+- パフォーマンス: comment fallback は **artifact 不在時のみ** provider 呼び出しする（happy path で余計な API hit を出さないよう、`comment_loader` を遅延 callable にする）。
+
+### スコープ境界（Issue 準拠）
+
+含まない: 課金・認証方式の変更 / interactive terminal runner・tmux runner の本実装 / 既存 provider の unrelated CRUD 変更 / docs-only 改定 / unrelated parser・adapter の全面リファクタ / artifact と comment の厳密同一性検証 / comment metadata 詳細保存 / harness による comment 代理投稿。
+
+## 変更スコープ
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `kaji_harness/verdict.py` | `load_verdict_yaml()` / `write_verdict_yaml()` / `parse_verdict_block()`（delimiter 抽出のみ、AI formatter 無し）を追加 |
+| `kaji_harness/runner.py` | attempt dir 採番 / prompt.txt 保存 / verdict 解決順（artifact→comment→stdout）/ 正規化保存 / layout を `steps/<step_id>/attempt-NNN/` へ |
+| `kaji_harness/prompt.py` | `verdict_path` 引数追加。`## 出力要件` を「verdict.yaml 保存 + comment 末尾追記 + stdout 互換出力」に書き換え。`## コンテキスト変数` に `verdict_path` 追加 |
+| （新規 or runner 内） verdict resolver | `resolve_verdict()` と attempt 採番 helper。runner に閉じてよいが、単体テスト容易性のため純関数として切り出す |
+| `.claude/skills/` 共通契約 | 個別 skill は編集せず、prompt 注入（`prompt.py`）で契約を一元化。skill-authoring.md に契約を明記 |
+
+> kaji は Python 単一スタック。backend / frontend の scope 分岐は無い。
+
+## 方針（Minimal How）
+
+### 1. verdict.py への純関数追加
+
+- `load_verdict_yaml(path, valid_statuses) -> Verdict`: `path` を読み、`_parse_yaml_fields` + `_validate` を通す（delimiter 無しの pure YAML）。
+- `write_verdict_yaml(path, verdict) -> None`: `Verdict` を `status/reason/evidence/suggestion` の pure YAML（`yaml.safe_dump`、block scalar 許容）で書く。round-trip 可能。
+- `parse_verdict_block(text, valid_statuses) -> Verdict | None`: comment 本文から STRICT→RELAXED delimiter を抽出し `_parse_yaml_fields`+`_validate`。block 不在は `None`（comment fallback は best-effort のため例外にしない）。
+
+### 2. verdict 解決順（resolver）
+
+```text
+resolve_verdict(attempt_dir, full_output, valid_statuses, comment_loader, ai_formatter):
+  1. (attempt_dir/verdict.yaml) が存在 → load_verdict_yaml（壊れていれば raise / fail-loud）, source="artifact"
+  2. else comment_loader() を呼び newest-first で parse_verdict_block → 最初に成立した block, source="comment"
+  3. else parse_verdict(full_output, ai_formatter=...)（既存 stdout 経路まるごと）, source="stdout"
+```
+
+- attempt scoping により「古い attempt の verdict 誤採用」は構造的に起きない（解決対象は常に **今 dispatch した attempt の dir**）。
+- artifact が存在すれば comment / stdout は **見ない**。よって stale comment が fresh artifact を上書きすることはない（核心の不変条件）。
+- comment fallback の stale 可能性（attempt 跨ぎの古い comment を拾う）は best-effort と明記。primary が artifact である限り通常運用では発生しない。
+
+### 3. runner の layout 変更
+
+- `run_dir = artifacts/<issue>/runs/<run_id>/`（`run.log` はここ、不変）。
+- 各 step dispatch 直前に `attempt_dir = allocate_attempt_dir(run_dir, step.id)` を採番（`runs/<run_id>/steps/<step_id>/` 配下の `attempt-*` 数 + 1 → `attempt-NNN` mkdir、`latest` symlink を best-effort で張り替え）。
+- `attempt_dir` を `execute_cli` / `execute_script` の `log_dir` として渡す（stdout/console/stderr はこの下に出る）。
+- agent step は build_prompt 結果を `attempt_dir/prompt.txt` に保存。exec_script は prompt 無し（env で注入済）。
+- dispatch 後 `resolve_verdict`。`source != "artifact"` のとき `write_verdict_yaml` で正規化保存（legacy skill が stdout しか出さなくても attempt-NNN/verdict.yaml が必ず残る → 完了条件「verdict が attempt-NNN/verdict.yaml に保存される」を決定論的に満たす）。
+- comment fallback 用 provider は既存 `provider = get_provider(self.config)`（`runner.py:267`）を再利用。
+
+### 4. 契約の一元注入（prompt.py）
+
+`build_prompt` の `## 出力要件` を次に変更（個別 skill は触らない）:
+
+```text
+## 出力要件
+作業完了後、以下を必ず実施してください:
+
+1. 次の YAML を `[verdict_path]` に保存する（pure YAML。---VERDICT--- delimiter は付けない）:
+   status: <PASS | ...>
+   reason: 判定理由
+   evidence: 具体的根拠
+   suggestion: 次アクション（ABORT/BACK 時必須）
+2. 作業報告 Issue comment の末尾に、同じ内容を ---VERDICT--- block として追記する。
+3. 互換のため、同じ ---VERDICT--- block を stdout にも出力する。
+```
+
+`## コンテキスト変数` に `verdict_path` を追加。stdout 出力（手順 3）を残すことで既存 stdout verdict テストと un-migrated 環境の互換を保つ。
+
+### 5. 段階的廃止方針
+
+stdout parse は当面の互換 fallback として残す。完全移行（全 agent が verdict.yaml を書く）後に stdout 経路の段階廃止を別 Issue で検討する旨を skill-authoring.md に注記する。
+
+## テスト戦略
+
+> **CRITICAL**: 本変更は実行時の振る舞いを変えるコード変更（feat）。Small / Medium で契約とファイル I/O を網羅し、Large は real-agent 非依存で wiring を検証する。
+
+### 変更タイプ
+- 実行時コード変更（runner / verdict / prompt の振る舞い変更 + 新規ファイル I/O）
+
+### Small テスト（外部依存なし・純関数）
+
+- `load_verdict_yaml`: 正常 YAML → `Verdict`。必須欠落 / invalid status / ABORT・BACK で suggestion 空 → 各例外。
+- `write_verdict_yaml` → `load_verdict_yaml` の round-trip 一致（複数行 evidence の block scalar 含む）。
+- `parse_verdict_block`: block 有り → `Verdict`、block 無し → `None`、invalid status block → 例外、複数 block → 先頭採用の定義を検証。
+- `resolve_verdict` 優先順位:
+  - artifact 有り → artifact 採用かつ `comment_loader` が **呼ばれない**（happy path で API hit しない不変条件）。
+  - artifact 無し + comment 有り → comment 採用。
+  - artifact 無し + comment 無し + stdout 有り → stdout 採用。
+  - 全滅 → `VerdictNotFound`。
+  - artifact が壊れている → fail-loud（comment/stdout に落ちない）。
+- attempt 採番 helper: 初回 `attempt-001`、再 dispatch で `attempt-002`、`latest` 更新（symlink 失敗時も例外を出さず採番継続）。
+
+### Medium テスト（runner レベル・mock CLI + 実 filesystem）
+
+- mock CLI が stdout verdict のみ返す（agent は verdict.yaml 未書き込み）→ harness が stdout で解決し `attempt-001/verdict.yaml` を正規化保存、遷移が正しい（= 既存 stdout 挙動の保全確認も兼ねる）。
+- attempt dir に事前 verdict.yaml がある（agent が書いた想定）→ artifact-primary で解決し、stdout と内容が異なっても **artifact を採用**。
+- **cycle / retry**: RETRY で同一 step が 2 回 dispatch → `attempt-001` と `attempt-002` が各々の `verdict.yaml` を持ち、遷移は **2 回目（attempt-002）** の verdict に従う（古い attempt を誤採用しないことの回帰テスト）。
+- comment fallback: mock provider.view_issue が verdict block 付き comment を返し、mock CLI は stdout verdict も verdict.yaml も出さない → comment で解決。
+- legacy layout 読み取り互換: `<issue>/runs/<旧run_id>/<step_id>/`（attempt 無し旧構造）が残存していても、新 run（新 run_id）が新 layout で正常完了し crash しない。
+
+### Large テスト（large_local・real-agent 非依存）
+
+- fake-agent shell script（`claude` を騙る stub）が `verdict.yaml` 書き込み + stdout 出力する状態で、実 CLI entrypoint 経由 `kaji run` を 1 step 実行し、artifact-primary 解決と layout（`steps/<step_id>/attempt-001/verdict.yaml`）を end-to-end 検証する。
+- real LLM を使う Large は **不要**と判断: 本機能は file I/O + 解決ロジックであり、LLM 推論を介さずに Medium（実 filesystem + mock CLI）で完全に exercise できる。real-agent E2E は非決定性を増やすだけで新規回帰シグナルを生まない（`testing-convention.md` § 省略してよい理由「既存ゲートで不具合パターンを捕捉できる」+「real LLM 経路は本契約に新規回帰情報を加えない」）。GitHub comment fallback の実 API 疎通は既存 `test_providers_github.py` の `view_issue` 解析テストで担保済。
+
+## 影響ドキュメント
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | あり | verdict source を stdout-only → artifact-primary に変える設計決定 + attempt-NNN layout 採用。新規 ADR を起こす |
+| docs/ARCHITECTURE.md | あり | § Verdict 判定機構 を artifact-primary + 解決順 + attempt layout に更新 |
+| docs/dev/skill-authoring.md | あり | § verdict 出力規約 に verdict.yaml 保存 + comment 末尾追記契約、解決順、`verdict_path` 変数、stdout 段階廃止注記を追加 |
+| docs/dev/shared_skill_rules.md | あり（軽微） | verdict 永続化（verdict.yaml + comment 末尾）の共通ルールを 1 項追加 |
+| docs/reference/python/logging.md | あり（軽微） | RunLogger の step log 出力先が `steps/<step_id>/attempt-NNN/` に変わる旨を反映 |
+| docs/dev/ (workflow 系) | なし | workflow YAML / 遷移仕様は不変 |
+| docs/reference/python/ (style 系) | なし | コーディング規約変更なし |
+| docs/cli-guides/ | なし | `kaji run` の CLI IF（引数・exit code）は不変 |
+| CLAUDE.md | なし | プロジェクト規約・必読 docs 一覧に変更なし |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| 既存 verdict parser | `kaji_harness/verdict.py:99-214, 294-298` | `_parse_yaml_fields` / `_validate` / STRICT・RELAXED パターンを再利用し新 parser を作らない。delimiter 不在の fail-loud（fabrication 防止）方針を artifact にも踏襲 |
+| 既存 verdict 解決呼び出し | `kaji_harness/runner.py:505-523` | 現状 `parse_verdict(result.full_output, ...)` が唯一の source。ここを resolver に差し替える起点 |
+| 現行 step log layout | `kaji_harness/runner.py:310-318, 418-419` | `runs/<run_id>/run.log` と `runs/<run_id>/<step_id>/`。後者を `steps/<step_id>/attempt-NNN/` に移す。参照は runner 限局 |
+| stream_and_log の出力 | `kaji_harness/cli.py:198-260` | `log_dir` 配下に `stdout.log` / `console.log` / `stderr.log` を出力。`log_dir` を attempt_dir にすればそのまま新 layout に乗る |
+| prompt の出力要件契約 | `kaji_harness/prompt.py:44-99` | `## 出力要件` で stdout verdict を指示。契約注入の一元ポイント。`verdict_path` 変数を足す |
+| comment 取得経路 | `kaji_harness/providers/github.py:197-209`, `kaji_harness/providers/local.py:551`, `kaji_harness/providers/models.py:24-39,42-64` | `view_issue().comments`（`Comment.body` / `created_at`）が両 provider 共通。fallback はこれを再利用、新規 provider method 不要 |
+| exec_script の verdict 契約 | `docs/dev/skill-authoring.md:101-109`, `kaji_harness/runner.py:507-510` | exec_script は AI formatter fallback を呼ばない。新 resolver でも同方針を維持 |
+| Issue 決定方針 | 本 Issue #220 本文 §「決定方針: artifact primary / Issue comment fallback」「artifact/log layout」「認識違いを避けるための明確化」 | artifact primary / comment fallback / run_id・step_id・attempt_id を YAML に重複保存しない / 代理投稿しない等の制約の正本 |
+| headless terminal spawn PoC | `draft/lab/headless-terminal-spawn/design.md` | stdout 非依存の完了判定（sentinel + output file）が必要という動機の一次メモ。本 verdict.yaml はその正規 verdict 経路にあたる |
+| PyYAML safe_dump/safe_load | https://pyyaml.org/wiki/PyYAMLDocumentation | `verdict.yaml` の pure YAML 直列化・読込は `yaml.safe_load` / `yaml.safe_dump` を使用（任意オブジェクト構築を避ける安全 API）。既存 `verdict.py` も `yaml.safe_load` を採用 |
+| testing-convention 省略条件 | `docs/dev/testing-convention.md:112-130` | real-agent Large 省略の正当化（既存ゲートで捕捉 + 新規回帰情報を増やさない）の根拠 |

--- a/kaji_harness/logger.py
+++ b/kaji_harness/logger.py
@@ -76,6 +76,14 @@ class RunLogger:
             dispatch=dispatch,
         )
 
+    def log_verdict_source(self, step_id: str, source: str, attempt: str) -> None:
+        """verdict 解決経路（artifact / comment / stdout）と attempt を記録する。
+
+        Issue #220: artifact-primary 解決の追跡性確保。``attempt`` は
+        ``attempt-NNN`` ディレクトリ名。
+        """
+        self._write("verdict_source", step_id=step_id, source=source, attempt=attempt)
+
     def log_cycle_iteration(self, cycle_name: str, iteration: int, max_iter: int) -> None:
         """サイクルイテレーションイベントを記録。"""
         self._write(

--- a/kaji_harness/prompt.py
+++ b/kaji_harness/prompt.py
@@ -18,6 +18,7 @@ def build_prompt(
     issue_context: IssueContext,
     *,
     pr_context: PRContext | None = None,
+    verdict_path: str | None = None,
 ) -> str:
     """ステップ実行用のプロンプトを構築する。
 
@@ -36,6 +37,9 @@ def build_prompt(
         pr_context: provider が解決した `PRContext`。``None`` の場合
             ``pr_id`` / ``pr_ref`` は variables に含まれない（branch 未 push /
             MR 未作成 / GitHub・Local provider の no-op 実装等）。
+        verdict_path: Issue #220。当該 attempt の ``verdict.yaml`` 絶対パス。
+            runner は常に渡す。``None`` の場合は ``[verdict_path]`` placeholder で
+            出力要件をレンダリングする（直接呼び出し / legacy 互換）。
 
     Returns:
         CLI に渡すプロンプト文字列
@@ -59,6 +63,9 @@ def build_prompt(
         variables["pr_id"] = pr_context.pr_id
         variables["pr_ref"] = pr_context.pr_ref
 
+    if verdict_path is not None:
+        variables["verdict_path"] = verdict_path
+
     # サイクル変数（サイクル内ステップのみ）
     cycle = workflow.find_cycle_for_step(step.id)
     if cycle:
@@ -74,6 +81,8 @@ def build_prompt(
 
     valid_statuses = list(step.on.keys())
     header = "\n".join(f"- {k}: {v}" for k, v in variables.items())
+    status_choices = " | ".join(valid_statuses)
+    verdict_target = verdict_path if verdict_path is not None else "[verdict_path]"
 
     return f"""スキル `{step.skill}` を実行してください。
 
@@ -87,10 +96,18 @@ def build_prompt(
 {header}
 
 ## 出力要件
-実行完了後、以下の YAML 形式で verdict を出力してください:
+作業完了後、以下を必ず実施してください:
+
+1. 次の YAML を `{verdict_target}` に保存する（pure YAML。`---VERDICT---` delimiter は付けない）:
+   status: {status_choices} のいずれか
+   reason: 判定理由
+   evidence: 具体的根拠（複数行可。抽象表現禁止）
+   suggestion: 次のアクション提案（ABORT/BACK 時必須）
+2. 作業報告 Issue comment の末尾に、同じ内容を次の `---VERDICT---` block として追記する。
+3. 互換のため、同じ block を stdout にも出力する:
 
 ---VERDICT---
-status: {" | ".join(valid_statuses)}
+status: {status_choices}
 reason: "判定理由"
 evidence: |
   具体的根拠（複数行可。抽象表現禁止）

--- a/kaji_harness/runner.py
+++ b/kaji_harness/runner.py
@@ -6,10 +6,12 @@ manages state transitions, and handles cycle limits.
 
 from __future__ import annotations
 
+import logging
+import os
 import sys
 import time
 from dataclasses import dataclass, field, replace
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from .cli import execute_cli
@@ -30,9 +32,55 @@ from .providers.local import LocalProvider
 from .script_exec import execute_script
 from .skill import SkillMetadata, load_skill_metadata, validate_skill_exists
 from .state import SessionState
-from .verdict import create_verdict_formatter, parse_verdict
+from .verdict import create_verdict_formatter, resolve_verdict, write_verdict_yaml
 from .workflow import validate_workflow
 from .worktree_discovery import AmbiguousWorktreeError, discover_existing_worktree
+
+# module-level stdlib logger. ``run()`` 内のローカル ``logger`` (RunLogger) と
+# 名前衝突しないよう underscore 付きで分離する（runner.py は RunLogger を
+# ``logger`` という名でローカル束縛する既存規約を持つため）。
+_logger = logging.getLogger(__name__)
+
+
+def allocate_attempt_dir(run_dir: Path, step_id: str) -> Path:
+    """Issue #220: 当該 step の次の attempt ディレクトリを採番して作成する。
+
+    layout は ``run_dir/steps/<step_id>/attempt-NNN/``。``steps/<step_id>/`` 配下に
+    既存の ``attempt-*`` がある場合はその数 + 1 を採番する（cycle / retry / resume で
+    同一 step が複数回 dispatch されても prompt / logs / verdict の対応関係を一意に
+    保つ）。``latest`` symlink は最新 attempt を指す convenience（symlink 非対応 FS
+    でも採番が壊れないよう best-effort で張り替える）。
+
+    Args:
+        run_dir: ``runs/<run_id>/``（``run.log`` と同階層）。
+        step_id: step ID。
+
+    Returns:
+        作成済みの attempt ディレクトリ絶対パス。
+    """
+    steps_dir = run_dir / "steps" / step_id
+    steps_dir.mkdir(parents=True, exist_ok=True)
+    existing = [p for p in steps_dir.glob("attempt-*") if p.is_dir()]
+    attempt_no = len(existing) + 1
+    attempt_name = f"attempt-{attempt_no:03d}"
+    attempt_dir = steps_dir / attempt_name
+    attempt_dir.mkdir(parents=True, exist_ok=True)
+    _update_latest_symlink(steps_dir, attempt_name)
+    return attempt_dir
+
+
+def _update_latest_symlink(steps_dir: Path, attempt_name: str) -> None:
+    """``steps/<step_id>/latest`` を最新 attempt に張り替える（best-effort）。
+
+    symlink 非対応 FS / 権限不足では例外を握り潰して採番を継続する。
+    """
+    latest = steps_dir / "latest"
+    try:
+        if latest.is_symlink() or latest.exists():
+            latest.unlink()
+        os.symlink(attempt_name, latest)
+    except OSError as exc:
+        _logger.debug("latest symlink update skipped (%s): %s", steps_dir, exc)
 
 
 @dataclass(frozen=True)
@@ -414,9 +462,11 @@ class WorkflowRunner:
                     if current_step.resume and session_id is None:
                         raise MissingResumeSessionError(current_step.id, current_step.resume)
 
-                    # ログディレクトリ
-                    step_log_dir = run_dir / current_step.id
-                    step_log_dir.mkdir(parents=True, exist_ok=True)
+                    # Issue #220: attempt 単位の log/verdict ディレクトリを採番。
+                    # cycle / retry / resume で同一 step が複数回 dispatch されても
+                    # prompt / logs / verdict を attempt-NNN で分離する。
+                    attempt_dir = allocate_attempt_dir(run_dir, current_step.id)
+                    verdict_yaml_path = attempt_dir / "verdict.yaml"
 
                     # exec_script では agent / model / effort を null として記録する
                     # （設計書 § 副作用: ignored fields を null 化して経路判別を明示）。
@@ -459,23 +509,27 @@ class WorkflowRunner:
                             "KAJI_BRANCH_NAME": issue_context.branch_name,
                             "KAJI_PROVIDER_TYPE": issue_context.provider_type,
                             "KAJI_DEFAULT_BRANCH": issue_context.default_branch,
+                            # Issue #220: script は verdict.yaml をここへ保存する
+                            "KAJI_VERDICT_PATH": str(verdict_yaml_path),
                         }
                         context_env["KAJI_GIT_REMOTE"] = issue_context.git_remote
                         if pr_context is not None:
                             context_env["KAJI_PR_ID"] = str(pr_context.pr_id)
                             context_env["KAJI_PR_REF"] = pr_context.pr_ref
 
+                        # comment fallback の lower bound（dispatch 直前に記録）
+                        attempt_started_at = datetime.now(UTC)
                         result = execute_script(
                             step=current_step,
                             module=metadata.exec_script,
                             env=context_env,
                             workdir=effective_workdir,
-                            log_dir=step_log_dir,
+                            log_dir=attempt_dir,
                             timeout=resolved_timeout,
                             verbose=self.verbose,
                         )
                     else:
-                        # プロンプト構築（canonical id を渡す）
+                        # プロンプト構築（canonical id + verdict_path を渡す）
                         prompt = build_prompt(
                             current_step,
                             run_ctx.canonical_id,
@@ -483,15 +537,20 @@ class WorkflowRunner:
                             self.workflow,
                             issue_context=issue_context,
                             pr_context=pr_context,
+                            verdict_path=str(verdict_yaml_path),
                         )
+                        # 生成済み prompt を attempt に保存（再現性・調査用）
+                        (attempt_dir / "prompt.txt").write_text(prompt, encoding="utf-8")
 
+                        # comment fallback の lower bound（dispatch 直前に記録）
+                        attempt_started_at = datetime.now(UTC)
                         # CLI 実行
                         result = execute_cli(
                             step=current_step,
                             prompt=prompt,
                             workdir=effective_workdir,
                             session_id=session_id,
-                            log_dir=step_log_dir,
+                            log_dir=attempt_dir,
                             execution_policy=execution_policy,
                             verbose=self.verbose,
                             default_timeout=default_timeout,
@@ -502,7 +561,7 @@ class WorkflowRunner:
                         state.save_session_id(current_step.id, result.session_id)
                     cost = result.cost
 
-                    # verdict をパース
+                    # Issue #220: verdict 解決順 artifact → comment → stdout。
                     valid = set(current_step.on.keys())
                     if is_exec_script:
                         # exec_script 経路では AI formatter fallback を呼ばない
@@ -516,11 +575,20 @@ class WorkflowRunner:
                             model=current_step.model,
                             workdir=effective_workdir,
                         )
-                    verdict = parse_verdict(
-                        result.full_output,
+                    verdict, verdict_source = resolve_verdict(
+                        attempt_dir=attempt_dir,
+                        full_output=result.full_output,
                         valid_statuses=valid,
+                        attempt_started_at=attempt_started_at,
+                        # comment fallback は artifact 不在時のみ遅延呼び出し。
+                        comment_loader=lambda: provider.view_issue(run_ctx.canonical_id).comments,
                         ai_formatter=formatter,
                     )
+                    logger.log_verdict_source(current_step.id, verdict_source, attempt_dir.name)
+                    # 解決 source が artifact 以外なら正規化保存（legacy skill が
+                    # stdout しか出さなくても attempt-NNN/verdict.yaml を必ず残す）。
+                    if verdict_source != "artifact":
+                        write_verdict_yaml(verdict_yaml_path, verdict)
 
                 # ログ記録 + 状態更新
                 duration_ms = int((time.monotonic() - start_time) * 1000)

--- a/kaji_harness/verdict.py
+++ b/kaji_harness/verdict.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 from string import Template
-from typing import Any
+from typing import Any, Protocol
 
 import yaml
 
@@ -470,3 +471,197 @@ def create_verdict_formatter(
         return result.stdout
 
     return formatter
+
+
+# ============================================================
+# Issue #220: artifact verdict.yaml + comment fallback resolution
+# ============================================================
+
+
+class CommentLike(Protocol):
+    """`resolve_verdict` の comment fallback が必要とする最小 interface。
+
+    provider 層の ``Comment`` (``providers.models.Comment``) と構造的に互換。
+    verdict.py を provider 実装へ依存させないため Protocol で受ける。
+    属性は read-only property として宣言し、frozen dataclass である
+    ``Comment`` と構造的に一致させる。
+    """
+
+    @property
+    def body(self) -> str: ...
+
+    @property
+    def created_at(self) -> str: ...
+
+
+def load_verdict_yaml(path: Path, valid_statuses: set[str]) -> Verdict:
+    """artifact の ``verdict.yaml`` (delimiter 無しの pure YAML) を読み込む。
+
+    既存 stdout verdict と同じ検証規則（``_parse_yaml_fields`` + ``_validate``）を
+    通す。``verdict.yaml`` が「存在するが壊れている」場合は fail-loud（呼び出し側
+    の ``resolve_verdict`` は comment / stdout へ fallthrough しない）。
+
+    Args:
+        path: ``verdict.yaml`` の絶対パス。存在前提（存在確認は呼び出し側）。
+        valid_statuses: 当該 step の ``on:`` キー集合。
+
+    Returns:
+        検証済み ``Verdict``。
+
+    Raises:
+        VerdictParseError: YAML parse 失敗 / 必須欠落 / ABORT・BACK で suggestion 空。
+        InvalidVerdictValue: status が ``valid_statuses`` 外。
+    """
+    text = path.read_text(encoding="utf-8")
+    verdict = _parse_yaml_fields(text)
+    _validate(verdict, valid_statuses)
+    return verdict
+
+
+def write_verdict_yaml(path: Path, verdict: Verdict) -> None:
+    """``Verdict`` を ``status/reason/evidence/suggestion`` の pure YAML で書き出す。
+
+    ``load_verdict_yaml`` と round-trip 可能。run_id / step_id / attempt_id は
+    保存しない（attempt path 自体が現在の run / step / attempt を表す）。
+
+    Args:
+        path: 書き込み先（親ディレクトリは必要なら作成する）。
+        verdict: 直列化する ``Verdict``。
+    """
+    data = {
+        "status": verdict.status,
+        "reason": verdict.reason,
+        "evidence": verdict.evidence,
+        "suggestion": verdict.suggestion,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def parse_verdict_block(text: str, valid_statuses: set[str]) -> Verdict | None:
+    """comment 本文から末尾の ``---VERDICT---`` block を抽出して検証する。
+
+    作業報告 comment の契約は「本文末尾に verdict block を追記」であるため、
+    引用・過去ログ中の古い block を誤採用しないよう **本文中で成立する最後（末尾）
+    の block** を採用する。STRICT delimiter を優先し、無ければ RELAXED を見る。
+
+    Args:
+        text: comment 本文。
+        valid_statuses: 当該 step の ``on:`` キー集合。
+
+    Returns:
+        末尾 block の ``Verdict``。block が 1 つも無ければ ``None``。
+
+    Raises:
+        VerdictParseError: block は在るが YAML / 必須フィールドが不正。
+        InvalidVerdictValue: status が ``valid_statuses`` 外（prompt 違反）。
+    """
+    matches = list(STRICT_PATTERN.finditer(text))
+    if not matches:
+        matches = list(RELAXED_PATTERN.finditer(text))
+    if not matches:
+        return None
+    block = matches[-1].group(1)
+    verdict = _parse_yaml_fields(block)
+    _validate(verdict, valid_statuses)
+    return verdict
+
+
+def _parse_comment_timestamp(created_at: str) -> datetime | None:
+    """comment の ISO8601 ``created_at`` を timezone-aware datetime に変換する。
+
+    GitHub / local とも ``%Y-%m-%dT%H:%M:%SZ`` 形式。parse 不能なら ``None`` を
+    返し、呼び出し側は fail-safe（現在 attempt 判定から除外）に倒す。
+    """
+    try:
+        dt = datetime.fromisoformat(created_at)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _is_current_comment(comment: CommentLike, attempt_started_at: datetime) -> bool:
+    """comment が現在 attempt の dispatch 以降に投稿されたかを判定する。
+
+    ``created_at >= attempt_started_at`` を満たす comment のみ現在 attempt 由来と
+    みなす。parse 不能な ``created_at`` は fail-safe で除外する（古い comment を
+    誤採用するより解決失敗を選ぶ）。
+    """
+    ts = _parse_comment_timestamp(comment.created_at)
+    if ts is None:
+        return False
+    return ts >= attempt_started_at
+
+
+def resolve_verdict(
+    *,
+    attempt_dir: Path,
+    full_output: str,
+    valid_statuses: set[str],
+    attempt_started_at: datetime,
+    comment_loader: Callable[[], Sequence[CommentLike]] | None,
+    ai_formatter: Callable[[str], str] | None = None,
+    max_retries: int = 2,
+) -> tuple[Verdict, str]:
+    """verdict を artifact → comment → stdout の順で解決する。
+
+    1. ``attempt_dir/verdict.yaml`` が存在 → ``load_verdict_yaml``（壊れていれば
+       fail-loud。comment / stdout へは落ちない）。``source="artifact"``。
+    2. else ``comment_loader()`` を呼び、``created_at >= attempt_started_at`` の
+       comment **のみ** を newest-first で走査し、最初に成立した末尾 block を採用。
+       ``source="comment"``。provider 取得失敗時は WARN して stdout へ。
+    3. else stdout の ``parse_verdict``（既存 3 段 fallback まるごと）。
+       ``source="stdout"``。
+
+    artifact が存在する間は comment / stdout を **見ない**ため、stale comment が
+    fresh artifact を上書きすることはない。comment fallback は
+    ``attempt_started_at`` を lower bound にすることで、retry / resume で当該
+    attempt が verdict.yaml も stdout verdict も出さなかった場合に前 attempt の
+    作業報告 comment を誤採用しない（Issue #220 完了条件）。
+
+    Args:
+        attempt_dir: 当該 attempt のディレクトリ（``verdict.yaml`` の親）。
+        full_output: CLI / script の stdout 全文（stdout fallback 用）。
+        valid_statuses: 当該 step の ``on:`` キー集合。
+        attempt_started_at: dispatch 直前に記録した timezone-aware 時刻。
+            comment fallback の lower bound。
+        comment_loader: artifact 不在時のみ呼ぶ遅延 callable。comment 列を返す。
+            ``None`` の場合 comment fallback を行わず stdout へ進む。
+        ai_formatter: stdout 経路の Step 3（AI formatter）。exec_script では
+            ``None``（formatter fallback を呼ばない）。
+        max_retries: stdout 経路の AI formatter retry 回数。
+
+    Returns:
+        ``(Verdict, source)``。source は ``"artifact"`` / ``"comment"`` / ``"stdout"``。
+
+    Raises:
+        VerdictNotFound: 全 source で verdict が成立しない。
+        VerdictParseError / InvalidVerdictValue: artifact が壊れている / status 不正。
+    """
+    artifact_path = attempt_dir / "verdict.yaml"
+    if artifact_path.exists():
+        return load_verdict_yaml(artifact_path, valid_statuses), "artifact"
+
+    if comment_loader is not None:
+        try:
+            comments: Sequence[CommentLike] = comment_loader()
+        except Exception as exc:  # noqa: BLE001 — provider 取得失敗は stdout へ fallthrough
+            logger.warning("comment fallback loader failed: %s; falling through to stdout", exc)
+            comments = []
+        current = [c for c in comments if _is_current_comment(c, attempt_started_at)]
+        for comment in reversed(current):  # newest-first
+            verdict = parse_verdict_block(comment.body, valid_statuses)
+            if verdict is not None:
+                return verdict, "comment"
+
+    return (
+        parse_verdict(
+            full_output, valid_statuses, ai_formatter=ai_formatter, max_retries=max_retries
+        ),
+        "stdout",
+    )

--- a/kaji_harness/verdict.py
+++ b/kaji_harness/verdict.py
@@ -591,11 +591,18 @@ def _is_current_comment(comment: CommentLike, attempt_started_at: datetime) -> b
     ``created_at >= attempt_started_at`` を満たす comment のみ現在 attempt 由来と
     みなす。parse 不能な ``created_at`` は fail-safe で除外する（古い comment を
     誤採用するより解決失敗を選ぶ）。
+
+    比較の lower bound は **秒に切り捨てて** から用いる。``attempt_started_at`` は
+    ``datetime.now(UTC)`` 由来でマイクロ秒精度を持つ一方、local comment / GitHub
+    ``createdAt`` の timestamp は秒精度（``%Y-%m-%dT%H:%M:%SZ``）で保存される。
+    dispatch と同一秒に投稿された fresh comment（例: dispatch ``12:00:00.5``、
+    comment ``12:00:00Z``）が、マイクロ秒差だけで stale 扱いされ取りこぼされるのを
+    防ぐ。
     """
     ts = _parse_comment_timestamp(comment.created_at)
     if ts is None:
         return False
-    return ts >= attempt_started_at
+    return ts >= attempt_started_at.replace(microsecond=0)
 
 
 def resolve_verdict(

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -139,8 +139,6 @@ class TestCanonicalIssueId:
 
     def test_run_persists_state_under_canonical_dir(self, tmp_path: Path) -> None:
         """``run()`` 完了後、state / progress.md は canonical id directory に書かれる。"""
-        from kaji_harness.models import Verdict
-
         repo = _write_repo(
             tmp_path,
             provider_section=(
@@ -150,7 +148,9 @@ class TestCanonicalIssueId:
         provider = LocalProvider(repo_root=repo, machine_id="pc1")
         provider.create_issue(title="x", body="b", slug="x", labels=["type:feature"])
         runner = _make_runner(repo, "1")  # raw 入力
-        # CLI 実行を mock：1 step 走らせて即 PASS で終了
+        # CLI 実行を mock：1 step 走らせて即 PASS で終了。Issue #220 以降 runner は
+        # parse_verdict を直接呼ばず resolve_verdict 経由で artifact→comment→stdout を
+        # 解決するため、stdout に valid な PASS block を含めて stdout 経路で解決させる。
         from kaji_harness.models import CLIResult
 
         with patch("kaji_harness.runner.execute_cli") as mock_exec:
@@ -160,10 +160,8 @@ class TestCanonicalIssueId:
                 session_id=None,
                 cost=None,
             )
-            with patch("kaji_harness.runner.parse_verdict") as mock_v:
-                mock_v.return_value = Verdict("PASS", "ok", "ok", "ok")
-                with patch("kaji_harness.runner.validate_skill_exists"):
-                    runner.run()
+            with patch("kaji_harness.runner.validate_skill_exists"):
+                runner.run()
         assert runner.canonical_issue_id == "local-pc1-1"
         assert runner.canonical_issue_ref == "local-pc1-1"
         # canonical dir に state が書かれる、raw dir には書かれない

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -560,3 +560,55 @@ class TestPrContextInjection:
         )
 
         assert "- issue_id: 42" in prompt
+
+
+# ============================================================
+# 16. verdict_path injection + 出力要件契約 (Issue #220)
+# ============================================================
+
+
+@pytest.mark.small
+class TestVerdictPathInjection:
+    """Issue #220: verdict_path 注入と verdict.yaml 保存 + comment 末尾追記契約。"""
+
+    def test_verdict_path_present_injects_variable_and_contract(self) -> None:
+        step = _make_step()
+        workflow = _make_workflow(steps=[step])
+        state = _make_state(issue="42")
+
+        path = "/abs/.kaji-artifacts/42/runs/2606041200/steps/implement/attempt-001/verdict.yaml"
+        prompt = build_prompt(
+            step,
+            issue="42",
+            state=state,
+            workflow=workflow,
+            issue_context=make_issue_context(issue_id="42"),
+            verdict_path=path,
+        )
+
+        # context 変数として注入される
+        assert f"- verdict_path: {path}" in prompt
+        # 出力要件に保存先 path と comment 末尾追記契約が含まれる
+        assert f"`{path}`" in prompt
+        assert "作業報告 Issue comment の末尾" in prompt
+        # stdout 互換 block も残る
+        assert "---VERDICT---" in prompt
+        assert "---END_VERDICT---" in prompt
+
+    def test_verdict_path_none_uses_placeholder_and_omits_variable(self) -> None:
+        step = _make_step()
+        workflow = _make_workflow(steps=[step])
+        state = _make_state(issue="42")
+
+        prompt = build_prompt(
+            step,
+            issue="42",
+            state=state,
+            workflow=workflow,
+            issue_context=make_issue_context(issue_id="42"),
+        )
+
+        # 注入されない（context header に出ない）
+        assert "- verdict_path:" not in prompt
+        # placeholder で契約はレンダリングされる
+        assert "[verdict_path]" in prompt

--- a/tests/test_verdict_artifact.py
+++ b/tests/test_verdict_artifact.py
@@ -226,6 +226,22 @@ class TestResolveVerdict:
         assert source == "comment"
         assert verdict.status == "PASS"
 
+    def test_same_second_comment_adopted(self, tmp_path: Path) -> None:
+        # dispatch はマイクロ秒精度（12:00:00.5）、comment は秒精度（12:00:00Z）。
+        # 同一秒投稿の fresh comment がマイクロ秒差で取りこぼされないこと。
+        started = self._started().replace(microsecond=500_000)
+        same_second = self._started().strftime("%Y-%m-%dT%H:%M:%SZ")
+        comment = _FakeComment(body="作業報告\n\n" + _block(status="PASS"), created_at=same_second)
+        verdict, source = resolve_verdict(
+            attempt_dir=tmp_path,
+            full_output="",
+            valid_statuses=VALID,
+            attempt_started_at=started,
+            comment_loader=lambda: [comment],
+        )
+        assert source == "comment"
+        assert verdict.status == "PASS"
+
     def test_old_comment_only_no_stdout_raises_not_found(self, tmp_path: Path) -> None:
         started = self._started()
         older = (started - timedelta(seconds=300)).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_verdict_artifact.py
+++ b/tests/test_verdict_artifact.py
@@ -1,0 +1,323 @@
+"""Small tests for artifact verdict.yaml + comment fallback resolution.
+
+Issue #220: verdict 解決を artifact `verdict.yaml`（primary）→ 作業報告 comment
+末尾の `---VERDICT---` block（fallback）→ stdout parse（互換 fallback）の順に
+する。本ファイルは純関数 / 単一ファイル I/O の Small 観点を検証する。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kaji_harness.errors import InvalidVerdictValue, VerdictNotFound, VerdictParseError
+from kaji_harness.models import Verdict
+from kaji_harness.verdict import (
+    load_verdict_yaml,
+    parse_verdict_block,
+    resolve_verdict,
+    write_verdict_yaml,
+)
+
+VALID = {"PASS", "RETRY", "BACK", "ABORT"}
+
+
+@dataclass(frozen=True)
+class _FakeComment:
+    """`Comment` 互換の最小 stub（body / created_at のみ）。"""
+
+    body: str
+    created_at: str
+
+
+def _block(
+    status: str = "PASS", reason: str = "r", evidence: str = "e", suggestion: str = ""
+) -> str:
+    """末尾に付ける `---VERDICT---` block を組み立てる。"""
+    lines = [
+        "---VERDICT---",
+        f"status: {status}",
+        f'reason: "{reason}"',
+        f'evidence: "{evidence}"',
+    ]
+    if suggestion:
+        lines.append(f'suggestion: "{suggestion}"')
+    lines.append("---END_VERDICT---")
+    return "\n".join(lines)
+
+
+# ============================================================
+# load_verdict_yaml（pure YAML、delimiter 無し）
+# ============================================================
+
+
+@pytest.mark.small
+class TestLoadVerdictYaml:
+    def test_valid_yaml(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        path.write_text(
+            "status: PASS\nreason: ok\nevidence: tests pass\nsuggestion: ''\n",
+            encoding="utf-8",
+        )
+        v = load_verdict_yaml(path, VALID)
+        assert v.status == "PASS"
+        assert v.reason == "ok"
+        assert v.evidence == "tests pass"
+        assert v.suggestion == ""
+
+    def test_missing_reason_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        path.write_text("status: PASS\nevidence: e\n", encoding="utf-8")
+        with pytest.raises(VerdictParseError):
+            load_verdict_yaml(path, VALID)
+
+    def test_invalid_status_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        path.write_text("status: BOGUS\nreason: r\nevidence: e\n", encoding="utf-8")
+        with pytest.raises(InvalidVerdictValue):
+            load_verdict_yaml(path, VALID)
+
+    def test_abort_without_suggestion_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        path.write_text("status: ABORT\nreason: r\nevidence: e\nsuggestion: ''\n", encoding="utf-8")
+        with pytest.raises(VerdictParseError):
+            load_verdict_yaml(path, VALID)
+
+    def test_back_without_suggestion_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        path.write_text("status: BACK\nreason: r\nevidence: e\n", encoding="utf-8")
+        with pytest.raises(VerdictParseError):
+            load_verdict_yaml(path, VALID)
+
+    def test_broken_yaml_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        path.write_text("status: PASS\nreason: : : :\n  - broken\n", encoding="utf-8")
+        with pytest.raises(VerdictParseError):
+            load_verdict_yaml(path, VALID)
+
+
+# ============================================================
+# write_verdict_yaml → load_verdict_yaml round-trip
+# ============================================================
+
+
+@pytest.mark.small
+class TestWriteVerdictYamlRoundTrip:
+    def test_single_line_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        v = Verdict(status="RETRY", reason="needs fix", evidence="1 test failing", suggestion="")
+        write_verdict_yaml(path, v)
+        loaded = load_verdict_yaml(path, VALID)
+        assert loaded == v
+
+    def test_multiline_evidence_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        v = Verdict(
+            status="ABORT",
+            reason="多段の理由\n2行目",
+            evidence="ruff: ok\nmypy: ok\npytest: 3 failed",
+            suggestion="設計に戻る",
+        )
+        write_verdict_yaml(path, v)
+        loaded = load_verdict_yaml(path, VALID)
+        assert loaded == v
+
+    def test_written_yaml_has_no_delimiter(self, tmp_path: Path) -> None:
+        path = tmp_path / "verdict.yaml"
+        v = Verdict(status="PASS", reason="r", evidence="e", suggestion="")
+        write_verdict_yaml(path, v)
+        text = path.read_text(encoding="utf-8")
+        assert "---VERDICT---" not in text
+        assert "---END_VERDICT---" not in text
+
+
+# ============================================================
+# parse_verdict_block（comment 末尾 block 抽出）
+# ============================================================
+
+
+@pytest.mark.small
+class TestParseVerdictBlock:
+    def test_block_present(self) -> None:
+        text = "作業報告本文\n\n" + _block(status="PASS", reason="done", evidence="ok")
+        v = parse_verdict_block(text, VALID)
+        assert v is not None
+        assert v.status == "PASS"
+
+    def test_no_block_returns_none(self) -> None:
+        assert parse_verdict_block("ただの作業報告。verdict なし。", VALID) is None
+
+    def test_invalid_status_block_raises(self) -> None:
+        text = _block(status="NOPE", reason="r", evidence="e")
+        with pytest.raises(InvalidVerdictValue):
+            parse_verdict_block(text, VALID)
+
+    def test_multiple_blocks_adopts_last(self) -> None:
+        # 過去ログ（先頭）に PASS、末尾の最新 block に RETRY。末尾を採用する。
+        text = (
+            "過去の引用:\n"
+            + _block(status="PASS", reason="old", evidence="old")
+            + "\n\n今回の作業報告\n\n"
+            + _block(status="RETRY", reason="new", evidence="new")
+        )
+        v = parse_verdict_block(text, VALID)
+        assert v is not None
+        assert v.status == "RETRY"
+        assert v.reason == "new"
+
+    def test_relaxed_delimiter_block(self) -> None:
+        text = "報告\n\n--- VERDICT ---\nstatus: PASS\nreason: r\nevidence: e\n--- END VERDICT ---"
+        v = parse_verdict_block(text, VALID)
+        assert v is not None
+        assert v.status == "PASS"
+
+
+# ============================================================
+# resolve_verdict 優先順位
+# ============================================================
+
+
+@pytest.mark.small
+class TestResolveVerdict:
+    def _started(self) -> datetime:
+        return datetime(2026, 6, 4, 12, 0, 0, tzinfo=UTC)
+
+    def _write_artifact(self, attempt_dir: Path, status: str = "PASS") -> None:
+        write_verdict_yaml(
+            attempt_dir / "verdict.yaml",
+            Verdict(status=status, reason="r", evidence="e", suggestion=""),
+        )
+
+    def test_artifact_primary_and_loader_not_called(self, tmp_path: Path) -> None:
+        self._write_artifact(tmp_path, status="PASS")
+        called = False
+
+        def loader() -> list[_FakeComment]:
+            nonlocal called
+            called = True
+            return []
+
+        verdict, source = resolve_verdict(
+            attempt_dir=tmp_path,
+            full_output="(stdout に別の verdict があっても無視)"
+            + _block(status="ABORT", suggestion="x"),
+            valid_statuses=VALID,
+            attempt_started_at=self._started(),
+            comment_loader=loader,
+        )
+        assert source == "artifact"
+        assert verdict.status == "PASS"
+        assert called is False, "artifact 解決時は comment_loader を呼ばない"
+
+    def test_current_comment_adopted(self, tmp_path: Path) -> None:
+        started = self._started()
+        newer = (started + timedelta(seconds=120)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        comment = _FakeComment(body="作業報告\n\n" + _block(status="PASS"), created_at=newer)
+        verdict, source = resolve_verdict(
+            attempt_dir=tmp_path,
+            full_output="",
+            valid_statuses=VALID,
+            attempt_started_at=started,
+            comment_loader=lambda: [comment],
+        )
+        assert source == "comment"
+        assert verdict.status == "PASS"
+
+    def test_old_comment_only_no_stdout_raises_not_found(self, tmp_path: Path) -> None:
+        started = self._started()
+        older = (started - timedelta(seconds=300)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        comment = _FakeComment(body=_block(status="PASS"), created_at=older)
+        with pytest.raises(VerdictNotFound):
+            resolve_verdict(
+                attempt_dir=tmp_path,
+                full_output="",
+                valid_statuses=VALID,
+                attempt_started_at=started,
+                comment_loader=lambda: [comment],
+            )
+
+    def test_old_comment_only_with_stdout_uses_stdout(self, tmp_path: Path) -> None:
+        started = self._started()
+        older = (started - timedelta(seconds=300)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # 古い comment は RETRY だが、stdout は PASS。古い comment を採らず stdout 採用。
+        comment = _FakeComment(body=_block(status="RETRY"), created_at=older)
+        verdict, source = resolve_verdict(
+            attempt_dir=tmp_path,
+            full_output="報告\n\n" + _block(status="PASS"),
+            valid_statuses=VALID,
+            attempt_started_at=started,
+            comment_loader=lambda: [comment],
+        )
+        assert source == "stdout"
+        assert verdict.status == "PASS"
+
+    def test_no_comment_with_stdout_uses_stdout(self, tmp_path: Path) -> None:
+        verdict, source = resolve_verdict(
+            attempt_dir=tmp_path,
+            full_output="報告\n\n" + _block(status="RETRY"),
+            valid_statuses=VALID,
+            attempt_started_at=self._started(),
+            comment_loader=lambda: [],
+        )
+        assert source == "stdout"
+        assert verdict.status == "RETRY"
+
+    def test_all_empty_raises_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(VerdictNotFound):
+            resolve_verdict(
+                attempt_dir=tmp_path,
+                full_output="verdict 無し",
+                valid_statuses=VALID,
+                attempt_started_at=self._started(),
+                comment_loader=lambda: [],
+            )
+
+    def test_broken_artifact_fails_loud(self, tmp_path: Path) -> None:
+        (tmp_path / "verdict.yaml").write_text(
+            "status: PASS\nreason: : :\n  bad\n", encoding="utf-8"
+        )
+        called = False
+
+        def loader() -> list[_FakeComment]:
+            nonlocal called
+            called = True
+            return []
+
+        with pytest.raises(VerdictParseError):
+            resolve_verdict(
+                attempt_dir=tmp_path,
+                full_output="報告\n\n" + _block(status="PASS"),
+                valid_statuses=VALID,
+                attempt_started_at=self._started(),
+                comment_loader=loader,
+            )
+        assert called is False, "壊れた artifact は fail-loud。comment/stdout に落ちない"
+
+    def test_comment_loader_failure_falls_through_to_stdout(self, tmp_path: Path) -> None:
+        def loader() -> list[_FakeComment]:
+            raise RuntimeError("provider down")
+
+        verdict, source = resolve_verdict(
+            attempt_dir=tmp_path,
+            full_output="報告\n\n" + _block(status="PASS"),
+            valid_statuses=VALID,
+            attempt_started_at=self._started(),
+            comment_loader=loader,
+        )
+        assert source == "stdout"
+        assert verdict.status == "PASS"
+
+    def test_unparseable_created_at_excluded(self, tmp_path: Path) -> None:
+        # created_at が parse 不能な comment は fail-safe で除外し、stdout へ。
+        comment = _FakeComment(body=_block(status="PASS"), created_at="not-a-timestamp")
+        with pytest.raises(VerdictNotFound):
+            resolve_verdict(
+                attempt_dir=tmp_path,
+                full_output="",
+                valid_statuses=VALID,
+                attempt_started_at=self._started(),
+                comment_loader=lambda: [comment],
+            )

--- a/tests/test_verdict_artifact_e2e_large_local.py
+++ b/tests/test_verdict_artifact_e2e_large_local.py
@@ -1,0 +1,177 @@
+"""Large-local E2E: artifact verdict.yaml resolution through the real CLI entrypoint.
+
+実 ``kaji run`` を subprocess で起動し、PATH 上に置いた fake ``claude`` stub が
+``verdict.yaml`` を書き + stdout に **乖離した** verdict block (RETRY) を出す状況で、
+harness が artifact (PASS) を primary 採用し、layout が
+``steps/<step_id>/attempt-001/verdict.yaml`` になることを end-to-end 検証する。
+
+real LLM は使わない（Issue #220 設計 § テスト戦略: 本機能は file I/O + 解決ロジック
+であり real 推論経路は新規回帰情報を加えない）。fake stub で CLI 起動 → prompt への
+``verdict_path`` 注入 → agent による artifact 書き込み → harness 解決の全配線を通す。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kaji_harness.providers import LocalProvider
+
+pytestmark = [pytest.mark.large, pytest.mark.large_local]
+
+
+_FAKE_CLAUDE = '''#!/usr/bin/env python3
+"""Fake `claude` CLI: writes verdict.yaml from prompt, emits stream-json JSONL.
+
+prompt 末尾引数から `- verdict_path: <path>` を抽出し、その path へ
+artifact verdict.yaml (status: PASS) を書く。stdout には意図的に乖離した
+RETRY verdict block を出し、harness が artifact(PASS) を優先することを検証可能にする。
+"""
+import json
+import re
+import sys
+
+prompt = sys.argv[-1]
+m = re.search(r"^- verdict_path: (.+)$", prompt, re.M)
+if m:
+    vpath = m.group(1).strip()
+    with open(vpath, "w", encoding="utf-8") as f:
+        f.write(
+            "status: PASS\\n"
+            "reason: e2e artifact primary\\n"
+            "evidence: fake agent wrote verdict.yaml\\n"
+            "suggestion: ''\\n"
+        )
+
+# stream-json JSONL（ClaudeAdapter 互換）。assistant text に乖離 RETRY block を仕込む。
+print(json.dumps({"type": "system", "subtype": "init", "session_id": "fake-sess-001"}))
+divergent = (
+    "作業ログ\\n\\n"
+    "---VERDICT---\\n"
+    "status: RETRY\\n"
+    'reason: "stdout divergent (should be ignored)"\\n'
+    'evidence: "stdout"\\n'
+    'suggestion: ""\\n'
+    "---END_VERDICT---"
+)
+print(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": divergent}]}}))
+print(json.dumps({"type": "result", "subtype": "success", "total_cost_usd": 0.0}))
+'''
+
+
+_WORKFLOW_YAML = """name: e2e-verdict
+description: single agent step for artifact verdict E2E
+requires_provider: any
+execution_policy: auto
+
+steps:
+  - id: implement
+    skill: e2e-impl
+    agent: claude
+    on:
+      PASS: end
+      RETRY: end
+      ABORT: end
+"""
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "--initial-branch=main", str(repo)], check=True)
+    kaji_dir = repo / ".kaji"
+    kaji_dir.mkdir()
+    (kaji_dir / "config.toml").write_text(
+        '[paths]\nskill_dir = ".claude/skills"\nartifacts_dir = ".kaji-artifacts"\n\n'
+        "[execution]\ndefault_timeout = 60\n\n"
+        '[provider]\ntype = "local"\n\n'
+        '[provider.local]\nmachine_id = "pc1"\ndefault_branch = "main"\n'
+    )
+    # minimal agent skill（frontmatter 無し → exec_script=None で agent step として通る）
+    skill_dir = repo / ".claude" / "skills" / "e2e-impl"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# e2e-impl\n\nfixture agent skill for E2E.\n")
+    (repo / "workflow.yaml").write_text(_WORKFLOW_YAML)
+    return repo
+
+
+def _make_fake_claude(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "claude"
+    fake.write_text(_FAKE_CLAUDE)
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def test_fake_agent_artifact_primary_e2e(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    bin_dir = _make_fake_claude(tmp_path)
+
+    # local issue 99 (type:feature) を作成
+    counter = repo / ".kaji" / "counters" / "pc1.txt"
+    counter.parent.mkdir(parents=True, exist_ok=True)
+    counter.write_text("98")
+    provider = LocalProvider(repo_root=repo, machine_id="pc1")
+    provider.create_issue(title="e2e", body="body", labels=["type:feature"], slug="e2e")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    # subprocess の ``python -m kaji_harness.cli_main`` が editable install 経由で
+    # 別 worktree（main repo）の古い kaji_harness を読まないよう、本 worktree を
+    # PYTHONPATH 先頭に置いて解決を固定する。tests/ は worktree root 直下。
+    worktree_root = Path(__file__).resolve().parents[1]
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{worktree_root}{os.pathsep}{existing_pp}" if existing_pp else str(worktree_root)
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kaji_harness.cli_main",
+            "run",
+            str(repo / "workflow.yaml"),
+            "99",
+            "--workdir",
+            str(repo),
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+    # layout: steps/<step_id>/attempt-001/verdict.yaml
+    runs = repo / ".kaji-artifacts" / "local-pc1-99" / "runs"
+    run_dirs = [p for p in runs.iterdir() if p.is_dir()]
+    assert len(run_dirs) == 1, f"expected 1 run dir, got {run_dirs}"
+    attempt = run_dirs[0] / "steps" / "implement" / "attempt-001"
+    vfile = attempt / "verdict.yaml"
+    assert vfile.exists(), f"verdict.yaml missing; attempt contents: {list(attempt.iterdir())}"
+
+    # artifact が primary 採用される（stdout の RETRY ではなく PASS）
+    text = vfile.read_text(encoding="utf-8")
+    assert "status: PASS" in text
+    assert "e2e artifact primary" in text
+
+    # run.log の verdict_source が artifact
+    sources = [
+        json.loads(line)
+        for line in (run_dirs[0] / "run.log").read_text(encoding="utf-8").splitlines()
+        if json.loads(line).get("event") == "verdict_source"
+    ]
+    assert sources and sources[-1]["source"] == "artifact"
+    assert sources[-1]["attempt"] == "attempt-001"
+    # prompt.txt も attempt に保存されている
+    assert (attempt / "prompt.txt").exists()

--- a/tests/test_verdict_artifact_runner.py
+++ b/tests/test_verdict_artifact_runner.py
@@ -1,0 +1,503 @@
+"""Runner-level tests for Issue #220 artifact verdict + attempt layout.
+
+Small: ``allocate_attempt_dir`` の採番 / latest symlink。
+Medium: ``WorkflowRunner.run()`` を mock CLI + 実 filesystem で回し、
+artifact-primary 解決 / stdout 正規化保存 / cycle attempt 分離 /
+comment fallback の現在 attempt scoping / legacy layout 互換を検証する。
+
+``test_verdict_artifact.py`` は ``resolve_verdict`` 等の純関数を Small で
+網羅する。本ファイルは runner への wiring（attempt_dir 採番・``verdict_path``
+注入・``attempt_started_at`` 記録・正規化保存）を検証する補完層。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess as _sp
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from kaji_harness.config import KajiConfig
+from kaji_harness.errors import VerdictNotFound
+from kaji_harness.models import CLIResult, CostInfo, CycleDefinition, Step, Verdict, Workflow
+from kaji_harness.providers import LocalProvider
+from kaji_harness.providers.models import Comment
+from kaji_harness.runner import WorkflowRunner, allocate_attempt_dir
+from kaji_harness.verdict import load_verdict_yaml, write_verdict_yaml
+
+VALID = {"PASS", "RETRY", "BACK", "ABORT"}
+
+
+# ============================================================
+# Small: allocate_attempt_dir
+# ============================================================
+
+
+@pytest.mark.small
+class TestAllocateAttemptDir:
+    def test_first_attempt_is_001(self, tmp_path: Path) -> None:
+        attempt = allocate_attempt_dir(tmp_path, "implement")
+        assert attempt == tmp_path / "steps" / "implement" / "attempt-001"
+        assert attempt.is_dir()
+
+    def test_second_dispatch_increments_to_002(self, tmp_path: Path) -> None:
+        first = allocate_attempt_dir(tmp_path, "implement")
+        second = allocate_attempt_dir(tmp_path, "implement")
+        assert first.name == "attempt-001"
+        assert second.name == "attempt-002"
+        assert first.is_dir() and second.is_dir()
+
+    def test_distinct_steps_have_independent_counters(self, tmp_path: Path) -> None:
+        a = allocate_attempt_dir(tmp_path, "design")
+        b = allocate_attempt_dir(tmp_path, "review")
+        assert a.name == "attempt-001"
+        assert b.name == "attempt-001"
+        assert a.parent != b.parent
+
+    def test_latest_symlink_points_to_newest(self, tmp_path: Path) -> None:
+        allocate_attempt_dir(tmp_path, "implement")
+        second = allocate_attempt_dir(tmp_path, "implement")
+        latest = tmp_path / "steps" / "implement" / "latest"
+        if not latest.is_symlink():
+            pytest.skip("filesystem does not support symlinks")
+        assert os.readlink(latest) == second.name
+
+    def test_symlink_failure_does_not_break_allocation(self, tmp_path: Path) -> None:
+        with patch("kaji_harness.runner.os.symlink", side_effect=OSError("no symlink")):
+            attempt = allocate_attempt_dir(tmp_path, "implement")
+        # symlink 失敗でも attempt は採番・作成される
+        assert attempt.name == "attempt-001"
+        assert attempt.is_dir()
+
+
+# ============================================================
+# Medium: runner-level resolution / layout
+# ============================================================
+
+
+def _verdict_block(status: str, reason: str = "ok", evidence: str = "e") -> str:
+    suggestion = "next" if status in ("ABORT", "BACK") else ""
+    return (
+        "報告本文\n\n"
+        "---VERDICT---\n"
+        f"status: {status}\n"
+        f'reason: "{reason}"\n'
+        f'evidence: "{evidence}"\n'
+        f'suggestion: "{suggestion}"\n'
+        "---END_VERDICT---\n"
+    )
+
+
+def _cli_result(status: str | None, session_id: str = "sess") -> CLIResult:
+    """status=None なら verdict block を含まない stdout を返す。"""
+    output = "verdict 無しの作業ログ" if status is None else _verdict_block(status)
+    return CLIResult(full_output=output, session_id=session_id, cost=CostInfo(usd=0.0), stderr="")
+
+
+def _make_config(tmp_path: Path) -> KajiConfig:
+    kaji_dir = tmp_path / ".kaji"
+    kaji_dir.mkdir(exist_ok=True)
+    config_file = kaji_dir / "config.toml"
+    config_file.write_text(
+        '[paths]\nskill_dir = ".claude/skills"\nartifacts_dir = ".kaji/artifacts"\n\n'
+        "[execution]\ndefault_timeout = 1800\n\n"
+        '[provider]\ntype = "local"\n\n'
+        '[provider.local]\nmachine_id = "pc1"\ndefault_branch = "main"\n'
+    )
+    if not (tmp_path / ".git").exists():
+        _sp.run(["git", "init", "-q", "--initial-branch=main", str(tmp_path)], check=True)
+    return KajiConfig._load(config_file)
+
+
+def _ensure_local_issue(tmp_path: Path, issue: int) -> None:
+    counter_path = tmp_path / ".kaji" / "counters" / "pc1.txt"
+    counter_path.parent.mkdir(parents=True, exist_ok=True)
+    issues_root = tmp_path / ".kaji" / "issues"
+    issues_root.mkdir(parents=True, exist_ok=True)
+    if any(d.name.startswith(f"local-pc1-{issue}-") for d in issues_root.iterdir()):
+        return
+    counter_path.write_text(str(issue - 1))
+    provider = LocalProvider(repo_root=tmp_path, machine_id="pc1")
+    provider.create_issue(
+        title=f"test issue {issue}",
+        body="body",
+        labels=["type:feature"],
+        slug=f"test-{issue}",
+    )
+
+
+def _make_runner(
+    tmp_path: Path, workflow: Workflow, issue: int = 99, **kwargs: object
+) -> WorkflowRunner:
+    config = _make_config(tmp_path)
+    _ensure_local_issue(tmp_path, issue)
+    return WorkflowRunner(
+        workflow=workflow,
+        issue_number=str(issue),
+        project_root=tmp_path,
+        artifacts_dir=tmp_path / ".kaji-artifacts",
+        config=config,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _single_step_workflow() -> Workflow:
+    return Workflow(
+        name="single",
+        description="one agent step",
+        execution_policy="auto",
+        steps=[
+            Step(
+                id="implement",
+                skill="issue-implement",
+                agent="claude",
+                on={"PASS": "end", "RETRY": "end", "ABORT": "end", "BACK": "end"},
+            ),
+        ],
+    )
+
+
+def _cycle_workflow() -> Workflow:
+    return Workflow(
+        name="cycle",
+        description="review cycle",
+        execution_policy="auto",
+        steps=[
+            Step(
+                id="implement",
+                skill="issue-implement",
+                agent="claude",
+                on={"PASS": "review", "ABORT": "end"},
+            ),
+            Step(
+                id="review",
+                skill="issue-review",
+                agent="codex",
+                on={"PASS": "end", "RETRY": "fix", "ABORT": "end"},
+            ),
+            Step(
+                id="fix",
+                skill="issue-fix-code",
+                agent="claude",
+                resume="implement",
+                on={"PASS": "verify", "ABORT": "end"},
+            ),
+            Step(
+                id="verify",
+                skill="issue-verify-code",
+                agent="codex",
+                on={"PASS": "end", "RETRY": "fix", "ABORT": "end"},
+            ),
+        ],
+        cycles=[
+            CycleDefinition(
+                name="code-review",
+                entry="review",
+                loop=["fix", "verify"],
+                max_iterations=3,
+                on_exhaust="ABORT",
+            ),
+        ],
+    )
+
+
+def _run_root(tmp_path: Path, issue: int = 99) -> Path:
+    """``.kaji-artifacts/local-pc1-<issue>/runs/<run_id>/`` の最新 run dir。"""
+    runs = tmp_path / ".kaji-artifacts" / f"local-pc1-{issue}" / "runs"
+    run_dirs = sorted(p for p in runs.iterdir() if p.is_dir())
+    assert run_dirs, f"no run dir under {runs}"
+    return run_dirs[-1]
+
+
+def _verdict_sources(run_dir: Path) -> list[dict[str, str]]:
+    log = run_dir / "run.log"
+    events = []
+    for line in log.read_text(encoding="utf-8").splitlines():
+        entry = json.loads(line)
+        if entry.get("event") == "verdict_source":
+            events.append(entry)
+    return events
+
+
+@pytest.mark.medium
+class TestRunnerStdoutNormalization:
+    def test_stdout_only_normalized_to_attempt_verdict_yaml(self, tmp_path: Path) -> None:
+        """agent が verdict.yaml を書かない（stdout のみ）→ stdout 解決し、
+        attempt-001/verdict.yaml に正規化保存される。"""
+        workflow = _single_step_workflow()
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            return _cli_result("PASS")
+
+        with (
+            patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+            patch("kaji_harness.runner.validate_skill_exists"),
+        ):
+            state = _make_runner(tmp_path, workflow).run()
+
+        assert state.last_completed_step == "implement"
+        run_dir = _run_root(tmp_path)
+        attempt = run_dir / "steps" / "implement" / "attempt-001"
+        vfile = attempt / "verdict.yaml"
+        assert vfile.exists(), "stdout 解決でも verdict.yaml が正規化保存される"
+        loaded = load_verdict_yaml(vfile, VALID)
+        assert loaded.status == "PASS"
+        sources = _verdict_sources(run_dir)
+        assert sources and sources[-1]["source"] == "stdout"
+        assert sources[-1]["attempt"] == "attempt-001"
+        # prompt.txt も保存される
+        assert (attempt / "prompt.txt").exists()
+
+
+@pytest.mark.medium
+class TestRunnerArtifactPrimary:
+    def test_artifact_wins_over_divergent_stdout(self, tmp_path: Path) -> None:
+        """agent が verdict.yaml=PASS を書く。stdout は ABORT。artifact を採用。"""
+        workflow = _single_step_workflow()
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            log_dir = kwargs["log_dir"]
+            assert isinstance(log_dir, Path)
+            write_verdict_yaml(
+                log_dir / "verdict.yaml",
+                Verdict(status="PASS", reason="agent wrote", evidence="e", suggestion=""),
+            )
+            return _cli_result("ABORT")  # stdout は別 verdict
+
+        with (
+            patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+            patch("kaji_harness.runner.validate_skill_exists"),
+        ):
+            state = _make_runner(tmp_path, workflow).run()
+
+        assert state.step_history[-1].verdict_status == "PASS"
+        assert state.step_history[-1].verdict_reason == "agent wrote"
+        run_dir = _run_root(tmp_path)
+        sources = _verdict_sources(run_dir)
+        assert sources[-1]["source"] == "artifact"
+
+
+@pytest.mark.medium
+class TestRunnerCycleAttemptSeparation:
+    def test_retry_creates_separate_attempt_dirs(self, tmp_path: Path) -> None:
+        """RETRY ループで同一 step が 2 回 dispatch → attempt-001 / attempt-002 が
+        各々の verdict.yaml を持ち、誤って共有しない。"""
+        workflow = _cycle_workflow()
+        # implement → review(RETRY) → fix → verify(RETRY) → fix → verify(PASS)
+        results = iter(
+            [
+                _cli_result("PASS", "s-impl"),
+                _cli_result("RETRY", "s-rev1"),
+                _cli_result("PASS", "s-fix1"),
+                _cli_result("RETRY", "s-ver1"),
+                _cli_result("PASS", "s-fix2"),
+                _cli_result("PASS", "s-ver2"),
+            ]
+        )
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            return next(results)
+
+        with (
+            patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+            patch("kaji_harness.runner.validate_skill_exists"),
+        ):
+            state = _make_runner(tmp_path, workflow).run()
+
+        assert state.last_completed_step == "verify"
+        run_dir = _run_root(tmp_path)
+        fix_steps = run_dir / "steps" / "fix"
+        assert (fix_steps / "attempt-001" / "verdict.yaml").exists()
+        assert (fix_steps / "attempt-002" / "verdict.yaml").exists()
+        verify_steps = run_dir / "steps" / "verify"
+        assert (verify_steps / "attempt-001" / "verdict.yaml").exists()
+        assert (verify_steps / "attempt-002" / "verdict.yaml").exists()
+        # attempt-001 と attempt-002 は別個（共有しない）
+        assert (verify_steps / "attempt-001" / "verdict.yaml").read_text() != (
+            verify_steps / "attempt-002" / "verdict.yaml"
+        ).read_text()
+
+
+class _CommentProvider:
+    """real LocalProvider に委譲しつつ ``view_issue`` のみ制御 comment を返す。
+
+    comment fallback の wiring を runner レベルで検証するための注入用 provider。
+    ``resolve_issue_context`` は実 provider に委譲し、``resolve_pr_context`` は
+    no-op（None）。
+    """
+
+    def __init__(self, real: LocalProvider, comments: list[Comment]) -> None:
+        self._real = real
+        self._comments = comments
+
+    def resolve_issue_context(self, rid: str) -> object:
+        return self._real.resolve_issue_context(rid)
+
+    def resolve_pr_context(self, branch_name: str) -> None:
+        return None
+
+    def view_issue(self, issue_id: str) -> object:
+        return SimpleNamespace(comments=list(self._comments))
+
+
+@pytest.mark.medium
+class TestRunnerCommentFallback:
+    def test_current_comment_adopted_when_no_artifact_no_stdout(self, tmp_path: Path) -> None:
+        """artifact 無し + stdout に verdict 無し + 現在 attempt 以降の comment 有り
+        → comment で解決し、verdict.yaml に正規化保存される。"""
+        workflow = _single_step_workflow()
+        config = _make_config(tmp_path)
+        _ensure_local_issue(tmp_path, 99)
+        real = LocalProvider(repo_root=tmp_path, machine_id="pc1")
+        # far-future timestamp → 必ず attempt_started_at 以降に scope される
+        comment = Comment(
+            author="agent",
+            body=_verdict_block("PASS", reason="from comment"),
+            created_at="2099-01-01T00:00:00Z",
+        )
+        fake = _CommentProvider(real, [comment])
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            return _cli_result(None)  # stdout に verdict 無し / artifact も書かない
+
+        runner = WorkflowRunner(
+            workflow=workflow,
+            issue_number="99",
+            project_root=tmp_path,
+            artifacts_dir=tmp_path / ".kaji-artifacts",
+            config=config,
+        )
+        with (
+            patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+            patch("kaji_harness.runner.validate_skill_exists"),
+            patch("kaji_harness.runner.get_provider", return_value=fake),
+        ):
+            state = runner.run()
+
+        assert state.step_history[-1].verdict_status == "PASS"
+        assert state.step_history[-1].verdict_reason == "from comment"
+        run_dir = _run_root(tmp_path)
+        sources = _verdict_sources(run_dir)
+        assert sources[-1]["source"] == "comment"
+        vfile = run_dir / "steps" / "implement" / "attempt-001" / "verdict.yaml"
+        assert vfile.exists()
+        assert load_verdict_yaml(vfile, VALID).status == "PASS"
+
+    def test_stale_comment_excluded_on_resume(self, tmp_path: Path) -> None:
+        """resume(--from) 経由で、前 attempt の古い comment(created_at < 現在 attempt)
+        のみ存在し artifact / stdout が無い場合、古い comment を採用せず VerdictNotFound。"""
+        workflow = _single_step_workflow()
+        config = _make_config(tmp_path)
+        _ensure_local_issue(tmp_path, 99)
+        real = LocalProvider(repo_root=tmp_path, machine_id="pc1")
+        # far-past timestamp → 現在 attempt の dispatch より前 = stale
+        stale = Comment(
+            author="agent",
+            body=_verdict_block("PASS", reason="stale prev attempt"),
+            created_at="2000-01-01T00:00:00Z",
+        )
+        fake = _CommentProvider(real, [stale])
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            return _cli_result(None)  # artifact も stdout verdict も無し
+
+        runner = WorkflowRunner(
+            workflow=workflow,
+            issue_number="99",
+            project_root=tmp_path,
+            artifacts_dir=tmp_path / ".kaji-artifacts",
+            config=config,
+            from_step="implement",
+        )
+        with (
+            patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+            patch("kaji_harness.runner.validate_skill_exists"),
+            patch("kaji_harness.runner.get_provider", return_value=fake),
+            pytest.raises(VerdictNotFound),
+        ):
+            runner.run()
+
+    def test_stale_comment_excluded_on_retry(self, tmp_path: Path) -> None:
+        """retry ループの 2 回目 dispatch（cycle 内で同一 step を再 dispatch）で、
+        前段までに投稿された古い comment(created_at < 当該 attempt) のみが存在し
+        artifact / stdout verdict が無い場合、古い comment を採用せず VerdictNotFound。
+
+        前段までの dispatch は stdout verdict で解決させ、最後の fix 再 dispatch だけ
+        verdict を一切出さない状況を作る。stale comment は far-past 固定なので、
+        どの attempt の ``attempt_started_at`` より前に位置し常に除外される。"""
+        workflow = _cycle_workflow()
+        config = _make_config(tmp_path)
+        _ensure_local_issue(tmp_path, 99)
+        real = LocalProvider(repo_root=tmp_path, machine_id="pc1")
+        stale = Comment(
+            author="agent",
+            body=_verdict_block("PASS", reason="stale prev attempt"),
+            created_at="2000-01-01T00:00:00Z",
+        )
+        fake = _CommentProvider(real, [stale])
+        # implement(PASS) → review(RETRY) → fix#1(PASS) → verify(RETRY) → fix#2(verdict 無し)
+        results = iter(
+            [
+                _cli_result("PASS"),
+                _cli_result("RETRY"),
+                _cli_result("PASS"),
+                _cli_result("RETRY"),
+                _cli_result(None),  # fix attempt-002: artifact も stdout verdict も無し
+            ]
+        )
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            return next(results)
+
+        runner = WorkflowRunner(
+            workflow=workflow,
+            issue_number="99",
+            project_root=tmp_path,
+            artifacts_dir=tmp_path / ".kaji-artifacts",
+            config=config,
+        )
+        with (
+            patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+            patch("kaji_harness.runner.validate_skill_exists"),
+            patch("kaji_harness.runner.get_provider", return_value=fake),
+            pytest.raises(VerdictNotFound),
+        ):
+            runner.run()
+        # fix は 2 回 dispatch され、2 回目は stale comment を採らず解決失敗している
+        run_dir = _run_root(tmp_path)
+        assert (run_dir / "steps" / "fix" / "attempt-001").is_dir()
+        assert (run_dir / "steps" / "fix" / "attempt-002").is_dir()
+
+
+@pytest.mark.medium
+class TestRunnerLegacyLayoutCompat:
+    def test_new_run_coexists_with_legacy_flat_layout(self, tmp_path: Path) -> None:
+        """旧 flat layout (runs/<old_run_id>/<step_id>/) が残っていても、
+        新 run は steps/<step_id>/attempt-NNN/ で正常完了し crash しない。"""
+        workflow = _single_step_workflow()
+        # 旧 layout を事前作成（attempt 無しの flat 構造）
+        legacy = tmp_path / ".kaji-artifacts" / "local-pc1-99" / "runs" / "2401010000" / "implement"
+        legacy.mkdir(parents=True, exist_ok=True)
+        (legacy / "stdout.log").write_text("legacy run stdout", encoding="utf-8")
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            return _cli_result("PASS")
+
+        with (
+            patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+            patch("kaji_harness.runner.validate_skill_exists"),
+        ):
+            state = _make_runner(tmp_path, workflow).run()
+
+        assert state.last_completed_step == "implement"
+        # 旧 layout は温存される
+        assert (legacy / "stdout.log").exists()
+        # 新 run は新 layout
+        runs = tmp_path / ".kaji-artifacts" / "local-pc1-99" / "runs"
+        new_runs = [p for p in runs.iterdir() if p.is_dir() and p.name != "2401010000"]
+        assert len(new_runs) == 1
+        assert (new_runs[0] / "steps" / "implement" / "attempt-001" / "verdict.yaml").exists()


### PR DESCRIPTION
## Summary

artifact の `verdict.yaml` を primary verdict source とし、Issue comment の `---VERDICT---` block → stdout parse の fallback チェーンを実装する。あわせて artifact/log layout を `runs/<run_id>/steps/<step_id>/attempt-NNN/` 構造へ移行し、verdict を attempt 単位で保存できるようにする。

Closes #220

## Changes

- `kaji_harness/verdict.py`: artifact verdict 解決ロジック（primary: `verdict.yaml` → fallback: Issue comment → stdout parse）を追加
- `kaji_harness/runner.py`: verdict 解決を新ロジックへ移行、attempt layout 対応
- `kaji_harness/logger.py`: attempt ディレクトリ構造 (`attempt-NNN/`) への出力対応
- `kaji_harness/prompt.py`: verdict.yaml 書き込み指示をプロンプトへ注入
- `tests/`: verdict artifact の単体・統合・e2e テストを追加

## Documentation

- `docs/adr/005-artifact-primary-verdict.md`: 設計書を恒久 ADR としてアーカイブ
- `docs/ARCHITECTURE.md`, `docs/dev/skill-authoring.md`, `docs/dev/shared_skill_rules.md`, `docs/reference/python/logging.md`: 実装に合わせて更新

## Test Plan

- [x] 既存テストがパス (`make check`)
- [x] 新規テスト追加: `test_verdict_artifact.py`, `test_verdict_artifact_e2e_large_local.py`, `test_verdict_artifact_runner.py`