### PR TITLE
fix: issue-start の NOTE ブロック blank line 欠落を deterministic 経路で修正 (#200)

### DIFF
--- a/.claude/skills/issue-start/SKILL.md
+++ b/.claude/skills/issue-start/SKILL.md
@@ -105,26 +105,20 @@ git worktree list
 
 ### Step 4: Issue本文にメタ情報を追記
 
-Issue本文の先頭にWorktree情報を追記します:
+Issue本文の先頭にWorktree情報を追記します。本文合成は `kaji` 内部の決定的な
+Python 経路（`build_worktree_note_body`）が担うため、エージェントは単一トークン
+引数を 3 つ渡すだけでよい（multi-line 本文を自前で組み立てない）:
 
 ```bash
-# 現在のIssue本文を取得
-CURRENT_BODY=$(kaji issue view [issue_id] --json body -q '.body')
-
-# メタ情報を先頭に追加した新しい本文を作成
 WT_BASENAME=$(basename "$WT")
-NEW_BODY=$(cat <<EOF
-> [!NOTE]
-> **Worktree**: \`../$WT_BASENAME\`
-> **Branch**: \`$BRANCH\`
-
-$CURRENT_BODY
-EOF
-)
-
-# Issue本文を更新
-kaji issue edit [issue_id] --commit --body "$NEW_BODY"
+kaji issue prepend-note [issue_id] --worktree "$WT_BASENAME" --branch "$BRANCH" --commit
 ```
+
+`kaji issue prepend-note` は現在の Issue 本文を取得し、`> [!NOTE]` メタブロックと
+本文の間に **空行ちょうど 1 行** を保証して合成・更新する。blank line がエージェント
+ではなく Python 文字列リテラルに固定されるため、どのモデルでも blockquote と本文
+heading が密着しない（Issue #200）。`--commit` は local provider で `issue.md` を
+atomic commit する（github では silent に無視）。
 
 ### Step 5: セットアップ完了報告
 

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T150717Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T150717Z-p1.md
@@ -1,0 +1,74 @@
+---
+author: p1
+created_at: '2026-06-04T15:07:17Z'
+---
+## 設計書作成完了
+
+設計書を作成しました。
+
+### 成果物
+
+- **ファイル**: `draft/design/issue-local-p1-25-interactive-terminal-runner-real-cli-poc.md`
+- **コミット**: fe871f1
+
+### 設計の要点
+
+1. **What**: `agent_runner="interactive_terminal"` の PoC runner が実 Claude/Codex CLI を kitty 上で起動し、各 agent が attempt prompt を読んで `verdict.yaml` を artifact として書く経路を、main 非汚染で検証する。
+2. **Why**: stdout 非 parse + artifact 出現 polling という headless と異なる契約は、mock unit test では再現不能で、実 CLI dogfooding でしか確認できない。
+3. **Constraints**: kitty 必須 / 実 claude・codex バイナリ必須 / 全成果物を worktree 内に閉じ main へ merge しない / verdict は artifact を一次ソースとする。
+
+### テスト戦略
+
+- 変更タイプ: **PoC 検証（実行時コード変更なし）**。新規恒久回帰テストは追加しない（`testing-convention.md` 4 条件を充足。実 kitty + 実 CLI 起動は GUI/対話・課金依存で CI 再現不能）。
+- 変更固有検証 (a) 実 CLI 起動 (b) `verdict.yaml` pure YAML 出力 (c) `run.log` の `verdict_source=artifact` を観測。
+- runner 引数バリデーション・分岐は既存 `tests/test_interactive_terminal.py` 等が Small で担保。
+
+### Self-Check 結果（design pre-handoff）
+
+- **経路**: main-session self-check
+- **対象 commit**: fe871f1
+- **参照 rubric**: `/issue-review-design` SKILL.md Step 1.5 / Step 2 § type 重み付け / Step 2 § レビュー基準 1〜5
+
+#### Step 1.5: Gate Check（一次情報）
+- 判定: ✅
+- 根拠: 「参照情報（Primary Sources）」に 6 件、各々 URL/パス + 設計判断の裏付け引用を記載。
+
+#### Step 2 § type 重み付け（type: feature）
+- 判定: ✅
+- 根拠: IF 設計（既存契約の型・エラー）・使用例・代替案・S/M/L 検証観点を重点的に記述。
+
+#### Step 2 § レビュー基準 1〜5
+- 1. 抽象化と責務の分離: ✅
+- 2. インターフェース設計: ✅（型・使用例・エラー定義あり）
+- 3. 信頼性とエッジケース: ✅（kitty/CLI 不在・polling 非同期性を制約に明示）
+- 4. 検証可能性: ✅（変更タイプ判定 + 省略理由 4 条件 + 変更固有検証）
+- 5. 影響ドキュメント: ✅
+
+#### 補完した項目
+- 無し
+
+#### Self-Check Verdict
+- **Yes** — handoff 可（全 ✅）
+
+### 完了条件の段階確認
+
+この段階で確認可能な完了条件:
+
+- [x] design step が draft design document を生成: ✅ 本設計書を作成・コミット
+- [ ] review-design step が pure YAML artifact verdict を生成: review-design 段階で確認予定
+- [ ] run.log が verdict_source=artifact を記録: 後続 step 実行時に確認予定
+
+### 次のステップ
+
+`/issue-review-design local-p1-25` でレビューをお願いします。
+
+---VERDICT---
+status: PASS
+reason: "PoC interactive terminal runner の real CLI 検証設計書を作成・コミット完了"
+evidence: |
+  draft/design/issue-local-p1-25-interactive-terminal-runner-real-cli-poc.md を作成（commit fe871f1）。
+  必須セクション（概要/背景・目的/インターフェース/制約/変更スコープ/方針/テスト戦略/影響ドキュメント/Primary Sources）を充足。
+  Self-Check は review-design rubric 全 5 観点 + Gate Check で ✅。
+  本 design step 自体が interactive_terminal runner（実 Claude CLI 起動 → prompt 読込 → verdict.yaml 書出）の live 検証となっている。
+suggestion: "/issue-review-design local-p1-25 でレビューを実施してください。"
+---END_VERDICT---

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T151633Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T151633Z-p1.md
@@ -1,0 +1,51 @@
+---
+author: p1
+created_at: '2026-06-04T15:16:33Z'
+---
+# 設計レビュー結果
+
+## 参照した一次情報
+
+| 情報源 | 確認結果 |
+|--------|----------|
+| `kaji_harness/interactive_terminal.py` | ✅ 設計と整合。`step.agent` の必須/対応 agent 検証、`prompt_path` 存在確認、`kitty --detach --hold <wrapper> <agent> <prompt_path> <verdict_path> <workdir>` 起動、`verdict_path.is_file()` polling、`CLIResult(full_output="")` 返却を確認。 |
+| `assets/interactive-terminal/wrapper.sh` | ✅ 設計と整合。`workdir` へ `cd` し、agent へ「prompt_path を読み、verdict_path に pure YAML を書く」初期 prompt を渡す。`claude` と `codex --cd "$workdir" --dangerously-bypass-approvals-and-sandbox` の分岐を確認。 |
+| `kaji_harness/runner.py` | ✅ 設計と整合。`agent_runner == "interactive_terminal"` で `execute_interactive_terminal` を呼び、attempt 配下の `prompt.txt` と `verdict.yaml` を渡す。`dispatch` も `interactive_terminal` として記録される。 |
+| `kaji_harness/config.py` | ✅ 設計と整合。`ExecutionConfig.agent_runner` は `Literal["headless", "interactive_terminal"]` で、設定値検証も `headless` / `interactive_terminal` のみ許容。 |
+| `kaji_harness/verdict.py` / `kaji_harness/logger.py` | ✅ 設計と整合。`resolve_verdict` は `attempt_dir/verdict.yaml` を最優先し source=`artifact` を返す。`RunLogger.log_verdict_source` は source と attempt を `run.log` に記録する。 |
+| `docs/dev/testing-convention.md` | ✅ 設計と整合。実行時コード変更なしの PoC 検証として恒久テストを追加しない理由を 4 条件に沿って記載し、実 kitty + 実 CLI は CI 再現困難な変更固有検証として扱っている。 |
+
+## 概要
+
+設計は、interactive_terminal runner の検証目的、対象インターフェース、制約、artifact-first verdict 解決、run.log 観測点を具体的に定義している。type:feature として重みの高い IF/使用例、信頼性、検証可能性はいずれも実装着手可能な粒度に達している。
+
+## 指摘事項 (Must Fix)
+
+なし。
+
+## 改善提案 (Should Fix)
+
+- `worktree_dir` と実行 workspace が異なる場合に備え、検証時に参照する一次情報の基準 workspace を明記すると、後続レビューでの迷いが減る。
+
+## 完了条件の段階確認
+
+設計段階の完了条件に対する充足判定:
+
+- Acceptance Criteria: design step produces a draft design document or aborts with a concrete reason: ✅ `draft/design/issue-local-p1-25-interactive-terminal-runner-real-cli-poc.md` が存在し、設計内容と primary sources が記載されている。
+- Acceptance Criteria: review-design step reads the design attempt context and produces a pure YAML artifact verdict: ✅ 本 review-design step の prompt を読み、verdict artifact を `/home/aki/dev/kaji/.kaji-artifacts/local-p1-25/runs/2606050013/steps/review-design/attempt-001/verdict.yaml` に書く前提でレビューを実施している。
+- Acceptance Criteria: run log records artifact as the verdict source for attempted real-agent steps: ✅ 設計は `resolve_verdict` artifact-first と `log_verdict_source` の観測点を明記しており、現 run.log でも review-design attempt の `dispatch` が `interactive_terminal` と記録されている。source 記録は verdict 解決後に runner が行うため、本 step 完了後の確認対象。
+
+## 判定
+
+[x] Approve (実装着手可)
+[ ] Changes Requested (設計修正が必要)
+
+---VERDICT---
+status: PASS
+reason: "設計品質基準を満たしており、実装着手可能"
+evidence: |
+  Issue local-p1-25 は type:feature であり、設計書はユースケース、代替案、既存 runner IF、使用例、制約、検証点を具体化している。
+  一次情報として kaji_harness/interactive_terminal.py、assets/interactive-terminal/wrapper.sh、kaji_harness/runner.py、kaji_harness/config.py、kaji_harness/verdict.py、kaji_harness/logger.py、docs/dev/testing-convention.md を確認し、設計の主要主張と整合していた。
+  テスト戦略は実行時コード変更なしの PoC 検証として恒久テストを追加しない理由を testing-convention.md の 4 条件に沿って説明し、実 kitty + 実 claude/codex 起動、artifact verdict、run.log verdict_source=artifact を変更固有検証として定義している。
+suggestion: ""
+---END_VERDICT---

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T153043Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T153043Z-p1.md
@@ -1,0 +1,62 @@
+---
+author: p1
+created_at: '2026-06-04T15:30:43Z'
+---
+## 設計書作成完了
+
+設計書は既に worktree `feat/local-p1-25` 内に作成・コミット済みです（本 design step 実行時点で deliverable は充足）。
+
+### 成果物
+
+- **ファイル**: `draft/design/issue-local-p1-25-interactive-terminal-runner-real-cli-poc.md`
+- **コミット**: `fe871f1 docs: add design for local-p1-25`
+
+### 設計の要点
+
+1. **What**: `agent_runner = "interactive_terminal"` の PoC runner が実 Claude / Codex の対話型 CLI を kitty 上で起動し、各 agent が attempt prompt を読んで `verdict.yaml` を artifact として書く経路を、main 非汚染で feature-development workflow 上で検証する。
+2. **Why**: interactive_terminal は「stdout 非 parse・artifact 出現 polling」という headless と根本的に異なる契約を持ち、実 CLI での成立は自動 unit test では担保不能。dogfooding（実行＝観測）でしか確認できない。
+3. **Constraints**: kitty 必須 / 実 `claude`・`codex` バイナリ必須 / 全成果物を worktree 内に閉じ main へ merge しない / verdict は artifact 一次ソース（Issue #220 依存）。
+
+### テスト戦略
+
+- 変更タイプ = PoC 検証（実行時コード変更なし）。恒久回帰テストは追加せず、`testing-convention.md` 4 条件（独自ロジック非追加 / 既存ゲートで捕捉 / 回帰情報増えない / 省略理由レビュー可）で省略を正当化。
+- 変更固有検証 (a) 実 CLI 起動・完走 (b) 各 attempt の `verdict.yaml` が pure YAML (c) `run.log` の `verdict_source=artifact` を design / review-design 両 step で確認。
+
+### Self-Check 結果（design pre-handoff）
+
+- **経路**: main-session self-check
+- **対象 commit**: fe871f1
+- **参照 rubric**: `/issue-review-design` SKILL.md Step 1.5 / Step 2 § type 重み付け / Step 2 § レビュー基準 1〜5
+
+#### Step 1.5: Gate Check（一次情報）
+- 判定: ⚠️
+- 根拠: 「参照情報（Primary Sources）」に実装ファイルのパスと契約挙動の要約/引用を記載済み。ただし `kaji_harness/interactive_terminal.py` / `assets/interactive-terminal/wrapper.sh` は本 worktree（feat/local-p1-25、main 由来）には存在せず poc/subscription-runner-real-cli 側に実在する。アクセス可能性ルールの「該当箇所を引用」フォールバックで Primary Sources 表の「根拠」列に契約を要約済みのため gate は通過するが、review-design 側でパス直読を試みると不在となる点を明示。
+
+#### Step 2 § type 重み付け（type: feature）
+- 判定: ✅
+- 根拠: 代替案表（headless 流用 / mock unit test / main merge の不採用理由）、ユースケース（kaji maintainer 視点）、使用例（config.toml + kaji run 起動形態）を記載。
+
+#### Step 2 § レビュー基準 1〜5
+- 1. 抽象化と責務の分離: ✅（検証スコープと What/Why/Constraints を分離記述）
+- 2. インターフェース設計: ✅（既存 `execute_interactive_terminal` の引数契約・副作用・観測成果物を明示）
+- 3. 信頼性とエッジケース: ✅（polling 非同期・終了コード非伝播・artifact 真偽委譲を制約に明記）
+- 4. 検証可能性: ✅（変更固有検証 (a)(b)(c) + Small/Medium/Large 省略理由を 4 条件にマップ）
+- 5. 影響ドキュメント: ✅（全行「なし」+ 恒久昇格時は別 Issue で ADR/cli-guides の注記）
+
+#### 補完した項目
+- 無し（既存設計書が全必須セクションを充足。今回 design step では新規修正不要）
+
+#### Self-Check Verdict
+- **Yes** — handoff 可（Step 1.5 のみ ⚠️ だが quote フォールバックで gate 通過。実装パス不在は PoC の branch 分離に起因する既知事項で設計修正対象ではない）
+
+### 完了条件の段階確認
+
+設計段階で確認可能な Acceptance Criteria:
+
+- [x] design step が draft 設計書を産出（または concrete reason で abort）: ✅ `draft/design/issue-local-p1-25-...md` を産出
+- [ ] review-design が pure YAML artifact verdict を産出: 後続 review-design step で確認予定
+- [ ] run.log が attempted real-agent step の verdict source = artifact を記録: 後続 step 実行・観測で確認予定
+
+### 次のステップ
+
+`/issue-review-design local-p1-25` でレビューをお願いします。

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T153109Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T153109Z-p1.md
@@ -1,0 +1,14 @@
+---
+author: p1
+created_at: '2026-06-04T15:31:09Z'
+---
+---VERDICT---
+status: PASS
+reason: "PoC design step deliverable 充足。設計書 fe871f1 を worktree に作成・コミット済みで全必須セクションを満たす。"
+evidence: |
+  draft/design/issue-local-p1-25-interactive-terminal-runner-real-cli-poc.md（fe871f1）が
+  必須 8 セクションを充足。type:feature 単一・BACK 非該当（NON_DESIGN=0）で初回起動扱い。
+  Self-Check Verdict=Yes（Step 1.5 のみ ⚠️: 実装ファイルは poc branch 側に実在し Primary
+  Sources の引用フォールバックで gate 通過）。設計完了コメントを投稿済み。
+suggestion: "/issue-review-design local-p1-25 でレビューへ進む"
+---END_VERDICT---

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T153414Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T153414Z-p1.md
@@ -1,0 +1,71 @@
+---
+author: p1
+created_at: '2026-06-04T15:34:14Z'
+---
+# 設計レビュー結果
+
+## 参照した一次情報
+
+| 情報源 | 確認結果 |
+|--------|----------|
+| `draft/design/issue-local-p1-25-interactive-terminal-runner-real-cli-poc.md` | ✅ 設計書を確認。Primary Sources 表は存在する |
+| `kaji_harness/interactive_terminal.py` | ⚠️ 差異あり。この worktree には存在しない（`nl -ba kaji_harness/interactive_terminal.py` が `No such file or directory`） |
+| `assets/interactive-terminal/wrapper.sh` | ⚠️ 差異あり。この worktree には存在しない。`find ... -path '*/wrapper.sh'` で見つかるのは `draft/lab/headless-terminal-spawn/wrapper.sh` のみ |
+| `kaji_harness/runner.py:590-647` | ⚠️ 差異あり。現行 runner は `is_exec_script` なら `execute_script`、それ以外は `execute_cli` を呼ぶだけで、`agent_runner == "interactive_terminal"` 分岐や `execute_interactive_terminal` dispatch は存在しない |
+| `kaji_harness/config.py:27-32,143-160` | ⚠️ 差異あり。`ExecutionConfig` は `default_timeout` のみで、設計書が述べる `agent_runner: Literal["headless","interactive_terminal"]` は存在しない |
+| `kaji_harness/verdict.py:618-655` / `kaji_harness/runner.py:671-682` / `kaji_harness/logger.py:100-106` | ✅ artifact → comment → stdout の verdict 解決順と `verdict_source` ログは設計記述と整合 |
+| `docs/dev/testing-convention.md` | ✅ docs-only / metadata-only 等の恒久テスト省略条件、物理的に作成不可の扱いを確認 |
+
+## 概要
+
+設計書は Primary Sources 表を持っているため一次情報ゲートは通過します。ただし、feature として重みの高いインターフェース設計と信頼性の中核部分が、現行 worktree の一次情報と一致していません。検証対象 runner のファイル、config key、runner dispatch が存在しない前提で設計されているため、このまま実装・検証へ進むと Issue の Acceptance Criteria（real CLI 起動、artifact verdict、run.log artifact source）を満たす経路を実行できません。
+
+## 指摘事項 (Must Fix)
+
+- [ ] **検証対象 runner の一次情報が現行 worktree と不整合です**
+  - 設計書は `kaji_harness/interactive_terminal.py` と `assets/interactive-terminal/wrapper.sh` を既存実装として扱っていますが、どちらも worktree に存在しません。
+  - `rg -n "execute_interactive_terminal|interactive_terminal|agent_runner|kitty|wrapper" kaji_harness assets tests docs draft` では production code / tests に該当実装がなく、該当する wrapper は `draft/lab/headless-terminal-spawn/wrapper.sh` の lab prototype だけです。
+  - **一次情報との関連**: 設計書 Primary Sources の先頭 2 件が検証不能または stale path です。公開 IF と使用例の根拠が失われているため type:feature では Must Fix です。
+
+- [ ] **`agent_runner = "interactive_terminal"` の設定契約が現行 config schema に存在しません**
+  - 設計書の使用例は `.kaji/config.toml [execution] agent_runner = "interactive_terminal"` ですが、`kaji_harness/config.py:27-32` の `ExecutionConfig` は `default_timeout` のみです。
+  - `kaji_harness/config.py:143-160` の `[execution]` parse も `default_timeout` だけを読み、`agent_runner` を検証・保持していません。
+  - **一次情報との関連**: Primary Sources の `config 検証` 行は `agent_runner: Literal[...]` としていますが、現行コードに該当 Literal はありません。
+
+- [ ] **runner dispatch の設計が現行 runner と矛盾しています**
+  - 設計書は `runner.py: dispatch_label="interactive_terminal"` から `execute_interactive_terminal(...)` へ流れるデータフローを示しています。
+  - 現行 `kaji_harness/runner.py:590-647` は `is_exec_script` なら `execute_script`、それ以外は `execute_cli` を呼ぶ構造で、`agent_runner` や `execute_interactive_terminal` の分岐はありません。
+  - `kaji_harness/runner.py:657-682` の artifact verdict 解決は存在しますが、interactive terminal runner を起動する前段がないため PoC の観測点 (a)(b) に到達できません。
+
+- [ ] **既存テストへの言及が不正確です**
+  - 設計書は `tests/test_interactive_terminal.py` が Small で担保するとしていますが、`rg --files tests | rg 'interactive|verdict_artifact|config'` で `tests/test_interactive_terminal.py` は存在しません。
+  - 恒久テストを追加しない理由の根拠として存在しないテストを挙げているため、testing-convention の「既存ゲートで捕捉済み」を満たす説明になっていません。
+
+## 改善提案 (Should Fix)
+
+- `draft/lab/headless-terminal-spawn/` の prototype を今回の検証対象にするのか、production runner を新設するのかを設計で明確化してください。Issue 要件が「既存 runner の検証」ではなく「PoC runner を feature worktree 内で作って検証」なら、変更スコープとテスト戦略も runtime code change として書き直す必要があります。
+
+## 完了条件の段階確認
+
+Issue 本文には `## 完了条件` セクションはありません。Acceptance Criteria に対する段階確認は以下です。
+
+- [ ] design step が draft design document または concrete abort reason を出す: ✅ 本設計書は存在する
+- [ ] review-design step が design attempt context を読み pure YAML artifact verdict を出す: ✅ 本レビューで `verdict.yaml` を出力する
+- [ ] run log が artifact を verdict source として記録する: ⚠️ artifact verdict 解決ロジック自体は `runner.py:671-682` と `logger.py:100-106` に存在するが、設計が前提にする interactive_terminal dispatch が存在しないため、後続 PoC の AC 達成構造としては不足
+
+## 判定
+
+[ ] Approve (実装着手可)
+[x] Changes Requested (設計修正が必要)
+
+---VERDICT---
+status: RETRY
+reason: "設計書の中核である interactive_terminal runner / agent_runner 設定 / wrapper の一次情報が現行 worktree と一致せず、Issue の real CLI 検証経路を実行できる設計になっていない"
+evidence: |
+  - `kaji_harness/interactive_terminal.py` は存在せず、設計書 Primary Sources の `execute_interactive_terminal` 根拠を確認できない。
+  - `assets/interactive-terminal/wrapper.sh` は存在せず、見つかる wrapper は `draft/lab/headless-terminal-spawn/wrapper.sh` の lab prototype のみ。
+  - `kaji_harness/config.py:27-32` の `ExecutionConfig` は `default_timeout` のみで、設計書の `agent_runner: Literal["headless","interactive_terminal"]` は存在しない。
+  - `kaji_harness/runner.py:590-647` は `execute_script` / `execute_cli` の dispatch のみで、`agent_runner == "interactive_terminal"` や `execute_interactive_terminal` への分岐がない。
+  - `tests/test_interactive_terminal.py` は存在せず、恒久テスト省略理由で参照している既存テスト根拠が不正確。
+suggestion: "設計書を現行コードに合わせて修正し、interactive terminal を既存 lab prototype として手動検証するのか、production runner/config/dispatch を feature worktree 内で追加して検証するのかを明確にしてください。"
+---END_VERDICT---

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T155058Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T155058Z-p1.md
@@ -1,0 +1,54 @@
+---
+author: p1
+created_at: '2026-06-04T15:50:58Z'
+---
+# 設計レビュー結果
+
+## 参照した一次情報
+
+| 情報源 | 確認結果 |
+|--------|----------|
+| `/home/aki/dev/kaji-poc-subscription-runner-real-cli/kaji_harness/interactive_terminal.py` | 差異あり: 設計書は `kitty --detach --hold` と記載しているが、実装は `kitty --hold` で `wrapper.sh` を起動し、`close_on_verdict` により verdict 出現後に terminal process を terminate する |
+| `/home/aki/dev/kaji-poc-subscription-runner-real-cli/assets/interactive-terminal/wrapper.sh` | 差異あり: 設計書は `claude "$initial_prompt"` / `codex --cd "$workdir" "$initial_prompt"` と記載しているが、実際は `script` 経由で transcript を取り、`claude --dangerously-skip-permissions` / `codex --cd ... --dangerously-bypass-approvals-and-sandbox` を exec する |
+| `/home/aki/dev/kaji-poc-subscription-runner-real-cli/kaji_harness/runner.py:647-657` | 設計と概ね整合: `agent_runner == "interactive_terminal"` で `execute_interactive_terminal` を dispatch し、`close_on_verdict` も渡している |
+| `/home/aki/dev/kaji-poc-subscription-runner-real-cli/kaji_harness/config.py:32,168-184` | 設計と概ね整合: `agent_runner` は `headless` / `interactive_terminal` に制限され、`interactive_terminal_close_on_verdict` も設定として扱われる |
+| `/home/aki/dev/kaji-poc-subscription-runner-real-cli/tests/test_interactive_terminal.py` | 差異あり: 設計書は Small が引数バリデーション中心と記載しているが、実テストは launch / close_on_verdict / missing kitty / timeout と wrapper transcript の Medium も含む |
+| `/home/aki/dev/kaji-poc-subscription-runner-real-cli/docs/dev/testing-convention.md` | 整合: 実 CLI + GUI 依存を恒久 Large test にしない判断は、物理的に作成不可・CI 再現不能の省略理由と整合 |
+
+## 概要
+
+Changes Requested。一次情報の記載自体はあるが、検証対象である interactive_terminal runner の起動契約と wrapper 契約が現行ソースと食い違っている。Issue の主目的が「real CLI を起動して artifact verdict を観測する」ことなので、ここは Must Fix として設計書を修正してから実装・検証へ進むべき。
+
+## 指摘事項 (Must Fix)
+
+- [ ] **Primary Sources の runner 起動契約を現行実装に合わせる**: 設計書の `kitty --detach --hold` 記載は、現行 `interactive_terminal.py` の argv と一致しない。実装は `kitty`, `--hold`, `wrapper`, `agent`, `prompt_path`, `verdict_path`, `terminal.log`, `workdir` の順で起動し、`close_on_verdict` が true の場合は verdict 出現後に `_close_terminal(process)` で terminal process を閉じる。この差異は検証対象 IF そのものなので、設計書の「出力」「データフロー」「Primary Sources」を更新すること。
+  - **一次情報との関連**: `kaji_harness/interactive_terminal.py:43-52`, `kaji_harness/interactive_terminal.py:67-75`, `kaji_harness/interactive_terminal.py:78-87`
+
+- [ ] **wrapper.sh の agent 実行契約を現行実装に合わせる**: 設計書は `claude "$initial_prompt"` / `codex --cd "$workdir" "$initial_prompt"` と記載しているが、現行 wrapper は `script --quiet --flush --command ... "$terminal_log"` で transcript を取り、`claude --dangerously-skip-permissions` および `codex --cd "$workdir" --dangerously-bypass-approvals-and-sandbox` を実行する。実 CLI 起動検証の前提条件・リスク・観測成果物に関わるため、`terminal.log` と権限 bypass flag を設計に明記すること。
+  - **一次情報との関連**: `assets/interactive-terminal/wrapper.sh:22-45`
+
+## 改善提案 (Should Fix)
+
+- **テスト戦略の既存テスト説明を更新**: `tests/test_interactive_terminal.py` は引数バリデーションだけでなく、kitty 起動 argv、verdict 後 close、missing kitty、timeout、wrapper transcript を検証している。設計書の Small / Medium の説明を現行テスト実態に合わせると、後続レビューで検証範囲を追いやすくなる。
+
+## 完了条件の段階確認
+
+- `review-design step reads the design attempt context and produces a pure YAML artifact verdict`: 本レビューは prompt と設計書を読み、artifact verdict を出力予定。
+- `run log records artifact as the verdict source for the attempted real-agent steps`: 現在の `run.log` には review-design の `step_start` はあるが、このレビュー時点では `verdict_source=artifact` は未記録。verdict 書き出し後に runner 側で確認される想定。
+- `Confirm that the interactive_terminal runner can launch the real Claude and Codex interactive CLIs`: 設計はこの確認方法を示しているが、起動契約の記述が現行ソースと異なるため不足。
+- `Confirm that each real agent reads the attempt prompt and writes the requested artifact verdict.yaml`: design/review-design の観測方針はあるが、wrapper の実際の prompt 注入・transcript 記録の記述が不足。
+
+## 判定
+
+[ ] Approve (実装着手可)
+[x] Changes Requested (設計修正が必要)
+
+---VERDICT---
+status: RETRY
+reason: "設計書の Primary Sources と現行 interactive_terminal 実装に Must Fix の不整合がある"
+evidence: |
+  設計書は execute_interactive_terminal が `kitty --detach --hold <wrapper.sh> <agent> <prompt_path> <verdict_path> <workdir>` を起動すると記載しているが、現行 `/home/aki/dev/kaji-poc-subscription-runner-real-cli/kaji_harness/interactive_terminal.py:43-52` は `kitty --hold <wrapper> <agent> <prompt_path> <verdict_path> <terminal.log> <workdir>` を起動しており `--detach` は使っていない。
+  設計書は wrapper が `claude "$initial_prompt"` / `codex --cd "$workdir" "$initial_prompt"` を exec すると記載しているが、現行 `/home/aki/dev/kaji-poc-subscription-runner-real-cli/assets/interactive-terminal/wrapper.sh:31-45` は `script` で terminal transcript を記録し、`claude --dangerously-skip-permissions` / `codex --cd "$workdir" --dangerously-bypass-approvals-and-sandbox` を実行している。
+  Issue の acceptance criteria は実 Claude/Codex interactive CLI 起動と artifact verdict 観測なので、起動契約・prompt 注入・terminal.log の実態が設計に反映されていない状態では設計レビューを PASS にできない。
+suggestion: "`/issue-fix-design local-p1-25` で設計書の出力、データフロー、Primary Sources、テスト戦略を現行 interactive_terminal.py / wrapper.sh / runner.py / config.py に合わせて更新する。"
+---END_VERDICT---

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T155515Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T155515Z-p1.md
@@ -1,0 +1,36 @@
+---
+author: p1
+created_at: '2026-06-04T15:55:15Z'
+---
+# 設計修正報告
+
+前回 review-design verdict (RETRY) の Must Fix（設計書 Primary Sources と現行 `interactive_terminal` 実装の不整合）に対応した。
+
+## 対応済み
+
+- **runner 起動契約**: `kitty --detach --hold ... <verdict_path> <workdir>` → 現行実装に合わせ `kitty --hold <wrapper> <agent> <prompt_path> <verdict_path> <terminal.log> <workdir>`（`--detach` なし、`Popen(cwd=workdir)`）に修正。「出力（副作用）」「データフロー」「Primary Sources」を `interactive_terminal.py:43-52,67-87` の argv / polling / `_close_terminal` に同期。
+- **`close_on_verdict` 契約の明記**: 入力表に `close_on_verdict: bool = True` を追加。verdict 出現後の terminate（`terminate`→5s→`kill`）と debug 用に端末を残す `False` 経路、`runner.py:651-661` が `config.execution.interactive_terminal_close_on_verdict` を渡す結線を反映。
+- **wrapper.sh の agent 実行契約**: `claude "$initial_prompt"` / `codex --cd "$workdir" "$initial_prompt"` → 現行 `wrapper.sh:22-45` の `script --quiet --flush --command ... "$terminal_log"` transcript 下で `claude --dangerously-skip-permissions` / `codex --cd "$workdir" --dangerously-bypass-approvals-and-sandbox` を `exec`（`script(1)` 不在時 `bash -lc` fallback）に修正。`terminal.log` 成果物と権限 bypass のリスクを制約・出力に追記。
+- **config 一次情報**: `config.py:32-33,162-185` に合わせ `agent_runner` Literal と `interactive_terminal_close_on_verdict` の検証（不正値 `ConfigLoadError`）を Primary Sources に明記。使用例 toml にも `interactive_terminal_close_on_verdict` を追加。
+- **テスト戦略の既存テスト説明（Should Fix）**: `tests/test_interactive_terminal.py` の実態（fake `Popen` で kitty argv・verdict 後 close・missing kitty・timeout を Small、`script(1)` transcript を Medium）と `tests/test_config.py` の `agent_runner` / `close_on_verdict` 検証に Small / Medium 説明を更新。
+
+## 議論/見送り
+
+なし。指摘は全て現行実装との整合のための事実修正であり、受け入れた。
+
+## 次のステップ
+
+`/issue-verify-design local-p1-25` で修正確認をお願いします。
+
+---VERDICT---
+status: PASS
+reason: "前回 RETRY の Must Fix（kitty 起動 argv / wrapper の agent 実行契約 / config 検証 / terminal.log）を現行 interactive_terminal.py・wrapper.sh・runner.py・config.py に合わせて設計書を修正した"
+evidence: |
+  - 出力・データフロー・Primary Sources を `kitty --hold <wrapper> <agent> <prompt_path> <verdict_path> <terminal.log> <workdir>`（`--detach` なし、`Popen(cwd=workdir)`）に修正し interactive_terminal.py:43-52 と一致させた。
+  - polling 後の `close_on_verdict` 分岐（`_close_terminal`: terminate→5s→kill）を入力表・出力・制約に追記し interactive_terminal.py:67-87 と一致させた。
+  - wrapper の実行契約を `script(1)` transcript 下の `claude --dangerously-skip-permissions` / `codex --cd "$workdir" --dangerously-bypass-approvals-and-sandbox` に修正し wrapper.sh:22-45 と一致させた。terminal.log 成果物と権限 bypass リスクを明記。
+  - runner 結線を runner.py:651-661、config 検証を config.py:32-33,162-185 の行・キー（agent_runner / interactive_terminal_close_on_verdict）に更新。
+  - テスト戦略の Small/Medium 説明を tests/test_interactive_terminal.py（kitty argv・close・missing kitty・timeout・transcript）と tests/test_config.py の実態へ同期。
+  - worktree feat/local-p1-25 に commit ceb4c68 として保存。
+suggestion: "/issue-verify-design local-p1-25 で修正確認を実施する"
+---END_VERDICT---

--- a/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T155645Z-p1.md
+++ b/.kaji/issues/local-p1-25-interactive-terminal-runner-real-cli-poc/comments/20260604T155645Z-p1.md
@@ -1,0 +1,47 @@
+---
+author: p1
+created_at: '2026-06-04T15:56:45Z'
+---
+# 設計修正確認結果
+
+## 修正項目の確認
+
+| 指摘項目 | 状態 | 理由・根拠 |
+|----------|------|------------|
+| Primary Sources の runner 起動契約を現行実装に合わせる | ✅ OK | 設計書は `kitty --hold <wrapper.sh> <agent> <prompt_path> <verdict_path> <terminal.log> <workdir>` を `subprocess.Popen(cwd=workdir)` で起動し、`--detach` は使わないと明記している。これは `/home/aki/dev/kaji-poc-subscription-runner-real-cli/kaji_harness/interactive_terminal.py:43-54` の argv / Popen と一致する。`close_on_verdict`、`_close_terminal(process)` の `terminate()` → 5 秒待ち → `kill()` も設計書に反映され、同ファイル `:67-87` と一致する。 |
+| wrapper.sh の agent 実行契約を現行実装に合わせる | ✅ OK | 設計書は `terminal.log` を attempt 配下に置き、`wrapper.sh` が `script --quiet --flush --command ... "$terminal_log"` で transcript を記録し、`claude --dangerously-skip-permissions` / `codex --cd "$workdir" --dangerously-bypass-approvals-and-sandbox` を実行すると明記している。これは `/home/aki/dev/kaji-poc-subscription-runner-real-cli/assets/interactive-terminal/wrapper.sh:22-45` と一致する。 |
+| テスト戦略の既存テスト説明を更新（Should Fix） | ✅ OK | 設計書は `tests/test_interactive_terminal.py` が fake `Popen` による kitty argv、verdict 後 close、missing kitty、timeout と wrapper transcript を扱うこと、`tests/test_config.py` が `agent_runner` / `interactive_terminal_close_on_verdict` を扱うことを記載している。`rg` で該当テスト名・設定キー・interactive runner artifact テストを確認した。 |
+
+## 反論への検討結果
+
+| 見送り項目 | 検討結果 | 理由 |
+|------------|----------|------|
+| なし | - | 設計修正報告では前回指摘を全て受け入れており、見送り・議論項目はない。 |
+
+## 新規発見事項（参考情報）
+
+> **注意**: 以下は今回の判定には影響しません。verify の対象は前回指摘事項のみです。
+
+| 発見事項 | 重要度 | 推奨対応 |
+|----------|--------|----------|
+| なし | - | - |
+
+## 判定
+
+[x] Approve (実装着手可)
+[ ] Changes Requested (再修正が必要)
+
+## 次のステップ
+
+`/issue-implement local-p1-25` で実装を開始してください。
+
+---VERDICT---
+status: PASS
+reason: "前回 RETRY の Must Fix 2 件は、現行 interactive_terminal.py / wrapper.sh の起動契約・実行契約に合わせて設計書へ反映済み"
+evidence: |
+  - 設計書は `kitty --hold <wrapper.sh> <agent> <prompt_path> <verdict_path> <terminal.log> <workdir>` と `Popen(cwd=workdir)` を記載し、`--detach` を使わない点も明記している。これは `/home/aki/dev/kaji-poc-subscription-runner-real-cli/kaji_harness/interactive_terminal.py:43-54` と一致する。
+  - 設計書は verdict 出現 polling、`close_on_verdict=True` 時の `_close_terminal`、`terminate()` → 5 秒待ち → `kill()` を記載している。これは `/home/aki/dev/kaji-poc-subscription-runner-real-cli/kaji_harness/interactive_terminal.py:67-87` と一致する。
+  - 設計書は `wrapper.sh` が `script --quiet --flush --command ... "$terminal_log"` で transcript を取り、`claude --dangerously-skip-permissions` / `codex --cd "$workdir" --dangerously-bypass-approvals-and-sandbox` を実行すると記載している。これは `/home/aki/dev/kaji-poc-subscription-runner-real-cli/assets/interactive-terminal/wrapper.sh:22-45` と一致する。
+  - 設計書は runner 結線 `kaji_harness/runner.py:651-661` と config 検証 `kaji_harness/config.py:32-33,162-185`、既存テスト `tests/test_config.py` / `tests/test_interactive_terminal.py` / `tests/test_verdict_artifact_runner.py` の説明も現行 workspace の実態に同期している。
+suggestion: ""
+---END_VERDICT---

--- a/.kaji/issues/local-p1-26-poc-addition-cli/comments/20260604T163121Z-p1.md
+++ b/.kaji/issues/local-p1-26-poc-addition-cli/comments/20260604T163121Z-p1.md
@@ -1,0 +1,70 @@
+---
+author: p1
+created_at: '2026-06-04T16:31:21Z'
+---
+## 設計書作成完了
+
+設計書を作成しました。
+
+### 成果物
+
+- **ファイル**: `draft/design/issue-local-p1-26-poc-addition-cli.md`
+
+### 設計の要点
+
+1. **What**: Python で 2 つの整数を足す関数 (`add(a: int, b: int) -> int`) と CLI (`python kaji_addition.py 1 2`)
+2. **Why**: interactive_terminal runner の PoC を最小限度のスコープで設計から検証まで実 workflow に近い形で検証する
+3. **Constraints**: 標準ライブラリのみ使用。既存コードへの変更なし
+
+### テスト戦略
+
+本 PoC では以下の検証を計画:
+
+- **Small テスト**: `add(a, b)` の純粋関数テスト（正常系・境界値・負数等）
+- **Large テスト**: CLI の integration test（stdout / stderr / exit code）
+
+Medium テスト は不要（外部依存なし。testing-convention.md の 4 条件充足）
+
+### 完了条件の段階確認
+
+この段階で確認可能な完了条件:
+
+- `add(1, 2) == 3`: ✅ 設計書「インターフェース」セクションで関数仕様を定義
+- CLI で出力: ✅ 設計書「インターフェース」セクションで CLI 仕様を定義
+- テスト: ✅ 設計書「テスト戦略」セクションで検証計画を定義
+
+実装時に具体的なテストケース実装・実行で最終確認予定
+
+### Self-Check 結果（design pre-handoff）
+
+- **経路**: main-session self-check
+- **対象 commit**: 4ac4219
+- **参照 rubric**: `/issue-review-design` SKILL.md Step 1.5 / Step 2 § type 重み付け（feat） / Step 2 § レビュー基準 1〜5
+
+#### Step 1.5: Gate Check（一次情報）
+- 判定: ✅ PASS
+- 根拠: 設計書「参照情報（Primary Sources）」セクションで、Python 標準ドキュメント・pytest 公式ドキュメント・kaji 開発規約への URL を記載。すべて公開 URL でアクセス可能
+
+#### Step 2 § type 重み付け（type: feature）
+- 判定: ✅ PASS
+- 根拠: feat の重点観点（代替案/ユースケース/使用例）をすべて記載
+  - ユースケース: 「Developer として、interactive_terminal runner の PoC を検証」で明記
+  - 代替案: 「既存の複雑な Issue を使用」との比較で不採用理由を説明
+  - 使用例: 関数直接利用と CLI 利用の 2 パターンを記載
+
+#### Step 2 § レビュー基準 1〜5
+- 1. 抽象化と責務の分離: ✅ PASS — 関数とエントリポイントを明確に分離。What（何をするか）と Constraint を記載
+- 2. インターフェース設計: ✅ PASS — 入力（パラメータ型・単位・必須/任意）、出力、エラーケースを表で明記。使用例 3 パターン
+- 3. 信頼性とエッジケース: ✅ PASS — ValueError, TypeError, exit code を含むエラーケースを定義。一次情報との乖離なし
+- 4. 検証可能性: ✅ PASS — Small/Large テストを定義。Medium 不要の根拠を testing-convention.md の 4 条件に基づいて明記
+- 5. 影響ドキュメント: ✅ PASS — 表で 6 カテゴリの影響なし を確認
+
+#### 補完した項目
+- なし（初版で Self-Check 基準を充足）
+
+### Self-Check Verdict
+- **Yes** — handoff 可（全 ✅）
+
+### 次のステップ
+
+`/issue-review-design local-p1-26` でレビューをお願いします。

--- a/.kaji/issues/local-p1-26-poc-addition-cli/comments/20260604T164007Z-p1.md
+++ b/.kaji/issues/local-p1-26-poc-addition-cli/comments/20260604T164007Z-p1.md
@@ -1,0 +1,82 @@
+---
+author: p1
+created_at: '2026-06-04T16:40:07Z'
+---
+## 実装完了
+
+設計書に基づいて実装を完了しました。
+
+### 成果物
+
+#### コード実装
+
+- **ファイル**: `kaji_addition.py`
+  - `add(a: int, b: int) -> int` 関数を実装
+  - CLI エントリポイント (`if __name__ == '__main__'`:) を実装
+  - 引数パースエラーハンドリング実装（ValueError, 引数個数チェック）
+
+#### テスト実装
+
+- **ファイル**: `tests/test_addition.py`
+  - Small テスト: 4 テストケース（正常系・ゼロ・負数・大きい値）
+  - Large テスト: 4 テストケース（正常系・負数・引数不正・パース失敗）
+
+### 検証結果
+
+#### 機能テスト（正常系）
+
+```bash
+$ python kaji_addition.py 1 2
+3
+$ python kaji_addition.py -3 2
+-1
+```
+
+✅ 期待どおり動作
+
+#### テストスイート実行
+
+```
+tests/test_addition.py::TestAddFunction
+  - test_add_positive_integers: PASS
+  - test_add_zero: PASS
+  - test_add_negative_numbers: PASS
+  - test_add_large_numbers: PASS
+
+tests/test_addition.py::TestAddCLI
+  - test_cli_normal_case: PASS
+  - test_cli_negative_numbers: PASS
+  - test_cli_missing_argument: PASS
+  - test_cli_invalid_argument: PASS
+
+計: 8 passed in 1.06s
+```
+
+✅ 全テストパス
+
+#### 既存テスト影響チェック
+
+```
+全テストスイート実行結果: 1690 passed, 2 skipped
+```
+
+✅ 既存テストへの影響なし
+
+### 完了条件の確認
+
+| 条件 | 状態 | 根拠 |
+|------|------|------|
+| `add(1, 2) == 3` | ✅ | 実装・テスト・手動実行で確認 |
+| CLI で出力 | ✅ | `python kaji_addition.py 1 2` が `3` を出力 |
+| テストが通る | ✅ | 8/8 テストパス、既存テスト回帰なし |
+
+### 実装の要点
+
+1. **関数実装**: 純粋な加算関数。型チェックはPython の duck typing に任せる
+2. **CLI**: `sys.argv[1:]` で引数をパース。argparse は不使用（最小実装）
+3. **エラーハンドリング**: try-except ValueError で parse 失敗、if len(sys.argv) != 3 で個数チェック
+4. **テスト戦略**: Small（単体）+ Large（subprocess 統合） で検証
+
+### 次のステップ
+
+`/issue-review-code local-p1-26` でコードレビューをお願いします。

--- a/.kaji/issues/local-p1-26-poc-addition-cli/comments/20260604T164309Z-p1.md
+++ b/.kaji/issues/local-p1-26-poc-addition-cli/comments/20260604T164309Z-p1.md
@@ -1,0 +1,56 @@
+---
+author: p1
+created_at: '2026-06-04T16:43:09Z'
+---
+# コードレビュー結果
+
+## 概要
+
+実装は設計と整合しており、独立検証でも問題は確認されませんでした。
+
+## 独立テスト実行結果
+
+| 項目 | 結果 |
+|------|------|
+| ruff check / ruff format --check / mypy | PASS |
+| pytest 総数 / passed / failed / errors / skipped | 1692 / 1690 / 0 / 0 / 2 |
+| baseline failure 一致 | 0 件 |
+| 新規 FAILED/ERROR (regression) | 0 件 |
+
+## type 別追加観点の判定
+
+判定対象 type: `type:feature`
+
+| 観点 | 該当 | 判定 | 根拠 |
+|------|:---:|:---:|------|
+| A. IF 契約の忠実性 | feat | ✅ | 設計書どおり `add(a: int, b: int) -> int` と `python kaji_addition.py <a> <b>` を実装し、戻り値とエラー挙動も一致している |
+| B. 再現テスト Red→Green | bug | — | 該当なし |
+| C. 同根欠陥の波及修正 | bug | — | 該当なし |
+| D. 振る舞い非変更の保証 | refactor | — | 該当なし |
+| E. 改善指標の達成 | refactor | — | 該当なし |
+| F. Scope 混在禁止 | feat/bug/refactor | ✅ | 新規 addition 関数と CLI、対応テストのみで、別 type の変更は混入していない |
+
+## 指摘事項 (Must Fix)
+
+- なし
+
+## 改善提案 (Should Fix)
+
+- なし
+
+## 良い点
+
+- Small/Large のテスト分離が設計どおりで、CLI の正常系と異常系が実測で確認されている。
+- 実装差分が小さく、既存コードへの影響がない。
+
+---VERDICT---
+status: PASS
+reason: "実装は設計と整合しており、独立実行した lint・型チェック・pytest がすべて成功し、新規回帰も確認されなかったため。"
+evidence: |
+  `kaji_addition.py` は `add(a: int, b: int) -> int` と CLI エントリポイントを実装し、`python kaji_addition.py 1 2` の期待出力 `3` を満たす。
+  `tests/test_addition.py` に Small 4 件と Large 4 件があり、加算ロジックと CLI の正常系 / 異常系を検証している。
+  独立実行した `ruff check kaji_harness/ tests/` は exit 0、`ruff format --check kaji_harness/ tests/` は exit 0、`mypy kaji_harness/` は exit 0。
+  独立実行した `pytest` は `1690 passed, 2 skipped` で終了し、新規 FAILED/ERROR は発生していない。
+  既存テスト群への回帰はなく、完了条件の `add(1, 2) == 3`、CLI 出力、関連テスト通過を満たしている。
+suggestion: ""
+---END_VERDICT---

--- a/docs/cli-guides/local-mode.md
+++ b/docs/cli-guides/local-mode.md
@@ -128,9 +128,21 @@ kaji issue list
 kaji issue context local-pc1-1 --json branch_prefix,branch_name,worktree_dir
 # → {"branch_prefix":"feat","branch_name":"feat/local-pc1-1","worktree_dir":"/abs/.../kaji-feat-local-pc1-1"}
 
+# 本文先頭に Worktree メタ情報（> [!NOTE] ブロック）を決定的に追記（/issue-start 用）
+kaji issue prepend-note local-pc1-1 --worktree kaji-feat-local-pc1-1 --branch feat/local-pc1-1 --commit
+
 # workflow 起動（local 専用）
 kaji run .kaji/wf/feature-development-local.yaml local-pc1-1
 ```
+
+`kaji issue prepend-note <id> --worktree <basename> --branch <branch> [--commit]`
+は `> [!NOTE]` メタブロックを本文先頭へ合成する provider 共通 subcommand。
+合成（NOTE ブロック + **空行ちょうど 1 行** + 既存本文）は `kaji` 内部の決定的な
+Python 経路が担うため、エージェントの multi-line 忠実度に依存せず blank line を
+保証する（Issue #200）。`--commit` は local provider で `issue.md` を atomic commit
+する（`gh issue prepend-note` は存在しないため github では `view_issue` /
+`edit_issue` 経路で更新し、`--commit` は silent に無視）。`/issue-start` skill の
+Step 4 がこれを呼ぶ。
 
 `kaji issue context` は frontmatter `branch_prefix` 優先 → `type:*` ラベル
 mapping → `chore` fallback の優先順で context を解決する（`provider.type='local'`

--- a/draft/design/issue-200-fix-issue-start-skill-issue-blank-line.md
+++ b/draft/design/issue-200-fix-issue-start-skill-issue-blank-line.md
@@ -1,0 +1,233 @@
+# [設計] issue-start のメタ情報追記で blank line 欠落を起こさない決定的な合成経路を導入する
+
+Issue: #200
+
+## 概要
+
+`/issue-start` Step 4 が Issue 本文先頭へ `> [!NOTE]` メタ情報ブロックを追記する際、blockquote と既存本文の間の blank line（および直前の改行）が、Haiku 等の一部エージェントが multi-line heredoc を忠実に再現できないことで欠落し、`> **Branch**: \`fix/199\`## 概要` のように本文先頭 heading が blockquote 行へ吸着する。本文合成を skill（エージェント）側の heredoc から `kaji` 内部の決定的な Python 経路へ移し、blank line を仕様上保証する。
+
+## 背景・目的
+
+### Observed Behavior（OB）
+
+`full-cycle.yaml` の `start` ステップ（`model: haiku`）で `/issue-start 199` を実行した結果、Issue #199 本文先頭が以下のように崩れた（Issue #200 本文に記録された実観測ログ）:
+
+```text
+$ gh issue view 199 --json body -q '.body' | head -4
+> [!NOTE]
+> **Worktree**: `../kaji-fix-199`
+> **Branch**: `fix/199`## 概要
+```
+
+`> **Branch**: \`fix/199\`` の直後に、本来あるべき「改行 + blank line」が 2 つとも欠落し、本文先頭の `## 概要` が blockquote 最終行へ連結している。結果として `## 概要` は heading ではなく blockquote 内テキストとして解釈される。
+
+### Expected Behavior（EB）
+
+Opus 担当実行（Issue #190）では blank line が保持され、blockquote 終端と本文の間に空行 1 行が入る（実観測）:
+
+```text
+$ gh issue view 190 --json body -q '.body' | head -6
+> [!NOTE]
+> **Worktree**: `../kaji-fix-190`
+> **Branch**: `fix/190`
+> **PR**: gh:198
+                  ← blank line
+## 設計書
+```
+
+skill spec（`.claude/skills/issue-start/SKILL.md:116-123`）の heredoc も、`> **Branch**: \`$BRANCH\`` の次行に blank line を置いてから `$CURRENT_BODY` を展開する形であり、EB はこの blank line が保持された状態。
+
+> **Bettenburg et al. (2008)** に倣い OB / EB / steps-to-reproduce を分離記述。本 Issue は OB（#199 実ログ）と EB（#190 実ログ + skill spec の意図）が一次情報で揃っている。
+
+### 目的
+
+エージェント（モデル）の multi-line 忠実度に依存せず、`/issue-start` のメタ情報追記が **どのモデルでも決定的に** blank line を保持することを保証する。
+
+## 再現手順（Steps to Reproduce）
+
+1. 前提: GitHub provider の Issue が存在し、本文先頭が `## ` で始まる（先頭に blank line を持たない）。`full-cycle.yaml` のように `start` ステップが `model: haiku`。
+2. `kaji run .kaji/wf/full-cycle.yaml <issue_id>`（または Haiku エージェントで `/issue-start <issue_id>`）を実行。
+3. `gh issue view <issue_id> --json body -q '.body' | head -5` で本文先頭を観測。
+4. `> **Branch**: ...` の直後に空行・改行なしで本文 heading が連結したケースを確認（OB）。
+
+> **再現の性質**: 本 OB はエージェントの heredoc 再現挙動に依存し、Haiku で観測・Opus で未観測の **モデル依存・確率的** な事象。確率的事象である以上、エージェントの再実行による回帰検証は安定せず、回帰テストは「決定的なコード経路」に対してのみ成立する（→ § テスト戦略、§ 方針）。
+
+## 根本原因（Root Cause）
+
+### なぜ壊れるか
+
+`SKILL.md:114-123` のメタ情報合成は、エージェントが以下の multi-line bash heredoc を **忠実に再構成して実行する** ことに依存している:
+
+```bash
+NEW_BODY=$(cat <<EOF
+> [!NOTE]
+> **Worktree**: \`../$WT_BASENAME\`
+> **Branch**: \`$BRANCH\`
+            ← この「空行 1 行」が分離子
+$CURRENT_BODY
+EOF
+)
+kaji issue edit [issue_id] --commit --body "$NEW_BODY"
+```
+
+blockquote と `$CURRENT_BODY` の分離子は **「文字としては空の 1 行」** に過ぎない。エージェントは SKILL.md を逐語実行するのではなく、`[issue_id]` 等を補完して **自らコマンドを再構成** する。Haiku 等の小型・高速モデルは再構成時に「意味的に不可視」な空行を脱落させやすく、`> **Branch**: \`$BRANCH\`` 行末の改行ごと潰して `$CURRENT_BODY` を同一行へ連結する。OB の `\`fix/199\`## 概要` は、改行 1 + 空行 1 の計 2 つが消えた状態と一致する。
+
+### kaji 側に正規化は無い
+
+`kaji issue edit --body` は body を素通しで `gh issue edit --body` へ渡すだけで、Python 側に blank line 正規化は存在しない（`kaji_harness/providers/github.py:211-234` `edit_issue`、`kaji_harness/cli_main.py:1061-1070` dispatch）。よって本文の正否は **完全にエージェントが組んだ文字列に委ねられている**。これが robustness 不足の核心。
+
+### いつから
+
+heredoc の空行分離子は skill 初版（`b0ade53`, 2026-01-08、旧 `.claude/commands/issue-start.md`）から存在する latent な脆弱性。`git blame .claude/skills/issue-start/SKILL.md -L 116,123` で line 120 の空行が初版由来であることを確認。`full-cycle.yaml` の `start` ステップを `model: haiku`（`.kaji/wf/full-cycle.yaml:52-55`）に割当てたことで顕在化した。Opus を使う `full-cycle-xhigh.yaml`（`start` は `model: sonnet`）等では未顕在。
+
+### 同根の他壊れ箇所
+
+メタ情報の追記はエージェント heredoc 合成に依存する箇所が `SKILL.md` Step 4 の **1 箇所のみ**。`/i-pr` の `**PR**` 追記は別 skill だが「既存 NOTE ブロックへの 1 行追記」であり、本文 heading との境界問題は発生しない（調査の結果、本 Issue のスコープ外）。`kaji issue edit` を直接叩く他 skill（review 系コメント等）はメタ情報の先頭追記を行わないため非該当。
+
+## インターフェース
+
+### 新規 CLI subcommand（provider 共通）
+
+```
+kaji issue prepend-note <issue_id> --worktree <worktree_basename> --branch <branch> [--commit]
+```
+
+- **入力**: `issue_id`（必須）、`--worktree`（NOTE に載せる worktree 相対パスの basename、例 `kaji-fix-200`）、`--branch`（例 `fix/200`）、`--commit`（local provider で `issue.md` を atomic commit。github では silent に無視＝既存 `edit` と同契約）。すべて **単一トークン引数** で、エージェントは multi-line 文字列を組まない。
+- **動作**: kaji 内部で (1) `provider.view_issue(id).body` で現在本文を取得 → (2) 純粋関数で NOTE ブロック + blank line + 現在本文を決定的に合成 → (3) `provider.edit_issue(id, body=...)`（local は `--commit` 時に既存 commit helper へ委譲）。
+- **dispatch 位置**: `gh issue prepend-note` は存在しないため、`context` と同様に `_handle_issue` の **local/github 分岐より前** で provider 共通 helper として捕捉する（`kaji_harness/cli_main.py:1052-1059` の `context` パターンに倣う）。`view_issue` / `edit_issue` は両 provider に実装済みのため単一実装で両対応。
+- **出力**: 副作用は Issue 本文更新（GitHub API / local `issue.md`）。stdout には成功時に更新後本文の要約 or 何も出さない（既存 `edit` に準拠）。失敗時 exit code は既存規約（`EXIT_INVALID_INPUT` 等）に従う。
+
+### 純粋関数（テスト対象の核）
+
+```python
+def build_worktree_note_body(current_body: str, *, worktree: str, branch: str) -> str:
+    """NOTE メタブロックを current_body 先頭へ blank line 1 行を保証して合成する。"""
+```
+
+- **保証する不変条件**:
+  - 戻り値 = `> [!NOTE]\n> **Worktree**: \`../{worktree}\`\n> **Branch**: \`{branch}\`\n\n{normalized_body}`
+  - blockquote と本文の間は **常に空行ちょうど 1 行**（`current_body` 先頭の余分な空行は剥がしてから 1 行を付与）。
+  - `current_body` が空文字 → NOTE ブロックのみ（末尾 blank line は付けない）。
+  - I/O 副作用なし（純粋関数）。
+- backtick / `$` 等を含む値も文字列として安全に埋め込む（shell 評価を経ないため heredoc の backtick 展開問題が原理的に消える）。
+
+### SKILL.md Step 4 の変更
+
+heredoc による `NEW_BODY` 合成 + `kaji issue edit --body "$NEW_BODY"` を廃止し、次へ置換:
+
+```bash
+WT_BASENAME=$(basename "$WT")
+kaji issue prepend-note [issue_id] --worktree "$WT_BASENAME" --branch "$BRANCH" --commit
+```
+
+エージェントは単一トークン 3 つを渡すだけで、multi-line 本文合成を一切行わない。
+
+### 後方互換性
+
+- 出力本文の形（NOTE ブロックのレイアウト）は EB と同一を維持 → `development_workflow.md` の NOTE ブロック例（lines 187-193）と整合し、後段 skill（`/i-pr` の `**PR**` 追記、`/i-dev-final-check` の設計書添付）への影響なし。
+- `kaji issue edit` の既存挙動・引数は不変（新 subcommand を追加するのみ）。
+
+## 制約・前提条件
+
+- kaji は Python 単一スタック。Scope 分岐なし。
+- 新 subcommand は github / local 両 provider で動作必須（`/issue-start` が両対応のため）。
+- **非目標（スコープ外）**: NOTE ブロックの重複追記防止（idempotency ガード）は現行 heredoc 方式にも無く、本 Issue では既存挙動と parity を維持する（混在を避ける）。必要なら別 Issue で追跡。
+- 最小侵襲を優先しつつ、bug の回帰テスト必須要件（`bug.md` § 8）を満たすため、決定的なコード経路の導入は不可避（→ § 方針 の代替案比較）。
+
+## 方針
+
+### アプローチ選定
+
+| 案 | 内容 | 採否 | 理由 |
+|----|------|------|------|
+| A: skill printf 化 | SKILL.md の heredoc を `printf '...\n\n%s' "$CURRENT_BODY"` に置換 | ✗ | 依然エージェントが `\n\n` を含むコマンドを再構成する＝モデル忠実度依存が残る。かつ Python コードが増えず **恒久回帰テストが作れない**（`bug.md` § 8 の必須要件を満たせない） |
+| B: kaji 側で決定的合成（採用） | view→合成→edit を kaji 内部 Python で実施。skill は単一トークン引数を渡すのみ | ✓ | エージェントの multi-line 忠実度依存を **原理的に除去**。純粋関数として Small で回帰テスト可能。Issue が許容する「`kaji issue edit` 側で normalize」方向 |
+| C: 既存 body の事後正規化 | `kaji issue edit` 受領 body に「blockquote 直後へ blank line 挿入」を後付け | ✗ | OB は `## 概要` が blockquote 最終行へ **吸着済み**（`> **Branch**: ...## 概要`）であり、`## 概要` は既に blockquote 内テキスト扱い。事後正規化では「本来本文だった行」を blockquote から切り離せない。合成時に防ぐしかない |
+
+### 採用案 B の合成擬似コード
+
+```python
+def build_worktree_note_body(current_body, *, worktree, branch):
+    note = f"> [!NOTE]\n> **Worktree**: `../{worktree}`\n> **Branch**: `{branch}`"
+    body = current_body.lstrip("\n")  # 先頭の余分な空行を剥がす
+    if not body:
+        return note + "\n"
+    return f"{note}\n\n{body}"
+
+# CLI handler（_handle_issue_prepend_note, provider 共通; context と同位置で捕捉）
+current = provider.view_issue(issue_id).body
+new_body = build_worktree_note_body(current, worktree=wt, branch=branch)
+# local: 既存 _local_issue_edit / _commit_local_issue_change 経路へ委譲（--commit atomic）
+# github: provider.edit_issue(issue_id, body=new_body)
+```
+
+blank line がエージェントではなく **Python 文字列リテラル `\n\n`** に固定されるため、モデルに依存しない。
+
+## テスト戦略
+
+### 変更タイプ
+
+実行時コード変更（kaji_harness に新 subcommand + 純粋関数を追加）+ 付随する skill spec（SKILL.md）更新。中核は実行時コード変更。
+
+> **bug 固有ルール（`bug.md` § 8）**: 修正前 Red → 修正後 Green の恒久回帰テストを最低 1 本、省略不可。本 Issue の OB はモデル依存・確率的でエージェント再実行による回帰検証は安定しないため、**決定的なコード経路（純粋関数 + CLI dispatch）に対して** 回帰テストを定義する。新規の純粋関数はテスト記述時点で未実装＝Red、実装後 Green に遷移し、実装前 Red 証跡となる。加えて Issue #199 の実観測 OB ログを escape clause の実世界 Red 証跡として併記する。
+
+#### Small テスト（核となる回帰テスト）
+
+`build_worktree_note_body` の不変条件を検証:
+
+- **blank line 保証**: `current_body="## 概要\n..."` → 戻り値が `...> **Branch**: \`fix/200\`\n\n## 概要` を含み、blockquote 行と `## 概要` の間が **空行ちょうど 1 行**（OB の `\`fix/200\`## 概要` 連結が起こらないことを assert）。← OB を直接 assert する回帰テスト本体。
+- **本文先頭の余分な空行を 1 行に正規化**: `current_body="\n\n## 概要"` でも空行 1 行へ収束（冪等性）。
+- **空 body**: `current_body=""` → NOTE ブロックのみ、末尾に余分な blank line を付けない。
+- **特殊文字耐性**: backtick / `$` / 複数行を含む body をそのまま保持（shell 評価を経ないこと）。
+
+#### Medium テスト（CLI dispatch 結合）
+
+`kaji issue prepend-note` の end-to-end（local provider、git fixture）:
+
+- `git init` fixture + local Issue を用意し `kaji issue prepend-note <id> --worktree ... --branch ... --commit` 実行後、`issue.md` 本文先頭が NOTE ブロック + blank line + 元本文の形になることを検証。
+- `context` と同じ provider 共通 dispatch で捕捉され、`gh` へ誤 forward しないこと（github 側は `view_issue`/`edit_issue` 経路を使う）。
+- **subprocess patch 方針**: `testing-convention.md` § subprocess.run patch スコープに従い、dispatch 結合テストでは `subprocess.run` 名前空間 patch を使わず、`git init -q --initial-branch=<default_branch>` fixture 系で検証する。
+
+#### Large テスト
+
+不要。理由（`testing-convention.md` の 4 条件に照合）:
+
+1. 独自ロジックの中核は純粋関数（Small）と dispatch（Medium）で被覆済み、実 GitHub API 疎通に固有の新規ロジックは無い（github 経路は既存 `edit_issue` の再利用）。
+2. 想定不具合（blank line 欠落）は Small が決定的に捕捉。
+3. 実 API 疎通テストを足しても回帰検出情報は増えない。
+4. github 実機での最終確認は完了条件どおり実 Issue 再実行（Haiku / Opus）で代替（`make verify-*` ではなく実運用確認、Issue #200 完了条件 item 3）。
+
+### 完了条件との対応
+
+- 根本原因の特定 → § 根本原因（heredoc 合成のエージェント忠実度依存 + kaji 側正規化不在）。
+- blank line 保持の保証 → 案 B（kaji 内部決定的合成）。
+- Haiku / Opus 双方で保持を再現確認 → 単一トークン引数化により合成がエージェント非依存となり、両モデルで実 Issue 再実行確認可（item 3）。
+- `make check` 通過 → 新規コードに Small/Medium テスト + ruff/mypy。
+- `/issue-start` Haiku 担当化の記載整合 → § 影響ドキュメント。
+
+## 影響ドキュメント
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | なし | 新規技術選定なし |
+| docs/ARCHITECTURE.md | なし | アーキ構造変更なし（既存 dispatch パターンの踏襲） |
+| docs/dev/development_workflow.md | 要確認（おそらく変更なし） | NOTE ブロック例（lines 185-202）は出力レイアウト不変のため整合維持。`/issue-start` を Haiku 担当化する旨の明示記載は development_workflow.md には無く、モデル割当は `.kaji/wf/full-cycle.yaml:55` の `model: haiku` に存在（item 5 の条件付き整合確認の結論: doc 側に該当記述なし＝doc 変更不要） |
+| docs/cli-guides/ | あり（要追記） | `kaji issue prepend-note` を CLI ガイドに追加（新 subcommand のため） |
+| docs/reference/ | なし | API 規約変更なし |
+| CLAUDE.md | なし | 規約変更なし |
+| .claude/skills/issue-start/SKILL.md | あり | Step 4 を `kaji issue prepend-note` 呼び出しへ置換（本 Issue の skill spec 変更本体） |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| issue-start skill spec | `.claude/skills/issue-start/SKILL.md:114-127` | Step 4 heredoc。blockquote と `$CURRENT_BODY` の分離子が「空行 1 行」であり、エージェント再構成で脱落しうる脆弱性の所在 |
+| Issue #199 本文（OB 実ログ） | `gh issue view 199 --json body -q '.body'`（Issue #200 本文にも転記） | `> **Branch**: \`fix/199\`## 概要` の連結。改行 1 + 空行 1 の計 2 つが欠落した実観測 |
+| Issue #190 本文（EB 実ログ） | `gh issue view 190 --json body -q '.body'` | NOTE ブロック終端と本文の間に空行 1 行が保持された正しいレイアウト |
+| 担当モデル割当 | `.kaji/wf/full-cycle.yaml:52-55` | `start` ステップ `model: haiku`。OB 顕在化の発生源。対して `full-cycle-xhigh.yaml` の `start` は `sonnet` |
+| heredoc 初版 | `git blame .claude/skills/issue-start/SKILL.md -L 116,123`（`b0ade53`, 2026-01-08） | 空行分離子が skill 初版由来の latent 脆弱性であること（「いつから」の裏付け） |
+| issue dispatch（provider 共通捕捉） | `kaji_harness/cli_main.py:1052-1070` | `context` が local/github 分岐前に捕捉される実装。`prepend-note` も `gh` に存在しないため同位置で捕捉する設計根拠 |
+| provider edit/view | `kaji_harness/providers/github.py:197-234` | `view_issue` / `edit_issue` が両 provider に実装済みで、`--body` を素通しする（kaji 側正規化が無い）こと |
+| local commit helper | `kaji_harness/cli_main.py:1440-1470` `_commit_local_issue_change` | `--commit` の atomic commit ロジック（no-op edit skip 含む）を prepend-note が再利用する根拠 |
+| テスト規約（4 条件 / サイズ / subprocess patch） | `docs/dev/testing-convention.md:60-76, 132-145` | Large 省略の 4 条件照合、dispatch 結合テストの subprocess patch 禁止スコープ |
+| bug 設計ガイド（回帰テスト必須 / escape clause） | `.claude/skills/_shared/design-by-type/bug.md:62-74` | 修正前 Red → 修正後 Green の恒久回帰テスト必須、実ログ escape clause の適用条件 |

--- a/kaji_harness/cli_main.py
+++ b/kaji_harness/cli_main.py
@@ -1057,6 +1057,10 @@ def _handle_issue(raw_args: list[str]) -> int:
         args = args[1:]
     if args and args[0] == "context":
         return _handle_issue_context(provider, args[1:])
+    # ``prepend-note`` も ``gh issue`` に存在しない provider 共通 helper のため、
+    # GitHub passthrough 前に捕捉する（Issue #200）。
+    if args and args[0] == "prepend-note":
+        return _handle_issue_prepend_note(provider, args[1:])
 
     if isinstance(provider, LocalProvider):
         return _handle_issue_local(provider, raw_args)
@@ -1229,6 +1233,100 @@ def _emit_json(payload: object, *, jq_expr: str | None) -> int:
         return rc
     # jq は末尾 newline を出すため二重出力を避けて write
     sys.stdout.write(out)
+    return EXIT_OK
+
+
+def build_worktree_note_body(current_body: str, *, worktree: str, branch: str) -> str:
+    """``> [!NOTE]`` メタブロックを ``current_body`` 先頭へ決定的に合成する。
+
+    ``/issue-start`` Step 4 はかつて multi-line bash heredoc でメタブロックと既存
+    本文を結合していたため、エージェントの multi-line 忠実度に依存し、Haiku 等で
+    blockquote と本文 heading の境界 blank line が脱落していた（Issue #200 OB）。
+    本関数は blank line を Python 文字列リテラル ``\\n\\n`` に固定し、モデル非依存に
+    レイアウトを保証する。
+
+    Args:
+        current_body: 現在の Issue 本文。
+        worktree: NOTE に載せる worktree 相対パスの basename（例 ``kaji-fix-200``）。
+        branch: ブランチ名（例 ``fix/200``）。
+
+    Returns:
+        ``> [!NOTE]`` ブロック + 空行ちょうど 1 行 + 正規化済み本文。``current_body``
+        が空（改行のみを含む）の場合は NOTE ブロックのみ（末尾改行 1 つ）。
+    """
+    note = f"> [!NOTE]\n> **Worktree**: `../{worktree}`\n> **Branch**: `{branch}`"
+    # 本文先頭の余分な空行を剥がし、必ず空行 1 行だけを分離子として付与する。
+    body = current_body.lstrip("\n")
+    if not body:
+        return note + "\n"
+    return f"{note}\n\n{body}"
+
+
+def _handle_issue_prepend_note(provider: IssueProvider, rest: list[str]) -> int:
+    """``kaji issue prepend-note <id> --worktree W --branch B [--commit]``。
+
+    provider 共通: ``view_issue`` で現在本文を取得し、``build_worktree_note_body``
+    で NOTE ブロック + blank line + 本文を決定的に合成して ``edit_issue`` で更新する。
+    エージェントが multi-line 本文を組み立てる必要を排し、blank line 脱落
+    （Issue #200）をモデル非依存に防ぐ。
+
+    ``gh issue prepend-note`` は存在しないため、``context`` と同様に ``_handle_issue``
+    の provider 分岐より前で捕捉される。``--commit`` は local provider で ``issue.md``
+    を atomic commit する用途。github では silent に無視する（既存 ``edit`` と同契約）。
+    """
+    p = argparse.ArgumentParser(prog="kaji issue prepend-note", add_help=True)
+    p.add_argument("issue_id", type=str)
+    p.add_argument("--worktree", required=True, type=str)
+    p.add_argument("--branch", required=True, type=str)
+    p.add_argument(
+        "--commit",
+        action="store_true",
+        help=(
+            "Commit the resulting .kaji/issues/<id>/issue.md atomically "
+            "(local provider only; silently ignored for github)."
+        ),
+    )
+    ns = p.parse_args(rest)
+
+    # provider 別 ID 正規化（_handle_issue_context と同じ規則）
+    local_rid: ResolvedId | None = None
+    if isinstance(provider, LocalProvider):
+        rid_or_rc = _resolve_local_id(provider, ns.issue_id, write=True)
+        if isinstance(rid_or_rc, int):
+            return rid_or_rc
+        local_rid = rid_or_rc
+        issue_id_value = local_rid.value
+    else:
+        try:
+            rid = normalize_id(ns.issue_id, provider_name="github", machine_id=None)
+        except ValueError as exc:
+            sys.stderr.write(f"Error: {exc}\n")
+            return EXIT_INVALID_INPUT
+        issue_id_value = rid.value
+
+    try:
+        current = provider.view_issue(issue_id_value)
+        new_body = build_worktree_note_body(current.body, worktree=ns.worktree, branch=ns.branch)
+        provider.edit_issue(issue_id_value, body=new_body)
+    except IssueNotFoundError as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        return EXIT_RUNTIME_ERROR
+    except GitHubProviderError as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        return EXIT_RUNTIME_ERROR
+    except (LocalProviderError, ValueError) as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        return EXIT_INVALID_INPUT
+
+    # local provider の --commit のみ issue.md を atomic commit。github は silent 無視。
+    if ns.commit and isinstance(provider, LocalProvider) and local_rid is not None:
+        issue_dir = provider._resolve_issue_dir(issue_id_value)
+        _commit_local_issue_change(
+            provider=provider,
+            rid=local_rid,
+            action="edit",
+            paths=[issue_dir / "issue.md"],
+        )
     return EXIT_OK
 
 

--- a/tests/test_issue_prepend_note_cli.py
+++ b/tests/test_issue_prepend_note_cli.py
@@ -1,0 +1,294 @@
+"""Tests for ``kaji issue prepend-note`` (Issue #200).
+
+``/issue-start`` Step 4 が Issue 本文先頭へ ``> [!NOTE]`` メタ情報ブロックを追記
+する際、heredoc によるエージェント multi-line 合成に依存していたため、Haiku 等
+一部モデルで blockquote と本文の境界 blank line が脱落し、
+``> **Branch**: `fix/199`## 概要`` のように本文 heading が blockquote 行へ吸着した
+（Issue #199 実観測 OB）。
+
+本ファイルは合成を kaji 内部の決定的経路（純粋関数 ``build_worktree_note_body`` +
+``kaji issue prepend-note`` dispatch）へ移し、モデル非依存に blank line を保証する
+ことの Red → Green 回帰証跡。
+
+設計書: ``draft/design/issue-200-fix-issue-start-skill-issue-blank-line.md``
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kaji_harness.cli_main import _handle_issue, build_worktree_note_body
+from kaji_harness.providers import LocalProvider
+from kaji_harness.providers.models import Issue
+
+# ============================================================
+# Small: build_worktree_note_body（核となる回帰テスト）
+# ============================================================
+
+
+@pytest.mark.small
+class TestBuildWorktreeNoteBody:
+    """純粋関数の不変条件（blank line 保証）を検証する。"""
+
+    def test_blank_line_guaranteed_between_note_and_heading(self) -> None:
+        """OB の直接 assert: blockquote 行と本文 heading の間が空行ちょうど 1 行。
+
+        Issue #199 OB の ``> **Branch**: `fix/199`## 概要`` 連結（改行 1 + 空行 1
+        の計 2 つが消えた状態）が起こらないことを保証する。
+        """
+        result = build_worktree_note_body(
+            "## 概要\n\n本文",
+            worktree="kaji-fix-200",
+            branch="fix/200",
+        )
+        # blockquote と heading の間は空行ちょうど 1 行
+        assert "> **Branch**: `fix/200`\n\n## 概要" in result
+        # OB の吸着（backtick 直後に heading が連結）が起きていない
+        assert "`fix/200`## 概要" not in result
+
+    def test_full_note_block_layout(self) -> None:
+        """NOTE ブロックのレイアウト全体が EB（#190 相当）と一致する。"""
+        result = build_worktree_note_body(
+            "## 概要",
+            worktree="kaji-fix-200",
+            branch="fix/200",
+        )
+        assert result == (
+            "> [!NOTE]\n> **Worktree**: `../kaji-fix-200`\n> **Branch**: `fix/200`\n\n## 概要"
+        )
+
+    def test_leading_blank_lines_normalized_to_one(self) -> None:
+        """本文先頭の余分な空行は 1 行へ収束する（冪等性）。"""
+        result = build_worktree_note_body(
+            "\n\n\n## 概要",
+            worktree="kaji-fix-200",
+            branch="fix/200",
+        )
+        assert "> **Branch**: `fix/200`\n\n## 概要" in result
+        # 空行が 2 行以上残らない
+        assert "`fix/200`\n\n\n" not in result
+
+    def test_empty_body_produces_note_only(self) -> None:
+        """空 body → NOTE ブロックのみ。末尾に余分な blank line を付けない。"""
+        result = build_worktree_note_body(
+            "",
+            worktree="kaji-fix-200",
+            branch="fix/200",
+        )
+        assert result == ("> [!NOTE]\n> **Worktree**: `../kaji-fix-200`\n> **Branch**: `fix/200`\n")
+
+    def test_whitespace_only_body_produces_note_only(self) -> None:
+        """改行のみの body も空扱いで NOTE ブロックのみになる。"""
+        result = build_worktree_note_body(
+            "\n\n",
+            worktree="kaji-fix-200",
+            branch="fix/200",
+        )
+        assert result == ("> [!NOTE]\n> **Worktree**: `../kaji-fix-200`\n> **Branch**: `fix/200`\n")
+
+    def test_special_chars_in_body_preserved(self) -> None:
+        """backtick / ``$`` / 複数行を含む body をそのまま保持する（shell 評価なし）。"""
+        body = "## 概要\n\n`code` と $VAR を含む `inline`\n- 行 2"
+        result = build_worktree_note_body(
+            body,
+            worktree="kaji-fix-200",
+            branch="fix/200",
+        )
+        assert result.endswith(body)
+        assert "$VAR" in result
+        assert "`code`" in result
+
+
+# ============================================================
+# Medium: kaji issue prepend-note dispatch 結合
+# ============================================================
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_local_repo(tmp_path: Path, *, machine_id: str = "pc1") -> Path:
+    """``provider.type='local'`` 用に config + git init された repo を用意する。"""
+    repo = tmp_path / "repo"
+    (repo / ".kaji").mkdir(parents=True)
+    (repo / ".kaji" / "config.toml").write_text(
+        '[paths]\nartifacts_dir = ".kaji-artifacts"\nskill_dir = ".claude/skills"\n\n'
+        "[execution]\ndefault_timeout = 1800\n\n"
+        '[provider]\ntype = "local"\n\n'
+        f'[provider.local]\nmachine_id = "{machine_id}"\n'
+    )
+    _git(repo, "init", "-q", "--initial-branch=main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    return repo
+
+
+@pytest.mark.medium
+class TestPrependNoteLocalDispatch:
+    """``kaji issue prepend-note`` の local provider end-to-end。"""
+
+    def test_prepend_note_inserts_block_with_blank_line(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """issue.md 本文先頭が NOTE ブロック + blank line + 元本文の形になる。"""
+        repo = _write_local_repo(tmp_path)
+        provider = LocalProvider(repo_root=repo, machine_id="pc1")
+        issue = provider.create_issue(
+            title="Hello",
+            body="## 概要\n\n元本文",
+            labels=["type:bug"],
+            slug="hello-test",
+        )
+        monkeypatch.chdir(repo)
+
+        rc = _handle_issue(
+            [
+                "prepend-note",
+                issue.id,
+                "--worktree",
+                "kaji-fix-200",
+                "--branch",
+                "fix/200",
+            ]
+        )
+        assert rc == 0
+
+        new_body = provider.view_issue(issue.id).body
+        assert new_body == (
+            "> [!NOTE]\n"
+            "> **Worktree**: `../kaji-fix-200`\n"
+            "> **Branch**: `fix/200`\n"
+            "\n"
+            "## 概要\n\n元本文"
+        )
+        # OB の吸着が起きていない
+        assert "`fix/200`## 概要" not in new_body
+
+    def test_prepend_note_with_commit_creates_atomic_commit(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``--commit`` で working tree が clean になり HEAD に issue.md が含まれる。"""
+        repo = _write_local_repo(tmp_path)
+        provider = LocalProvider(repo_root=repo, machine_id="pc1")
+        issue = provider.create_issue(
+            title="Hello",
+            body="## 概要\n\n元本文",
+            labels=["type:bug"],
+            slug="hello-test",
+        )
+        # seed issue を commit し HEAD を clean にする
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "seed")
+        monkeypatch.chdir(repo)
+
+        rc = _handle_issue(
+            [
+                "prepend-note",
+                issue.id,
+                "--worktree",
+                "kaji-fix-200",
+                "--branch",
+                "fix/200",
+                "--commit",
+            ]
+        )
+        assert rc == 0
+
+        status = _git(repo, "status", "--porcelain").stdout
+        assert status == "", f"unexpected dirty status: {status!r}"
+
+        files = _git(repo, "show", "--name-only", "--format=", "HEAD").stdout.strip().splitlines()
+        assert any(f.endswith("/issue.md") for f in files), f"issue.md not in HEAD: {files}"
+
+    def test_prepend_note_caught_before_local_subcommand_guard(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``prepend-note`` は ``context`` 同様 provider 共通で先回り捕捉され、
+        ``_LOCAL_ISSUE_SUBS`` の unknown subcommand ガードへ落ちない。"""
+        repo = _write_local_repo(tmp_path)
+        provider = LocalProvider(repo_root=repo, machine_id="pc1")
+        issue = provider.create_issue(
+            title="Hello", body="## 概要", labels=["type:bug"], slug="hello-test"
+        )
+        monkeypatch.chdir(repo)
+
+        rc = _handle_issue(
+            ["prepend-note", issue.id, "--worktree", "kaji-fix-200", "--branch", "fix/200"]
+        )
+        assert rc == 0
+        # unknown subcommand エラーが出ていない
+        assert "is not supported" not in capsys.readouterr().err
+
+
+@pytest.mark.medium
+class TestPrependNoteGitHubDispatch:
+    """``provider.type='github'`` での provider 共通 dispatch 検証。"""
+
+    def test_github_routes_via_provider_methods_not_gh_passthrough(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """github でも ``gh issue prepend-note`` へ forward せず
+        ``view_issue`` / ``edit_issue`` 経路で合成本文を edit する。"""
+        repo = tmp_path / "repo"
+        (repo / ".kaji").mkdir(parents=True)
+        (repo / ".kaji" / "config.toml").write_text(
+            '[paths]\nartifacts_dir = ".kaji-artifacts"\nskill_dir = ".claude/skills"\n\n'
+            "[execution]\ndefault_timeout = 1800\n\n"
+            '[provider]\ntype = "github"\n\n[provider.github]\nrepo = "o/r"\n'
+        )
+        monkeypatch.chdir(repo)
+
+        current = Issue(id="200", title="t", body="## 概要", state="open")
+        edited = Issue(id="200", title="t", body="(edited)", state="open")
+        with (
+            patch(
+                "kaji_harness.providers.GitHubProvider.view_issue",
+                return_value=current,
+            ) as mock_view,
+            patch(
+                "kaji_harness.providers.GitHubProvider.edit_issue",
+                return_value=edited,
+            ) as mock_edit,
+            patch("kaji_harness.cli_main.subprocess.run") as mock_run,
+        ):
+            rc = _handle_issue(
+                [
+                    "prepend-note",
+                    "200",
+                    "--worktree",
+                    "kaji-fix-200",
+                    "--branch",
+                    "fix/200",
+                    "--commit",
+                ]
+            )
+        assert rc == 0
+        mock_view.assert_called_once()
+        # edit_issue に渡る body が決定的合成（blank line 保証）であること
+        _, kwargs = mock_edit.call_args
+        sent_body = kwargs["body"]
+        assert "> **Branch**: `fix/200`\n\n## 概要" in sent_body
+        assert "`fix/200`## 概要" not in sent_body
+        # gh / git subprocess へ forward していない（github の --commit は silent 無視）
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

`/issue-start` Step 4 で Issue 本文先頭に `> [!NOTE]` ブロックを追記する際、エージェント（特に Haiku）の multi-line heredoc 再現精度に依存していたため、blockquote と本文 heading の間の blank line が脱落していた。本文合成を `kaji issue prepend-note` という決定的な Python 経路へ移し、blank line をモデル非依存で保証する。

Closes #200

## Changes

- `kaji_harness/cli_main.py`: 純粋関数 `build_worktree_note_body` と provider 共通 dispatch `_handle_issue_prepend_note` を追加
- `tests/test_issue_prepend_note_cli.py`: Small（純粋関数）+ Medium（local/github dispatch）の回帰テスト追加
- `.claude/skills/issue-start/SKILL.md`: Step 4 を `kaji issue prepend-note` 呼び出しへ置換
- `docs/cli-guides/local-mode.md`: `prepend-note` subcommand を追記

## Documentation

- `.claude/skills/issue-start/SKILL.md` を更新（Step 4 手順の置換）
- `docs/cli-guides/local-mode.md` に新 subcommand を追記
- 設計書: `draft/design/issue-200-fix-issue-start-skill-issue-blank-line.md`（アーカイブ済み）

## Test Plan

- [x] 既存テストがパス（`make check`）
- [x] 新規テスト追加: `tests/test_issue_prepend_note_cli.py`（Small × 5 + Medium × 3）
- [x] `build_worktree_note_body` の blank line 保証を unit test で確認