### PR TITLE
feat: 起動コンソールへの harness progress と review-poll heartbeat 表示 (#235)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,6 +148,16 @@ WorkflowRunner.run()
 exec_script の 3 経路を `dispatch` field で区別する。詳細は
 [ロギング規約](./reference/python/logging.md) を参照。
 
+#### observability 2 層（機械可読ログ ↔ 起動コンソール progress）
+
+kaji のログは責務の異なる 2 層に分かれる（Issue #235）。**機械可読ログ** は `RunLogger`
+（`logger.py`）が `run.log` へ JSONL で書く実行記録で、プログラムが解析する正本。一方
+**起動コンソール progress** は `console_log.py` が設定する stdlib `logging`（`kaji.*` 名前空間）で、
+`kaji run` を叩いた起動コンソールに日時付き `[kaji]` 行（workflow / step / verdict / transition、
+および exec step の `[review-poll]` heartbeat）を人間向けに時系列表示する（`INFO` 以下 stdout /
+`WARNING` 以上 stderr、`--log-level` で閾値制御）。後者は `RunLogger` の JSONL 契約に影響しない
+別系統であり、`run.log` には混入しない。
+
 ### Runner backend dispatch（headless ↔ interactive_terminal）
 
 agent 経路の起動 backend は repository config の `[execution] agent_runner`（または

--- a/docs/cli-guides/interactive-terminal-runner.md
+++ b/docs/cli-guides/interactive-terminal-runner.md
@@ -116,6 +116,35 @@ kaji run .kaji/wf/feature-development.yaml 224 \
 kaji run .kaji/wf/feature-development.yaml 224 --agent-runner headless
 ```
 
+## 起動コンソール progress（Issue #235）
+
+interactive terminal runner では agent の作業内容は pane 側に表示されるため、起動コンソール
+（`kaji run` を叩いた元の pane）には harness 自身の進行が見えにくい。Issue #235 で、harness は
+起動コンソールへ日時付き `[kaji]` progress を stdlib `logging` 経由で出力する。
+
+```text
+[2026-06-07T12:34:57] [kaji] workflow start: feature-development issue #224
+[2026-06-07T12:34:57] [kaji] step start: design attempt-001 dispatch=agent agent=claude model=opus
+[2026-06-07T12:35:02] [kaji] pane launched: design pane=%12 verdict=/.../steps/design/attempt-001/verdict.yaml
+[2026-06-07T12:42:10] [kaji] verdict detected: design source=artifact status=PASS
+[2026-06-07T12:42:10] [kaji] step end: design status=PASS duration=433000ms next=review-design
+[2026-06-07T12:42:10] [kaji] workflow end: status=COMPLETE duration=...ms
+```
+
+- `INFO` 以下は stdout、`WARNING` 以上は stderr に出る。
+- `--log-level {DEBUG,INFO,WARNING,ERROR}`（default `INFO`）で表示閾値を制御する。
+- `--quiet` は agent/exec の stdout streaming（pane や exec 中継）を抑制するが、`[kaji]` progress
+  には影響しない（両者は独立）。harness progress だけ抑えたい場合は `--log-level WARNING` を使う。
+- `review-poll` のような deterministic exec step は pane を開かない代わり、polling 中に
+  `POLL_INTERVAL_SEC`（10s）ごとの `[review-poll]` heartbeat を起動コンソールへ flush 出力する
+  （経過秒・PR 番号・head 短縮・観測中 state・timeout 残を含む）。これにより待機中 / 停止中 /
+  エラーを `run.log` を開かずに切り分けられる。
+
+```bash
+# harness progress を抑えて警告/エラーのみ表示
+kaji run .kaji/wf/feature-development.yaml 224 --log-level WARNING
+```
+
 ## 振る舞い
 
 1. runner は `tmux split-window -d -h -P -F '#{pane_id}' -t "$TMUX_PANE" <wrapper.sh + 8 args>` を

--- a/docs/reference/python/logging.md
+++ b/docs/reference/python/logging.md
@@ -5,6 +5,18 @@ kaji における実行ログの規約。`kaji_harness/logger.py` の `RunLogger
 > このドキュメントは Python 標準 `logging` モジュールの使い方ガイドではない。
 > `RunLogger` は JSONL を直接書き出す専用実装であり、標準 `logging` を使用しない。
 
+> [!NOTE]
+> kaji には責務の異なる **2 系統** のログ層がある。本ドキュメントは前者（機械可読
+> ログ）の契約を定める。
+>
+> | 層 | 実装 | 出力 | 用途 |
+> |----|------|------|------|
+> | 機械可読ログ | `RunLogger`（`logger.py`） | `run.log`（JSONL） | プログラムが解析する実行記録 |
+> | 起動コンソール progress | stdlib `logging`（`console_log.py` / `kaji.*` 名前空間） | stdout（`INFO` 以下）/ stderr（`WARNING` 以上） | `kaji run` 起動コンソールで人間が時系列に進行を追う表示 |
+>
+> 後者は Issue #235 で導入。起動コンソール向けの **人間可読 progress** であり、
+> `RunLogger` の JSONL 契約には一切影響しない。詳細は § 起動コンソール progress logging。
+
 ## RunLogger の概要
 
 `RunLogger` は `kaji_harness/logger.py` に定義された dataclass。ワークフロー実行中のイベントを JSONL 形式でファイルに記録する。
@@ -229,18 +241,42 @@ def log_budget_exceeded(self, step_id: str, budget_usd: float, spent_usd: float)
 
 既存フィールドの削除・型変更は禁止。新フィールドの追加は `| None` として optional にする。
 
+## 起動コンソール progress logging（Issue #235）
+
+`run.log`（JSONL）とは別系統の、`kaji run` 起動コンソール向け人間可読表示層。
+`kaji_harness/console_log.py` の `configure_console_logging()` が stdlib `logging` の
+二ハンドラを `kaji` ルート logger に設定する。
+
+- **routing**: `INFO` 以下 → stdout、`WARNING` 以上 → stderr。
+- **formatter**: `[%(asctime)s] [kaji] %(message)s`（local time。`script_exec` の
+  exec 中継行 `[ts] [step_id] ...` と同一タイムラインに並ぶよう local time にそろえる）。
+- **logger 名前空間**: 各モジュールは `logging.getLogger("kaji.<module>")` を使い、
+  `kaji` ルートのハンドラへ伝播させる。`RunLogger`（`kaji_harness.*`）とは別ツリー。
+- **`--log-level`**: `kaji run --log-level {DEBUG,INFO,WARNING,ERROR}`（default `INFO`）で
+  閾値を制御。`--quiet`（agent/exec stdout streaming 抑制）とは独立。
+
+この層は「人間が起動コンソールで進行を追う」用途に限定し、プログラムが解析する記録は
+引き続き `RunLogger`（JSONL）を正本とする。
+
 ## 禁止事項
 
-### 標準 logging の直接使用
+### `RunLogger` 文脈での標準 logging 直接使用
+
+`run.log`（JSONL 機械可読ログ）に書くべきイベントを、標準 `logging` で出してはならない。
+機械可読ログは必ず `RunLogger` のメソッド経由にする。
 
 ```python
-# ❌ 禁止
+# ❌ 禁止: run.log に残すべきイベントを stdlib logging で出す
 import logging
 logging.info("step started")
 
 # ✅ RunLogger を使う
 self.logger.log_step_start(step.id, step.agent, step.model, step.effort, session_id)
 ```
+
+> 起動コンソール向けの **人間可読 progress** を `kaji.*` 名前空間の stdlib `logging` で
+> 出すのは別系統として許容される（§ 起動コンソール progress logging）。この禁止事項は
+> あくまで「JSONL 機械可読ログを stdlib logging で代替するな」という趣旨に限定される。
 
 ### 文字列フォーマットでのイベント記述
 
@@ -271,7 +307,7 @@ self._write("step_start", agent=step.agent, model=step.model, ...)
 - [ ] `RunLogger` のメソッドを正しいタイミングで呼んでいるか
 - [ ] `log_workflow_end` が正常・異常終了どちらのパスでも呼ばれているか（`try/finally` 等）
 - [ ] 新規イベントのフィールド名が snake_case か
-- [ ] 標準 `logging` モジュールを直接使用していないか
+- [ ] `run.log`（JSONL）に残すべきイベントを標準 `logging` で代替していないか（起動コンソール progress は別系統として許容）
 - [ ] 機密情報がフィールドに含まれていないか
 
 ## 関連ドキュメント

--- a/draft/design/issue-235-harness-progress-review-poll-heartbeat.md
+++ b/draft/design/issue-235-harness-progress-review-poll-heartbeat.md
@@ -1,0 +1,252 @@
+# [設計] 起動コンソールへの harness progress と review-poll heartbeat 表示
+
+Issue: #235
+
+## 概要
+
+`kaji run` の起動コンソールに、ハーネス自身の進行状況（workflow / step / verdict / transition）を
+Python 標準 `logging` 経由で日時付き `[kaji]` 行として出力し、あわせて `review-poll` の deterministic
+polling ループに `POLL_INTERVAL_SEC`（10s）ごとの heartbeat を stdout へ flush 出力する。
+
+## 背景・目的
+
+### ユースケース
+
+- **`interactive_terminal` 利用者として**、agent の作業は pane 側に見えるが起動コンソールでは
+  ハーネスが何をしているか分からない。**起動コンソールだけを見て** harness がいま workflow の
+  どの step を起動・遷移したかを時系列で追跡したい。
+- **`review-poll` 運用者として**、最大 30 分 polling しうる `review-poll` step が「待機中 /
+  停止中 / エラー」のどれなのかを、`run.log` を別途開かずに **起動コンソールの heartbeat で** 即座に
+  切り分けたい。
+
+### 代替案と不採用理由
+
+- **独自 `ConsoleReporter` 出力制御層を新設する案**: 不採用。Issue 方針が「stdlib logging の
+  level / handler / formatter で制御し、独自出力制御層は作らない」と明示。stdlib logging の
+  二ハンドラ（stdout / stderr）で要件を満たせるため、新抽象は過剰。
+- **`RunLogger`（JSONL）に人間可読出力も兼ねさせる案**: 不採用。`run.log` は機械可読契約
+  （`docs/reference/python/logging.md`）であり、人間向け表示と責務が異なる。JSONL 契約は不変に保つ。
+
+## インターフェース
+
+### 入力
+
+| 項目 | 型 / 値 | 説明 |
+|------|---------|------|
+| `--log-level`（新規 CLI option, `kaji run`） | `DEBUG` / `INFO` / `WARNING` / `ERROR`、default `INFO` | 起動コンソール progress の閾値 |
+| `--quiet`（既存） | flag | agent / exec の **stdout streaming** を抑制（既存 `verbose=not args.quiet` 意味を維持）。harness progress とは独立 |
+| `POLL_INTERVAL_SEC`（既存定数） | `10`（秒） | heartbeat 出力間隔。polling 間隔と同一 |
+
+### 出力（副作用）
+
+1. **harness progress（stdlib logging）**: `INFO` 以下 → **stdout**、`WARNING` 以上 → **stderr**。
+   formatter は以下（local time。`script_exec` の relay 行 `[ts] [step_id] ...` が `datetime.now()`
+   ＝ local time を使うため、両者を同一タイムラインに並べるには console も local time にそろえる）。
+
+   ```text
+   # INFO 以下（stdout handler）
+   [2026-06-07T12:34:56] [kaji] workflow start: feature-development issue #235
+   # WARNING 以上（stderr handler）
+   [2026-06-07T12:34:56] [kaji] WARNING: resolve_pr_context for branch 'feat/...' failed: ...
+   ```
+
+2. **review-poll heartbeat（subprocess stdout）**: `codex_review_poll` が polling 毎に 1 行 stdout へ
+   `print(..., flush=True)`。これは exec step として `script_exec._run_argv` が
+   `[{_now_stamp()}] [{step.id}] {line}` 形式で relay するため、起動コンソールには
+   `[2026-06-07T13:00:01] [review-poll] polling PR #176 head=abc1234 elapsed=0s remaining=1800s`
+   のように表示される（`[review-poll]` prefix・日時は relay 側が付与、heartbeat 行自体は素の本文）。
+
+3. `RunLogger` の `run.log`（JSONL）への出力契約は **不変**。
+
+### 使用例
+
+```bash
+# 既定（INFO）: harness progress が stdout に出る
+kaji run .kaji/wf/feature-development.yaml 235
+
+# harness progress を抑え、警告/エラーのみ表示
+kaji run .kaji/wf/feature-development.yaml 235 --log-level WARNING
+
+# agent/exec の stdout streaming だけ止める（harness progress は INFO のまま出る）
+kaji run .kaji/wf/feature-development.yaml 235 --quiet
+```
+
+### エラー
+
+- `--log-level` に未定義値 → argparse `choices` で fail-fast（exit 2 相当、既存定義エラー経路）。
+- heartbeat 出力中の `print` 失敗（pipe 切断等）は polling 判定ロジックに影響させない
+  （観測のみの副作用。verdict 判定は不変）。
+
+## 制約・前提条件
+
+- **依存追加なし**: Python 標準 `logging`（`StreamHandler` / `Filter` / `Formatter`）のみ使用。
+- **`RunLogger` JSONL 契約の非破壊**: `logger.py` のフィールド・イベント名は変更しない。
+- **verdict marker 非汚染**: heartbeat 行は `---VERDICT---` / `---END_VERDICT---` および
+  `---` 始まりの marker 類似文字列を含めない（`verdict.py` の抽出正規表現を壊さない）。
+- **flush 必須**: subprocess の stdout は tty でないため Python は block-buffer する。各 heartbeat 行は
+  `flush=True` で即時送出しないと `script_exec` の pipe で終了まで溜まる。
+- **`--quiet` 連動**: heartbeat は exec stdout streaming に乗るため、`--quiet`（`verbose=False`）時は
+  `script_exec` 側で relay されない。これは「agent/exec streaming 抑制」という `--quiet` 既存意味と整合。
+- **polling 判定ロジック不変**: `classify` / `run_polling` の状態機械の終了判定（PASS / RETRY /
+  BACK_FALLBACK / ABORT）は変更しない。heartbeat は副作用追加のみ。
+
+## 変更スコープ
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `kaji_harness/cli_main.py` | `--log-level` option 追加、`configure_console_logging(level)` 呼び出し（`cmd_run` 冒頭） |
+| `kaji_harness/console_log.py`（新規・小） | `configure_console_logging()`：stdout（`<= INFO`）/ stderr（`>= WARNING`）の二ハンドラ + 二 formatter をルート `kaji` logger に設定。冪等 |
+| `kaji_harness/runner.py` | workflow start / step start / exec start / verdict detected / step end / transition / cycle / barrier / abort / workflow end の各点で `logging.getLogger("kaji.runner").info()/warning()` を発火（既存 `RunLogger` 呼び出しと並置） |
+| `kaji_harness/interactive_terminal.py` | pane launch 成功直後に pane launched progress を `logging.getLogger("kaji.interactive_terminal").info()` |
+| `kaji_harness/scripts/codex_review_poll.py` | `run_polling` に progress emit を追加（injectable callback、default は stdout flush print）。`format_heartbeat()` 純粋関数を追加 |
+| `tests/` | console routing / formatter / heartbeat content / verdict 非破壊 / flush / runner progress のテスト |
+
+kaji は Python 単一スタック。backend/frontend の Scope 分岐は無い。
+
+## 方針（Minimal How）
+
+### 1. console logging 設定（`console_log.py`）
+
+stdout/stderr split は logging の標準パターン（stdout handler に `levelno < WARNING` の Filter、
+stderr handler に `setLevel(WARNING)`）。
+
+```python
+ISO_LOCAL = "%Y-%m-%dT%H:%M:%S"  # local time。script_exec relay と整合
+
+def configure_console_logging(level: int = logging.INFO) -> None:
+    root = logging.getLogger("kaji")
+    root.setLevel(level)
+    root.propagate = False
+    # 冪等化: 既存 kaji handler を除去してから張り直す（再呼び出し / テスト対策）
+    for h in [h for h in root.handlers if getattr(h, "_kaji", False)]:
+        root.removeHandler(h)
+
+    out = logging.StreamHandler(sys.stdout)
+    out.addFilter(lambda r: r.levelno < logging.WARNING)
+    out.setFormatter(logging.Formatter("[%(asctime)s] [kaji] %(message)s", ISO_LOCAL))
+    out._kaji = True  # type: ignore[attr-defined]
+
+    err = logging.StreamHandler(sys.stderr)
+    err.setLevel(logging.WARNING)
+    err.setFormatter(logging.Formatter("[%(asctime)s] [kaji] %(levelname)s: %(message)s", ISO_LOCAL))
+    err._kaji = True  # type: ignore[attr-defined]
+
+    root.addHandler(out)
+    root.addHandler(err)
+```
+
+- 各モジュールは `logging.getLogger("kaji.<module>")` を使い、`kaji` ルートのハンドラに伝播させる。
+- `runner.py` 既存の `_logger = logging.getLogger(__name__)`（`kaji_harness.runner`）は **別系統**。
+  console progress 用には `kaji.*` 名前空間の logger を新規に用いる（混線回避）。
+
+### 2. runner progress 発火点
+
+既存 `RunLogger` 呼び出しの隣で、人間可読メッセージを `logging` に出す。表示対象は Issue「表示対象」節を網羅:
+
+| 進行 | 例（message 部のみ。formatter が `[ts] [kaji]` を付与） |
+|------|--------|
+| workflow start | `workflow start: <workflow.name> issue <issue_ref>` |
+| step start | `step start: <step_id> attempt-NNN dispatch=<agent\|exec\|exec_script> [agent=.. model=.. effort=..]` |
+| exec start | `exec start: <argv を join、長大なら省略>` |
+| pane launched（interactive_terminal） | `pane launched: <step_id> pane=<pane_id> verdict=<verdict_path>` |
+| verdict detected | `verdict detected: <step_id> source=<artifact\|comment\|stdout> status=<status>` |
+| step end | `step end: <step_id> status=<status> duration=<ms>ms next=<next_step_id\|end>` |
+| cycle iteration / exhaust | `cycle iteration: <name> <i>/<max>` / `cycle exhausted: <name>` |
+| `--before` barrier | `barrier hit: <step>` / `barrier missed: <step>`（missed は warning） |
+| abort / error | `WARNING: ...` / `ERROR: ...`（既存 `sys.stderr.write` 群を logging へ寄せる or 併置） |
+| workflow end | `workflow end: status=<status> duration=<ms>ms` |
+
+> next step id は `current_step.on.get(verdict.status)` 確定後に出す。step_end の next を表示するため、
+> transition 解決後に step end を出す順序とする（or step end と transition を 2 行に分ける）。
+
+### 3. review-poll heartbeat
+
+`run_polling` のループ末尾（`sleep` 直前）で progress を 1 回 emit。injectable callback で testability を確保。
+
+```python
+def format_heartbeat(*, elapsed_sec, pr_number, head_sha, state, remaining_sec) -> str:
+    # marker 非汚染: "---" を含めない素のテキスト
+    return (f"polling PR #{pr_number} head={head_sha[:7]} "
+            f"state={state} elapsed={int(elapsed_sec)}s remaining={max(0, int(remaining_sec))}s")
+
+def run_polling(..., emit_progress=_default_emit):  # _default_emit = print(..., flush=True)
+    ...
+    while True:
+        ...                                  # 既存判定（不変）
+        emit_progress(format_heartbeat(
+            elapsed_sec=now() - start,
+            pr_number=pr_number, head_sha=head_sha,
+            state=state, remaining_sec=no_reaction_timeout_sec - (now() - start)
+            # in_progress 中は in_progress_timeout 基準の残を表示する分岐を持たせる
+        ))
+        sleep(poll_interval_sec)
+```
+
+- `_default_emit(line)` は `sys.stdout.write(line + "\n"); sys.stdout.flush()`（または `print(line, flush=True)`）。
+- terminal state（`done_pass` / `done_retry`）で return する経路では heartbeat を出さず即 return（verdict 直前に
+  不要な progress を混ぜない）。`---VERDICT---` block は従来どおり `emit_verdict` が最後に 1 度出す。
+
+## テスト戦略
+
+> **CRITICAL**: 実行時コード変更（CLI option / logging 副作用 / polling ループ副作用）。
+> Small / Medium で検証観点を定義する。Large は新規追加しない（理由を明記）。
+
+### 変更タイプ
+
+実行時コード変更（起動コンソール出力・subprocess stdout 副作用・CLI option 追加）。
+
+### Small テスト
+
+- **console routing**: `configure_console_logging()` 後、`StringIO` を差した stdout/stderr 相当で、
+  `INFO`/`DEBUG` レコードが stdout 側のみ、`WARNING`/`ERROR` が stderr 側のみに出ることを検証。
+- **formatter 整形**: INFO 行が `^\[<ISO local>\] \[kaji\] <msg>$`、WARNING 行が
+  `\[kaji\] WARNING: <msg>` 形式であることを正規表現で検証。`--log-level WARNING` 時に INFO が出ないこと。
+- **冪等性**: `configure_console_logging()` 二度呼びでハンドラが重複登録されない（行が二重化しない）。
+- **`format_heartbeat()` 純粋関数**: 必須要素（PR 番号・head[:7]・elapsed・remaining・state）を含み、
+  かつ `---VERDICT---` / `---END_VERDICT---` / `---` を **含まない** ことを assert。
+- **`--log-level` parse**: default `INFO`、未定義値で argparse エラー（`choices`）。
+
+### Medium テスト
+
+- **`run_polling` heartbeat**: `now` / `sleep` / `emit_progress`（収集リスト）を注入し、poll 毎に 1 回
+  heartbeat が呼ばれること、elapsed / remaining が単調に推移すること、終了判定（PollResult.state）が
+  従来と同一であることを検証（既存の `run_polling` medium テスト資産を流用）。
+- **verdict parse 非破壊**: heartbeat を複数行混ぜた `codex_review_poll.main()` の合成 stdout を
+  `parse_verdict_block()` / `resolve_verdict()` に渡し、抽出される `status` が heartbeat 無しの場合と
+  一致することを検証（完了条件「heartbeat が `---VERDICT---` parse を破壊しない」をテストで固定）。
+- **flush 検証**: `write`/`flush` 呼び出しを記録する fake stream を `_default_emit` に差し、各 heartbeat で
+  `flush` が呼ばれることを assert（subprocess pipe で終了まで溜まらないことの単位化）。
+- **runner progress**: 既存 runner テスト（exec-step 最小 workflow）を `capsys` で回し、`[kaji] workflow
+  start` / `step start` / `exec start` / `verdict detected` / `step end ... next=...` / `workflow end` が
+  stdout に、WARNING 系が stderr に出ることを検証。`RunLogger` の `run.log` JSONL が不変であることも併検証。
+
+### Large テスト
+
+- **追加しない**。理由（`docs/dev/testing-convention.md` の 4 条件）:
+  1. polling の API 経路・判定ロジックに新規ロジックを追加しない（heartbeat は観測副作用のみ）。
+  2. 想定不具合（marker 汚染 / flush 漏れ / routing 誤り）は上記 Small/Medium と既存品質ゲートで捕捉済み。
+  3. 実 GitHub 疎通を足しても、logging/heartbeat に関する新規回帰シグナルはほぼ増えない
+     （実 API 疎通は既存 review-poll Large テストが既にカバー）。
+  4. 以上をレビュー可能な形で説明できる。
+
+## 影響ドキュメント
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/reference/python/logging.md | **あり** | 「禁止事項: 標準 logging の直接使用」が現状 blanket 記述。これを **RunLogger / run.log（JSONL 機械可読ログ）文脈に scope 限定** し、別途「起動コンソール向け console progress logging（stdlib logging, `kaji.*` 名前空間）」層の存在と方針（stdout/stderr split・formatter）を追記する必要がある |
+| docs/cli-guides/ | **あり** | `kaji run` の `--log-level` option 追記。`interactive-terminal-runner.md` に起動コンソール progress（pane launched 等）への言及余地 |
+| docs/ARCHITECTURE.md | **あり（軽微）** | 起動コンソール observability 層（人間向け console logging）と `run.log`（機械可読 JSONL）の責務分離を 1 段落で補足 |
+| docs/adr/ | なし | 新ライブラリ採用なし（stdlib logging）。`ConsoleReporter` 不採用は Issue 方針で確定済みのため ADR 不要 |
+| docs/dev/ | なし | workflow / 開発手順の変更なし |
+| CLAUDE.md | なし | 規約・必読文書の変更なし |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| Python `logging` HOWTO | https://docs.python.org/3/howto/logging.html | 「Logging Levels」「Handlers send the log records to the appropriate destination」。複数 Handler で出力先を分離し、Handler ごとに level / Filter / Formatter を独立設定できる → stdout(`<WARNING`)/stderr(`>=WARNING`) 二分割の根拠 |
+| `logging.Formatter` (datefmt) | https://docs.python.org/3/library/logging.html#logging.Formatter | `datefmt` で `asctime` の書式を指定可能。`%Y-%m-%dT%H:%M:%S` で `2026-06-07T12:34:56`（local time）形式を再現 |
+| `logging.Filter` | https://docs.python.org/3/library/logging.html#filter-objects | Handler に Filter を付け `record.levelno < WARNING` で INFO 以下のみ stdout に通す根拠 |
+| 組み込み `print`（flush） | https://docs.python.org/3/library/functions.html#print | `flush` 引数で「stream は強制的に flush される」。pipe（非 tty）出力時の block buffering を回避し heartbeat を即時送出する根拠 |
+| 現行 relay 実装 | `kaji_harness/script_exec.py:146` | `print(f"[{_now_stamp()}] [{step.id}] {stripped}")`。`_now_stamp()` は `datetime.now().isoformat(timespec="seconds")`（local time）→ console formatter を local time にそろえる根拠 |
+| RunLogger JSONL 契約 | `docs/reference/python/logging.md` / `kaji_harness/logger.py` | JSONL 機械可読ログの source of truth。console logging はこの契約に影響しない別系統であることの裏付け |

--- a/draft/design/issue-235-harness-progress-review-poll-heartbeat.md
+++ b/draft/design/issue-235-harness-progress-review-poll-heartbeat.md
@@ -74,8 +74,20 @@ kaji run .kaji/wf/feature-development.yaml 235 --quiet
 ### エラー
 
 - `--log-level` に未定義値 → argparse `choices` で fail-fast（exit 2 相当、既存定義エラー経路）。
-- heartbeat 出力中の `print` 失敗（pipe 切断等）は polling 判定ロジックに影響させない
+- **heartbeat emitter の失敗隔離**: heartbeat 出力中の `sys.stdout.write` / `flush` が
+  `BrokenPipeError` または `OSError` を送出しても、polling 判定ロジックには一切影響させない
   （観測のみの副作用。verdict 判定は不変）。
+  - **捕捉責務の所在**: 二段で containment する。
+    1. **`_default_emit(line)`（出力実体）**: `sys.stdout.write` / `flush` を `try/except
+       (BrokenPipeError, OSError)` で囲み、捕捉したら **黙って return**（heartbeat は best-effort）。
+       pipe 切断（reader 側の `script_exec` が先に閉じた等）を polling 失敗に昇格させない。
+    2. **`run_polling`（呼び出し側）**: 注入された `emit_progress` が任意の例外を投げても
+       polling state を変えないよう、`emit_progress(...)` 呼び出しを `try/except Exception`
+       で囲み、例外を捨てる。これにより custom emitter（テストの fake 含む）が壊れても
+       state machine の終了判定は不変に保たれる。
+  - **根拠**: 組み込み `print` / stream の `flush=True` は flush を強制するが、write/flush 失敗を
+    自動で無害化する契約ではない（後述 Primary Sources）。「観測のみの副作用」を満たすには
+    上記の明示的 containment が必要。
 
 ## 制約・前提条件
 
@@ -96,10 +108,11 @@ kaji run .kaji/wf/feature-development.yaml 235 --quiet
 |----------|----------|
 | `kaji_harness/cli_main.py` | `--log-level` option 追加、`configure_console_logging(level)` 呼び出し（`cmd_run` 冒頭） |
 | `kaji_harness/console_log.py`（新規・小） | `configure_console_logging()`：stdout（`<= INFO`）/ stderr（`>= WARNING`）の二ハンドラ + 二 formatter をルート `kaji` logger に設定。冪等 |
-| `kaji_harness/runner.py` | workflow start / step start / exec start / verdict detected / step end / transition / cycle / barrier / abort / workflow end の各点で `logging.getLogger("kaji.runner").info()/warning()` を発火（既存 `RunLogger` 呼び出しと並置） |
+| `kaji_harness/runner.py` | workflow start / step start / verdict detected / step end / transition / cycle / barrier / abort / workflow end の各点で `logging.getLogger("kaji.runner").info()/warning()` を発火（既存 `RunLogger` 呼び出しと並置） |
+| `kaji_harness/script_exec.py` | `exec start` progress を **`_run_argv`（`exec` / `exec_script` 共有コア）** から発火。実 argv を知るのは runner ではなくこの層のため（後述 § 2 の argv 表示参照） |
 | `kaji_harness/interactive_terminal.py` | pane launch 成功直後に pane launched progress を `logging.getLogger("kaji.interactive_terminal").info()` |
 | `kaji_harness/scripts/codex_review_poll.py` | `run_polling` に progress emit を追加（injectable callback、default は stdout flush print）。`format_heartbeat()` 純粋関数を追加 |
-| `tests/` | console routing / formatter / heartbeat content / verdict 非破壊 / flush / runner progress のテスト |
+| `tests/` | console routing / formatter / heartbeat content / verdict 非破壊 / flush / **emitter 失敗隔離** / runner progress のテスト追加 + 既存 `tests/test_cli_timestamp.py::test_quiet_flag_suppresses_timestamp_output` の期待値更新（`[kaji]` progress 行は残る前提に絞る） |
 
 kaji は Python 単一スタック。backend/frontend の Scope 分岐は無い。
 
@@ -146,8 +159,8 @@ def configure_console_logging(level: int = logging.INFO) -> None:
 | 進行 | 例（message 部のみ。formatter が `[ts] [kaji]` を付与） |
 |------|--------|
 | workflow start | `workflow start: <workflow.name> issue <issue_ref>` |
-| step start | `step start: <step_id> attempt-NNN dispatch=<agent\|exec\|exec_script> [agent=.. model=.. effort=..]` |
-| exec start | `exec start: <argv を join、長大なら省略>` |
+| step start | `step start: <step_id> attempt-NNN dispatch=<agent\|exec\|exec_script> [agent=.. model=.. effort=..]`（runner.py） |
+| exec start | `exec start: <argv を join、長大なら省略>`（**script_exec.py の `_run_argv`**。理由は下記） |
 | pane launched（interactive_terminal） | `pane launched: <step_id> pane=<pane_id> verdict=<verdict_path>` |
 | verdict detected | `verdict detected: <step_id> source=<artifact\|comment\|stdout> status=<status>` |
 | step end | `step end: <step_id> status=<status> duration=<ms>ms next=<next_step_id\|end>` |
@@ -158,6 +171,20 @@ def configure_console_logging(level: int = logging.INFO) -> None:
 
 > next step id は `current_step.on.get(verdict.status)` 確定後に出す。step_end の next を表示するため、
 > transition 解決後に step end を出す順序とする（or step end と transition を 2 行に分ける）。
+
+#### `exec start` の argv 表示位置（`exec` / `exec_script` 共通化）
+
+`exec start` だけは runner.py ではなく **`script_exec.py` の `_run_argv`** から発火する。理由:
+
+- 実 argv を組み立てるのは `_run_argv` の呼び出し元であり、runner.py は知らない:
+  - `execute_exec` → `command_label=" ".join(argv)`（workflow.yaml の任意 argv そのまま）
+  - `execute_script` → `args=[sys.executable, "-m", module]` / `command_label=module`（runner からは module 名のみ）
+- もし runner.py で表示すると `exec_script` は module 名しか出せず、`exec` と表示粒度が食い違う。
+- `_run_argv` は両 dispatch の唯一の共有コアで、既に `command_label`（`exec`=full argv / `exec_script`=module）と
+  実 `args` を保持する。ここで `exec start: <argv>` を 1 箇所だけ発火すれば、両 dispatch で
+  **同じ作り方の argv 文字列**（`" ".join(args)`。長大時は末尾省略）を一貫表示でき、実装重複も避けられる。
+- relay 行 `[ts] [step_id] ...` と同じ `_now_stamp()`（local time）コンテキストに並ぶため、
+  console formatter の local time とも整合する。
 
 ### 3. review-poll heartbeat
 
@@ -182,7 +209,27 @@ def run_polling(..., emit_progress=_default_emit):  # _default_emit = print(...,
         sleep(poll_interval_sec)
 ```
 
-- `_default_emit(line)` は `sys.stdout.write(line + "\n"); sys.stdout.flush()`（または `print(line, flush=True)`）。
+- `_default_emit(line)` は `sys.stdout.write(line + "\n"); sys.stdout.flush()` を行い、
+  `BrokenPipeError` / `OSError` を捕捉して return する（best-effort。失敗を例外として伝播させない）:
+
+  ```python
+  def _default_emit(line: str) -> None:
+      try:
+          sys.stdout.write(line + "\n")
+          sys.stdout.flush()
+      except (BrokenPipeError, OSError):
+          return  # heartbeat は観測のみ。pipe 切断を polling 失敗に昇格させない
+  ```
+
+- `run_polling` 側でも、注入 emitter が壊れても state machine を守るため emit 呼び出しを隔離する:
+
+  ```python
+  try:
+      emit_progress(format_heartbeat(...))
+  except Exception:
+      pass  # emitter 例外は polling 判定に影響させない（観測のみの副作用）
+  ```
+
 - terminal state（`done_pass` / `done_retry`）で return する経路では heartbeat を出さず即 return（verdict 直前に
   不要な progress を混ぜない）。`---VERDICT---` block は従来どおり `emit_verdict` が最後に 1 度出す。
 
@@ -212,13 +259,29 @@ def run_polling(..., emit_progress=_default_emit):  # _default_emit = print(...,
   heartbeat が呼ばれること、elapsed / remaining が単調に推移すること、終了判定（PollResult.state）が
   従来と同一であることを検証（既存の `run_polling` medium テスト資産を流用）。
 - **verdict parse 非破壊**: heartbeat を複数行混ぜた `codex_review_poll.main()` の合成 stdout を
-  `parse_verdict_block()` / `resolve_verdict()` に渡し、抽出される `status` が heartbeat 無しの場合と
-  一致することを検証（完了条件「heartbeat が `---VERDICT---` parse を破壊しない」をテストで固定）。
+  `parse_verdict_block()`（現行 `kaji_harness/verdict.py:544` に実在）/ `resolve_verdict()`（同 `:608`）に渡し、
+  抽出される `status` が heartbeat 無しの場合と一致することを検証
+  （完了条件「heartbeat が `---VERDICT---` parse を破壊しない」をテストで固定）。
 - **flush 検証**: `write`/`flush` 呼び出しを記録する fake stream を `_default_emit` に差し、各 heartbeat で
   `flush` が呼ばれることを assert（subprocess pipe で終了まで溜まらないことの単位化）。
+- **emitter 失敗隔離（Must Fix 対応）**: 二観点を固定する。
+  1. **`_default_emit` の例外吸収**: `sys.stdout` を `write`/`flush` で `BrokenPipeError`（および
+     `OSError`）を投げる fake stream に差し替え、`_default_emit("line")` が **例外を送出せず return** すること。
+  2. **`run_polling` の state 不変**: 必ず例外を投げる `emit_progress`（`raise BrokenPipeError` / 任意 `Exception`）を
+     注入して `run_polling` を回し、heartbeat 無し（`emit_progress` 省略時）と **同一の `PollResult.state`**
+     （done_pass / done_retry / done_fallback / done_abort）になることを、既存の medium 状態機械シナリオで検証。
+     → 「heartbeat は観測のみの副作用」を回帰テストで固定する。
 - **runner progress**: 既存 runner テスト（exec-step 最小 workflow）を `capsys` で回し、`[kaji] workflow
   start` / `step start` / `exec start` / `verdict detected` / `step end ... next=...` / `workflow end` が
   stdout に、WARNING 系が stderr に出ることを検証。`RunLogger` の `run.log` JSONL が不変であることも併検証。
+- **既存 `--quiet` テストの整合更新（Should Fix 対応）**:
+  `tests/test_cli_timestamp.py::test_quiet_flag_suppresses_timestamp_output`（現状 `:347-390`）は
+  「`--quiet` 時に `^\[<ISO>\]` で始まる timestamp 行が stdout に **一切** 出ない」ことを期待している。
+  本設計では `--quiet`（agent/exec streaming 抑制）でも harness progress（`[ts] [kaji] ...`）は
+  `--log-level`（default INFO）で出るため、この期待は成立しなくなる。**期待値を「抑制対象は
+  agent/exec relay 行（`[ts] [step_id] ...`、`[kaji]` 以外の prefix）のみで、`[ts] [kaji] ...` の
+  harness progress 行は残る」へ更新する**（regex を `\[kaji\]` を除外する形に絞る、または relay prefix を
+  明示的に対象化する）。この更新は本設計に伴う必須変更として `tests/` 変更スコープに含める。
 
 ### Large テスト
 

--- a/kaji_harness/cli_main.py
+++ b/kaji_harness/cli_main.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import logging
 import shutil
 import subprocess
 import sys
@@ -163,6 +164,15 @@ def _register_run(subparsers: argparse._SubParsersAction[argparse.ArgumentParser
         help="Starting directory for config discovery (default: current directory)",
     )
     p.add_argument("--quiet", action="store_true", help="Suppress agent output streaming")
+    # Issue #235: 起動コンソール progress（stdlib logging）の閾値。--quiet とは独立で、
+    # agent/exec の stdout streaming 抑制（--quiet）と harness progress 表示を分離する。
+    p.add_argument(
+        "--log-level",
+        dest="log_level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Console progress log level (default: INFO).",
+    )
     # Issue #224: per-run overrides for the [execution] runner backend. These take
     # precedence over both config.local.toml and config.toml (precedence 1).
     p.add_argument(
@@ -365,6 +375,12 @@ def _apply_execution_overrides(config: KajiConfig, args: argparse.Namespace) -> 
 
 def cmd_run(args: argparse.Namespace) -> int:
     """Execute the `run` subcommand."""
+    # Issue #235: 起動コンソール progress logging を初期化する（argparse choices で
+    # 検証済みの log level を stdlib level int へ変換）。RunLogger の JSONL とは別系統。
+    from .console_log import configure_console_logging
+
+    configure_console_logging(getattr(logging, getattr(args, "log_level", "INFO")))
+
     # Mutual exclusion: --from and --step
     if args.from_step and args.single_step:
         print(

--- a/kaji_harness/console_log.py
+++ b/kaji_harness/console_log.py
@@ -1,0 +1,58 @@
+"""起動コンソール向け human-readable progress logging の設定（Issue #235）。
+
+``run.log``（``RunLogger`` が書く JSONL 機械可読ログ）とは **別系統** の、
+``kaji run`` 起動コンソール向け表示層。stdlib ``logging`` の二ハンドラで
+``INFO`` 以下を stdout、``WARNING`` 以上を stderr に振り分ける。
+
+各モジュールは ``logging.getLogger("kaji.<module>")`` を使い、``kaji`` ルート
+logger に設定したハンドラへ伝播させる。``RunLogger`` の JSONL 契約には一切
+影響しない（``docs/reference/python/logging.md`` の機械可読ログとは責務が異なる）。
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+# local time。``script_exec`` の relay 行 ``[ts] [step_id] ...`` が
+# ``datetime.now()``（local time）を使うため、同一タイムラインに並べるには
+# console も local time にそろえる。
+ISO_LOCAL = "%Y-%m-%dT%H:%M:%S"
+
+# console progress 用ルート logger 名。``RunLogger`` (``kaji_harness.*``) とは
+# 別ツリーにして混線を避ける。
+ROOT_LOGGER_NAME = "kaji"
+
+
+def configure_console_logging(level: int = logging.INFO) -> None:
+    """``kaji`` ルート logger に stdout / stderr の二ハンドラを設定する。
+
+    stdout handler は ``levelno < WARNING`` の Filter で INFO 以下のみ通す。
+    stderr handler は ``setLevel(WARNING)`` で WARNING 以上のみ通す。冪等：
+    再呼び出し時は既存の kaji handler を除去してから張り直すため、ハンドラが
+    重複登録されない（テスト / resume で複数回呼ばれても安全）。
+
+    Args:
+        level: ルート logger の閾値。default ``logging.INFO``。
+    """
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    root.setLevel(level)
+    root.propagate = False
+    # 冪等化: 既存 kaji handler を除去してから張り直す。
+    for handler in [h for h in root.handlers if getattr(h, "_kaji", False)]:
+        root.removeHandler(handler)
+
+    out = logging.StreamHandler(sys.stdout)
+    out.addFilter(lambda record: record.levelno < logging.WARNING)
+    out.setFormatter(logging.Formatter("[%(asctime)s] [kaji] %(message)s", ISO_LOCAL))
+    out._kaji = True  # type: ignore[attr-defined]
+
+    err = logging.StreamHandler(sys.stderr)
+    err.setLevel(logging.WARNING)
+    err.setFormatter(
+        logging.Formatter("[%(asctime)s] [kaji] %(levelname)s: %(message)s", ISO_LOCAL)
+    )
+    err._kaji = True  # type: ignore[attr-defined]
+
+    root.addHandler(out)
+    root.addHandler(err)

--- a/kaji_harness/interactive_terminal.py
+++ b/kaji_harness/interactive_terminal.py
@@ -20,6 +20,7 @@ with no latency contract.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import shlex
@@ -31,6 +32,9 @@ from pathlib import Path
 
 from .errors import CLIExecutionError, CLINotFoundError, StepTimeoutError
 from .models import CLIResult, Step
+
+# Issue #235: 起動コンソール向け progress logger（kaji.* 名前空間）。
+_console = logging.getLogger("kaji.interactive_terminal")
 
 _CODEX_RESUME_RE = re.compile(
     r"\bcodex\s+resume\s+([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b"
@@ -214,6 +218,8 @@ def execute_interactive_terminal(
         model=step.model or "",
         effort=step.effort or "",
     )
+    # Issue #235: pane 起動成功直後に起動コンソールへ progress を出す。
+    _console.info("pane launched: %s pane=%s verdict=%s", step.id, pane_id, verdict_path)
     if not _pipe_pane(tmux, pane_id, terminal_log):
         # tmux rejected the pipe — most likely the pane already closed because a
         # short-running agent wrote verdict.yaml and exited before we could

--- a/kaji_harness/runner.py
+++ b/kaji_harness/runner.py
@@ -49,6 +49,11 @@ from .worktree_discovery import AmbiguousWorktreeError, discover_existing_worktr
 # ``logger`` という名でローカル束縛する既存規約を持つため）。
 _logger = logging.getLogger(__name__)
 
+# Issue #235: 起動コンソール向け human-readable progress logger（kaji.* 名前空間）。
+# ``_logger``（``kaji_harness.runner``）とは別ツリーで、console_log の handler に
+# 伝播する。RunLogger の JSONL 契約とは独立した人間向け表示のみを担う。
+_console = logging.getLogger("kaji.runner")
+
 
 def allocate_attempt_dir(run_dir: Path, step_id: str) -> Path:
     """Issue #220: 当該 step の次の attempt ディレクトリを採番して作成する。
@@ -444,6 +449,7 @@ class WorkflowRunner:
         run_dir.mkdir(parents=True, exist_ok=True)
         logger = RunLogger(log_path=run_dir / "run.log")
         logger.log_workflow_start(run_ctx.canonical_id, self.workflow.name)
+        _console.info("workflow start: %s issue %s", self.workflow.name, run_ctx.issue_ref)
 
         # 4. 開始ステップの決定
         if self.single_step:
@@ -478,6 +484,7 @@ class WorkflowRunner:
             )
             last_verdict = ambiguous_abort
             end_status = "ABORT"
+            _console.error("workflow abort: %s", ambiguous_abort.reason)
             # cli_main は state.last_transition_verdict.status == "ABORT" を見て
             # EXIT_ABORT を返すため、main loop 未到達でもここで反映する。
             state.last_transition_verdict = ambiguous_abort
@@ -490,6 +497,7 @@ class WorkflowRunner:
                 total_cost=total_cost if total_cost > 0 else None,
                 error=None,
             )
+            _console.info("workflow end: status=%s duration=%dms", end_status, total_duration_ms)
             return state
 
         # 5. メインループ
@@ -498,6 +506,7 @@ class WorkflowRunner:
                 # --before barrier: dispatch 直前で停止（開始 step / --from 開始 step も含む）
                 if self.before_step and current_step.id == self.before_step:
                     logger.log_barrier_hit(self.before_step)
+                    _console.info("barrier hit: %s", self.before_step)
                     barrier_hit = True
                     break
 
@@ -547,6 +556,7 @@ class WorkflowRunner:
                         evidence=f"{cycle.max_iterations} iterations reached",
                         suggestion="手動で確認してください",
                     )
+                    _console.info("cycle exhausted: %s", cycle.name)
                     cost: CostInfo | None = None
                 else:
                     # PR context は step ごとに最新状態を見る（`i-pr` step 実行後など、
@@ -578,6 +588,23 @@ class WorkflowRunner:
                         session_id,
                         attempt=attempt_no,
                         dispatch=dispatch_label,
+                    )
+                    # Issue #235: agent step のみ agent/model/effort を付記する
+                    # （exec / exec_script は LLM 非経路なので付けない）。
+                    agent_suffix = ""
+                    if not is_script_like:
+                        agent_parts = [f"agent={current_step.agent}"]
+                        if current_step.model:
+                            agent_parts.append(f"model={current_step.model}")
+                        if current_step.effort:
+                            agent_parts.append(f"effort={current_step.effort}")
+                        agent_suffix = " " + " ".join(agent_parts)
+                    _console.info(
+                        "step start: %s %s dispatch=%s%s",
+                        current_step.id,
+                        attempt_dir.name,
+                        dispatch_label,
+                        agent_suffix,
                     )
 
                     # タイムアウト解決: workflow.default_timeout → config.execution.default_timeout
@@ -728,6 +755,12 @@ class WorkflowRunner:
                             ai_formatter=formatter,
                         )
                         logger.log_verdict_source(current_step.id, verdict_source, attempt_dir.name)
+                        _console.info(
+                            "verdict detected: %s source=%s status=%s",
+                            current_step.id,
+                            verdict_source,
+                            verdict.status,
+                        )
                         # 解決 source が artifact 以外なら正規化保存（legacy skill が
                         # stdout しか出さなくても attempt-NNN/verdict.yaml を必ず残す）。
                         if verdict_source != "artifact":
@@ -831,18 +864,41 @@ class WorkflowRunner:
                         state.cycle_iterations(cycle.name),
                         cycle.max_iterations,
                     )
+                    _console.info(
+                        "cycle iteration: %s %d/%d",
+                        cycle.name,
+                        state.cycle_iterations(cycle.name),
+                        cycle.max_iterations,
+                    )
 
                 # 次のステップを決定
                 if self.single_step:
+                    # Issue #235: --step は遷移しないので next=end として step end を出す。
+                    _console.info(
+                        "step end: %s status=%s duration=%dms next=end",
+                        current_step.id,
+                        verdict.status,
+                        duration_ms,
+                    )
                     break
 
                 next_step_id = current_step.on.get(verdict.status)
                 if next_step_id is None:
                     raise InvalidTransition(current_step.id, verdict.status)
 
+                # Issue #235: next step 解決後に step end progress を出す（next を含めるため）。
+                _console.info(
+                    "step end: %s status=%s duration=%dms next=%s",
+                    current_step.id,
+                    verdict.status,
+                    duration_ms,
+                    next_step_id,
+                )
+
                 # --before barrier: dispatch 直前で停止
                 if self.before_step and next_step_id == self.before_step:
                     logger.log_barrier_hit(self.before_step)
+                    _console.info("barrier hit: %s", self.before_step)
                     barrier_hit = True
                     break
 
@@ -863,6 +919,7 @@ class WorkflowRunner:
                 and naturally_completed
             ):
                 logger.log_barrier_missed(self.before_step)
+                _console.warning("barrier missed: %s", self.before_step)
                 print(
                     f"WARN: stop point '{self.before_step}' was never reached; "
                     "workflow completed naturally",
@@ -875,6 +932,7 @@ class WorkflowRunner:
         except Exception as exc:
             end_status = "ERROR"
             end_error = f"{type(exc).__name__}: {exc}"
+            _console.error("workflow error: %s", end_error)
             raise
         finally:
             total_duration_ms = int((time.monotonic() - workflow_start) * 1000)
@@ -885,4 +943,5 @@ class WorkflowRunner:
                 total_cost=total_cost if total_cost > 0 else None,
                 error=end_error,
             )
+            _console.info("workflow end: status=%s duration=%dms", end_status, total_duration_ms)
         return state

--- a/kaji_harness/script_exec.py
+++ b/kaji_harness/script_exec.py
@@ -23,6 +23,7 @@ private helper ``_run_argv`` で共有する。共通の不変条件:
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
@@ -35,6 +36,13 @@ from .errors import CLINotFoundError, ScriptExecutionError, StepTimeoutError
 from .models import CLIResult, Step
 from .result import derive_signal
 
+# Issue #235: 起動コンソール向け progress logger（kaji.* 名前空間）。
+# RunLogger の JSONL とは別系統で、人間向け表示のみを担う。
+_console = logging.getLogger("kaji.script_exec")
+
+# exec start 行で表示する argv 文字列の最大長。これを超えたら末尾を省略する。
+_ARGV_DISPLAY_LIMIT = 200
+
 # skill-authoring.md の env 契約上「未解決なら未注入」となる reserved 変数。
 # parent process に古い値が残っていた場合に subprocess へ漏れて
 # review_poll_entry 等が無関係 PR を polling する事故を防ぐため、
@@ -44,6 +52,19 @@ _OPTIONAL_RESERVED_ENV = frozenset({"KAJI_PR_ID", "KAJI_PR_REF"})
 
 def _now_stamp() -> str:
     return datetime.now().isoformat(timespec="seconds")
+
+
+def _format_argv(args: list[str]) -> str:
+    """argv を 1 行表示用に join する。長大なら末尾を省略する。
+
+    exec / exec_script 共通の表示作法。``command_label`` ではなく実 ``args`` を
+    join することで、両 dispatch で同じ作り方の argv 文字列を一貫表示する
+    （設計書 § exec start の argv 表示位置）。
+    """
+    joined = " ".join(args)
+    if len(joined) > _ARGV_DISPLAY_LIMIT:
+        return joined[:_ARGV_DISPLAY_LIMIT] + "…"
+    return joined
 
 
 def _run_argv(
@@ -83,6 +104,11 @@ def _run_argv(
     full_env = {**base_env, **env}
 
     log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Issue #235: 起動コンソールへ exec start progress を出す。実 argv を知るのは
+    # この共有コアのみ（runner は exec_script の module 名しか持たない）ため、
+    # exec / exec_script いずれもここで 1 箇所だけ発火し表示粒度を揃える。
+    _console.info("exec start: %s", _format_argv(args))
 
     try:
         process = subprocess.Popen(

--- a/kaji_harness/scripts/codex_review_poll.py
+++ b/kaji_harness/scripts/codex_review_poll.py
@@ -43,6 +43,45 @@ class PollResult:
     reason: str
 
 
+def format_heartbeat(
+    *,
+    elapsed_sec: float,
+    pr_number: int,
+    head_sha: str,
+    state: str,
+    remaining_sec: float,
+) -> str:
+    """polling 進捗 heartbeat の 1 行を組み立てる純粋関数（Issue #235）。
+
+    起動コンソール運用者が「待機中 / 停止中 / エラー」を切り分けられるよう、
+    経過秒・PR 番号・head 短縮・観測中 state・timeout 残を 1 行に含める。
+
+    verdict marker 非汚染: ``---VERDICT---`` / ``---END_VERDICT---`` および
+    ``---`` 始まりの marker 類似文字列を **含めない** 素のテキストを返す
+    （``verdict.py`` の抽出正規表現を壊さない）。
+    """
+    return (
+        f"polling PR #{pr_number} head={head_sha[:7]} "
+        f"state={state} elapsed={int(elapsed_sec)}s remaining={max(0, int(remaining_sec))}s"
+    )
+
+
+def _default_emit(line: str) -> None:
+    """heartbeat を stdout へ flush 出力する既定 emitter。
+
+    subprocess の stdout は非 tty で block-buffer されるため、各行を
+    ``flush()`` で即時送出しないと ``script_exec`` の pipe で終了まで溜まる。
+    ``BrokenPipeError`` / ``OSError``（reader 側が先に閉じた等）は捕捉して
+    黙って return する。heartbeat は観測のみの best-effort 副作用であり、
+    pipe 切断を polling 失敗へ昇格させない。
+    """
+    try:
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+    except (BrokenPipeError, OSError):
+        return
+
+
 def _is_bot(user: dict[str, Any], bot_id: int) -> bool:
     """Match by id (primary). login is checked only as a secondary signal."""
     return isinstance(user, dict) and user.get("id") == bot_id
@@ -138,11 +177,17 @@ def run_polling(
     bot_id: int = BOT_ID,
     now: object = time.monotonic,
     sleep: object = time.sleep,
+    emit_progress: object = _default_emit,
 ) -> PollResult:
     """Drive the state machine until a terminal state is reached.
 
     `now` and `sleep` are injectable for medium tests. `head_committed_at`
     is fetched once by the caller (skill bash) and held constant across polls.
+
+    `emit_progress` is an injectable heartbeat sink (default: stdout flush
+    print). It is called once per non-terminal poll just before sleeping and
+    is fully isolated: any exception it raises is swallowed so the verdict
+    state machine stays unchanged (Issue #235, heartbeat is observation only).
     """
     reactions_path = f"repos/{owner}/{repo}/issues/{pr_number}/reactions"
     reviews_path = f"repos/{owner}/{repo}/pulls/{pr_number}/reviews"
@@ -215,6 +260,26 @@ def run_polling(
                         "done_abort",
                         f"IN_PROGRESS_TIMEOUT_SEC ({in_progress_timeout_sec}s) exceeded",
                     )
+
+        # Issue #235: non-terminal poll の末尾で heartbeat を 1 回 emit する。
+        # emitter が任意の例外を投げても polling 判定（state machine）には影響
+        # させない（観測のみの副作用）。
+        if state == "in_progress" and in_progress_start is not None:
+            remaining = in_progress_timeout_sec - (now() - in_progress_start)  # type: ignore[operator]
+        else:
+            remaining = no_reaction_timeout_sec - elapsed
+        try:
+            emit_progress(  # type: ignore[operator]
+                format_heartbeat(
+                    elapsed_sec=elapsed,
+                    pr_number=pr_number,
+                    head_sha=head_sha,
+                    state=state,
+                    remaining_sec=remaining,
+                )
+            )
+        except Exception:
+            pass
 
         sleep(poll_interval_sec)  # type: ignore[operator]
 

--- a/kaji_harness/scripts/codex_review_poll.py
+++ b/kaji_harness/scripts/codex_review_poll.py
@@ -185,9 +185,12 @@ def run_polling(
     is fetched once by the caller (skill bash) and held constant across polls.
 
     `emit_progress` is an injectable heartbeat sink (default: stdout flush
-    print). It is called once per non-terminal poll just before sleeping and
-    is fully isolated: any exception it raises is swallowed so the verdict
-    state machine stays unchanged (Issue #235, heartbeat is observation only).
+    print). It is called once per non-terminal poll just before sleeping —
+    including the API-failure retry wait and the eyes-lost grace wait — so the
+    startup console can distinguish "waiting / stalled / erroring" on every
+    sleep path. It is fully isolated: any exception it raises is swallowed so
+    the verdict state machine stays unchanged (Issue #235, heartbeat is
+    observation only).
     """
     reactions_path = f"repos/{owner}/{repo}/issues/{pr_number}/reactions"
     reviews_path = f"repos/{owner}/{repo}/pulls/{pr_number}/reviews"
@@ -197,6 +200,31 @@ def run_polling(
     in_progress_start: float | None = None
     eyes_lost_at: float | None = None
     consecutive_failures = 0
+
+    def emit_heartbeat(state_label: str) -> None:
+        """非 terminal poll の sleep 直前に heartbeat を 1 回 emit する（Issue #235）。
+
+        elapsed / remaining は現在の state machine 状態から都度計算する。emitter が
+        任意の例外を投げても polling 判定（state machine）には一切影響させない
+        （観測のみの副作用）。
+        """
+        elapsed = now() - start  # type: ignore[operator]
+        if state == "in_progress" and in_progress_start is not None:
+            remaining = in_progress_timeout_sec - (now() - in_progress_start)  # type: ignore[operator]
+        else:
+            remaining = no_reaction_timeout_sec - elapsed
+        try:
+            emit_progress(  # type: ignore[operator]
+                format_heartbeat(
+                    elapsed_sec=elapsed,
+                    pr_number=pr_number,
+                    head_sha=head_sha,
+                    state=state_label,
+                    remaining_sec=remaining,
+                )
+            )
+        except Exception:
+            pass
 
     while True:
         try:
@@ -210,6 +238,8 @@ def run_polling(
                     "done_abort",
                     f"gh api failed {consecutive_failures} times in a row: {exc}",
                 )
+            # transient error の待機中であることを起動コンソールへ可視化する。
+            emit_heartbeat(f"api_retry:{consecutive_failures}/{api_failure_limit}")
             sleep(poll_interval_sec)  # type: ignore[operator]
             continue
 
@@ -250,6 +280,8 @@ def run_polling(
             else:
                 if eyes_lost_at is None:
                     eyes_lost_at = now()  # type: ignore[operator]
+                    # eyes 消失の grace 待機中であることを起動コンソールへ可視化する。
+                    emit_heartbeat("in_progress/eyes_lost_grace")
                     sleep(eyes_grace_sec)  # type: ignore[operator]
                     continue
                 if (
@@ -262,24 +294,7 @@ def run_polling(
                     )
 
         # Issue #235: non-terminal poll の末尾で heartbeat を 1 回 emit する。
-        # emitter が任意の例外を投げても polling 判定（state machine）には影響
-        # させない（観測のみの副作用）。
-        if state == "in_progress" and in_progress_start is not None:
-            remaining = in_progress_timeout_sec - (now() - in_progress_start)  # type: ignore[operator]
-        else:
-            remaining = no_reaction_timeout_sec - elapsed
-        try:
-            emit_progress(  # type: ignore[operator]
-                format_heartbeat(
-                    elapsed_sec=elapsed,
-                    pr_number=pr_number,
-                    head_sha=head_sha,
-                    state=state,
-                    remaining_sec=remaining,
-                )
-            )
-        except Exception:
-            pass
+        emit_heartbeat(state)
 
         sleep(poll_interval_sec)  # type: ignore[operator]
 

--- a/tests/test_cli_timestamp.py
+++ b/tests/test_cli_timestamp.py
@@ -345,7 +345,12 @@ class TestKajiRunTimestampLarge:
             )
 
     def test_quiet_flag_suppresses_timestamp_output(self, tmp_path: Path) -> None:
-        """--quiet フラグ使用時、タイムスタンプ付き出力が stdout に出ないこと。"""
+        """--quiet は agent/exec relay 行を抑制するが、harness progress は残る。
+
+        Issue #235: ``--quiet`` は agent/exec の stdout streaming（``[ts] [step_id]``
+        relay 行）を抑制する既存意味を保つ。一方 harness progress（``[ts] [kaji] ...``）
+        は ``--log-level``（default INFO）で制御され、``--quiet`` では抑制されない。
+        """
         wf, workdir = _build_e2e_env(tmp_path)
 
         bin_dir = tmp_path / "bin"
@@ -385,6 +390,14 @@ class TestKajiRunTimestampLarge:
             for line in result.stdout.splitlines()
             if re.match(r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\]", line)
         ]
-        assert not timestamp_lines, (
-            f"Expected no timestamp lines with --quiet, got: {timestamp_lines}"
+        # 抑制対象は agent/exec relay 行（`[ts] [step_id] ...`、`[kaji]` 以外の prefix）のみ。
+        relay_lines = [line for line in timestamp_lines if "[kaji]" not in line]
+        assert not relay_lines, (
+            f"Expected no agent/exec relay timestamp lines with --quiet, got: {relay_lines}"
+        )
+        # harness progress（`[ts] [kaji] ...`）は --quiet でも INFO で残る。
+        kaji_lines = [line for line in timestamp_lines if "[kaji]" in line]
+        assert kaji_lines, (
+            f"Expected harness progress [kaji] lines to remain with --quiet, "
+            f"got none. stdout={result.stdout!r}"
         )

--- a/tests/test_codex_review_poll.py
+++ b/tests/test_codex_review_poll.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -13,9 +14,12 @@ from kaji_harness.scripts import codex_review_poll as mod
 from kaji_harness.scripts.codex_review_poll import (
     BOT_ID,
     PollResult,
+    _default_emit,
     classify,
+    format_heartbeat,
     run_polling,
 )
+from kaji_harness.verdict import parse_verdict_block
 
 FIXTURES = Path(__file__).parent / "fixtures" / "codex_review_poll"
 HEAD = "abc123def4567890abc123def4567890abc123de"
@@ -310,3 +314,193 @@ class TestEmitVerdict:
         out = mod.emit_verdict(PollResult("done_abort", "api failed"), "check")
         assert "status: ABORT" in out
         assert "suggestion:" in out
+
+
+# --- format_heartbeat (Small) -----------------------------------------------
+
+
+@pytest.mark.small
+class TestFormatHeartbeat:
+    def test_contains_required_elements(self) -> None:
+        line = format_heartbeat(
+            elapsed_sec=12.7,
+            pr_number=176,
+            head_sha=HEAD,
+            state="in_progress",
+            remaining_sec=1788.0,
+        )
+        assert "PR #176" in line
+        assert f"head={HEAD[:7]}" in line
+        assert "elapsed=12s" in line  # int 切り捨て
+        assert "remaining=1788s" in line
+        assert "state=in_progress" in line
+
+    def test_does_not_contain_verdict_markers(self) -> None:
+        line = format_heartbeat(
+            elapsed_sec=0,
+            pr_number=1,
+            head_sha=HEAD,
+            state="init",
+            remaining_sec=60,
+        )
+        assert "---VERDICT---" not in line
+        assert "---END_VERDICT---" not in line
+        assert "---" not in line
+
+    def test_negative_remaining_clamped_to_zero(self) -> None:
+        line = format_heartbeat(
+            elapsed_sec=120,
+            pr_number=1,
+            head_sha=HEAD,
+            state="init",
+            remaining_sec=-5,
+        )
+        assert "remaining=0s" in line
+
+
+# --- heartbeat in run_polling (Medium) --------------------------------------
+
+
+@pytest.mark.medium
+class TestHeartbeat:
+    def _run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sequence: list[tuple[list[dict[str, Any]], list[dict[str, Any]]]],
+        **kwargs: Any,
+    ) -> tuple[PollResult, list[str]]:
+        _gh_responses(monkeypatch, sequence)
+        clock = _FakeClock()
+        emitted: list[str] = []
+        result = run_polling(
+            pr_number=176,
+            owner="apokamo",
+            repo="kaji",
+            head_sha=HEAD,
+            head_committed_at=HEAD_AT,
+            poll_interval_sec=10,
+            no_reaction_timeout_sec=60,
+            in_progress_timeout_sec=1800,
+            eyes_grace_sec=10,
+            now=clock.now,
+            sleep=clock.sleep,
+            emit_progress=emitted.append,
+            **kwargs,
+        )
+        return result, emitted
+
+    def test_heartbeat_emitted_each_nonterminal_poll(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        eyes = _load("reactions_eyes.json")
+        plus_one = _load("reactions_plus_one.json")
+        # poll1 eyes(in_progress), poll2 eyes(in_progress), poll3 plus_one(done_pass)
+        result, emitted = self._run(monkeypatch, [(eyes, []), (eyes, []), (plus_one, [])])
+        assert result.state == "done_pass"
+        # 非 terminal poll は 2 回 → heartbeat も 2 行（terminal poll では出さない）
+        assert len(emitted) == 2
+        for line in emitted:
+            assert "PR #176" in line
+            assert "---" not in line
+
+    def test_heartbeat_elapsed_monotonic_increasing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        eyes = _load("reactions_eyes.json")
+        plus_one = _load("reactions_plus_one.json")
+        _result, emitted = self._run(
+            monkeypatch, [(eyes, []), (eyes, []), (eyes, []), (plus_one, [])]
+        )
+        elapsed_vals = [int(re.search(r"elapsed=(\d+)s", ln).group(1)) for ln in emitted]
+        assert elapsed_vals == sorted(elapsed_vals)
+        assert len(set(elapsed_vals)) == len(elapsed_vals)  # 単調増加（重複なし）
+
+    def test_state_unchanged_when_emitter_always_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        eyes = _load("reactions_eyes.json")
+        plus_one = _load("reactions_plus_one.json")
+        seq = [(eyes, []), (eyes, []), (plus_one, [])]
+
+        def boom(_line: str) -> None:
+            raise BrokenPipeError("pipe closed")
+
+        # 例外を投げる emitter でも結論は heartbeat 無しと同一でなければならない
+        baseline, _ = self._run(monkeypatch, seq)
+        _gh_responses(monkeypatch, seq)
+        clock = _FakeClock()
+        with_raise = run_polling(
+            pr_number=176,
+            owner="apokamo",
+            repo="kaji",
+            head_sha=HEAD,
+            head_committed_at=HEAD_AT,
+            poll_interval_sec=10,
+            no_reaction_timeout_sec=60,
+            in_progress_timeout_sec=1800,
+            eyes_grace_sec=10,
+            now=clock.now,
+            sleep=clock.sleep,
+            emit_progress=boom,
+        )
+        assert with_raise.state == baseline.state == "done_pass"
+
+
+# --- _default_emit flush / failure isolation (Medium) -----------------------
+
+
+class _RecordingStream:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.writes: list[str] = []
+        self.flushes = 0
+        self.fail = fail
+
+    def write(self, data: str) -> int:
+        if self.fail:
+            raise BrokenPipeError("write failed")
+        self.writes.append(data)
+        return len(data)
+
+    def flush(self) -> None:
+        if self.fail:
+            raise OSError("flush failed")
+        self.flushes += 1
+
+
+@pytest.mark.medium
+class TestDefaultEmit:
+    def test_writes_and_flushes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stream = _RecordingStream()
+        monkeypatch.setattr("sys.stdout", stream)
+        _default_emit("heartbeat line")
+        assert stream.writes == ["heartbeat line\n"]
+        assert stream.flushes == 1
+
+    def test_broken_pipe_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stream = _RecordingStream(fail=True)
+        monkeypatch.setattr("sys.stdout", stream)
+        # 例外を送出せず return すること
+        _default_emit("heartbeat line")
+
+
+# --- verdict parse non-destruction (Medium) ---------------------------------
+
+
+@pytest.mark.medium
+class TestVerdictParseNonDestruction:
+    def test_heartbeat_lines_do_not_break_verdict_parse(self) -> None:
+        valid = {"PASS", "RETRY", "BACK_FALLBACK", "ABORT"}
+        verdict_block = mod.emit_verdict(
+            PollResult("done_fallback", "no reaction"), "run fallback review"
+        )
+        heartbeats = "\n".join(
+            format_heartbeat(
+                elapsed_sec=i * 10,
+                pr_number=176,
+                head_sha=HEAD,
+                state="init",
+                remaining_sec=60 - i * 10,
+            )
+            for i in range(3)
+        )
+        combined = heartbeats + "\n" + verdict_block
+        with_hb = parse_verdict_block(combined, valid)
+        without_hb = parse_verdict_block(verdict_block, valid)
+        assert with_hb is not None and without_hb is not None
+        assert with_hb.status == without_hb.status == "BACK_FALLBACK"

--- a/tests/test_codex_review_poll.py
+++ b/tests/test_codex_review_poll.py
@@ -441,6 +441,86 @@ class TestHeartbeat:
         )
         assert with_raise.state == baseline.state == "done_pass"
 
+    def test_heartbeat_emitted_on_api_failure_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # 1 回目の poll で gh api が失敗 → retry 待機中に heartbeat が出ること。
+        # 2 回目で fresh +1 を返し done_pass で終了（terminal は heartbeat 無し）。
+        plus_one = _load("reactions_plus_one.json")
+        calls = {"n": 0}
+
+        def fake_gh_api(path: str) -> list[dict[str, Any]]:
+            calls["n"] += 1
+            if calls["n"] == 1:  # poll1 の reactions 取得で失敗
+                raise subprocess.CalledProcessError(1, ["gh", "api", path])
+            if "reactions" in path:
+                return plus_one
+            return []
+
+        monkeypatch.setattr(mod, "_gh_api", fake_gh_api)
+        clock = _FakeClock()
+        emitted: list[str] = []
+        result = run_polling(
+            pr_number=176,
+            owner="apokamo",
+            repo="kaji",
+            head_sha=HEAD,
+            head_committed_at=HEAD_AT,
+            poll_interval_sec=10,
+            no_reaction_timeout_sec=60,
+            in_progress_timeout_sec=1800,
+            eyes_grace_sec=10,
+            api_failure_limit=3,
+            now=clock.now,
+            sleep=clock.sleep,
+            emit_progress=emitted.append,
+        )
+        assert result.state == "done_pass"
+        # API failure retry の sleep 直前に heartbeat が 1 行出る（transient error 可視化）
+        retry_lines = [ln for ln in emitted if "api_retry:1/3" in ln]
+        assert len(retry_lines) == 1
+        for line in emitted:
+            assert "PR #176" in line
+            assert "---" not in line
+
+    def test_heartbeat_emitted_on_eyes_lost_grace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # eyes 観測 → eyes 消失（grace 待機）→ +1 の遷移を classify を差し替えて強制し、
+        # grace 待機の sleep 直前に heartbeat が出ることを固定する。
+        seq = [
+            PollResult("in_progress", "eyes"),  # poll1: in_progress
+            PollResult("init", "eyes lost"),  # poll2: eyes 消失 → grace 待機
+            PollResult("done_pass", "fresh +1"),  # poll3: 終了
+        ]
+        idx = {"i": 0}
+
+        def fake_classify(*_args: Any, **_kwargs: Any) -> PollResult:
+            r = seq[min(idx["i"], len(seq) - 1)]
+            idx["i"] += 1
+            return r
+
+        _gh_responses(monkeypatch, [([], [])])
+        monkeypatch.setattr(mod, "classify", fake_classify)
+        clock = _FakeClock()
+        emitted: list[str] = []
+        result = run_polling(
+            pr_number=176,
+            owner="apokamo",
+            repo="kaji",
+            head_sha=HEAD,
+            head_committed_at=HEAD_AT,
+            poll_interval_sec=10,
+            no_reaction_timeout_sec=60,
+            in_progress_timeout_sec=1800,
+            eyes_grace_sec=10,
+            now=clock.now,
+            sleep=clock.sleep,
+            emit_progress=emitted.append,
+        )
+        assert result.state == "done_pass"
+        grace_lines = [ln for ln in emitted if "eyes_lost_grace" in ln]
+        assert len(grace_lines) == 1
+        for line in emitted:
+            assert "PR #176" in line
+            assert "---" not in line
+
 
 # --- _default_emit flush / failure isolation (Medium) -----------------------
 

--- a/tests/test_console_log.py
+++ b/tests/test_console_log.py
@@ -1,0 +1,133 @@
+"""起動コンソール progress logging のテスト（Issue #235）。
+
+console_log.configure_console_logging() の stdout/stderr routing・formatter・
+冪等性、および ``kaji run --log-level`` の argparse 契約を固定する。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from kaji_harness.cli_main import create_parser
+from kaji_harness.console_log import ROOT_LOGGER_NAME, configure_console_logging
+
+
+@pytest.fixture
+def _clean_root() -> None:
+    """各テストの前後で kaji ルート logger のハンドラ/状態をリセットする。"""
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    saved = list(root.handlers)
+    saved_level = root.level
+    saved_propagate = root.propagate
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    yield
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    for h in saved:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+    root.propagate = saved_propagate
+
+
+@pytest.mark.small
+class TestConsoleRouting:
+    def test_info_and_debug_go_to_stdout_only(
+        self, _clean_root: None, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure_console_logging(logging.DEBUG)
+        log = logging.getLogger("kaji.runner")
+        log.debug("debug line")
+        log.info("info line")
+        captured = capsys.readouterr()
+        assert "debug line" in captured.out
+        assert "info line" in captured.out
+        assert "debug line" not in captured.err
+        assert "info line" not in captured.err
+
+    def test_warning_and_error_go_to_stderr_only(
+        self, _clean_root: None, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure_console_logging(logging.DEBUG)
+        log = logging.getLogger("kaji.runner")
+        log.warning("warn line")
+        log.error("err line")
+        captured = capsys.readouterr()
+        assert "warn line" in captured.err
+        assert "err line" in captured.err
+        assert "warn line" not in captured.out
+        assert "err line" not in captured.out
+
+
+@pytest.mark.small
+class TestFormatter:
+    def test_info_format_has_iso_timestamp_and_kaji_prefix(
+        self, _clean_root: None, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure_console_logging(logging.INFO)
+        logging.getLogger("kaji.runner").info("workflow start: demo issue #1")
+        line = capsys.readouterr().out.strip()
+        assert re.match(
+            r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\] \[kaji\] workflow start: demo issue #1$",
+            line,
+        ), f"unexpected info format: {line!r}"
+
+    def test_warning_format_includes_levelname(
+        self, _clean_root: None, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure_console_logging(logging.INFO)
+        logging.getLogger("kaji.runner").warning("barrier missed: review")
+        line = capsys.readouterr().err.strip()
+        assert re.match(
+            r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\] \[kaji\] WARNING: barrier missed: review$",
+            line,
+        ), f"unexpected warning format: {line!r}"
+
+    def test_log_level_warning_suppresses_info(
+        self, _clean_root: None, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure_console_logging(logging.WARNING)
+        log = logging.getLogger("kaji.runner")
+        log.info("should not appear")
+        log.warning("should appear")
+        captured = capsys.readouterr()
+        assert "should not appear" not in captured.out
+        assert "should appear" in captured.err
+
+
+@pytest.mark.small
+class TestIdempotency:
+    def test_double_configure_does_not_duplicate_handlers(
+        self, _clean_root: None, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure_console_logging(logging.INFO)
+        configure_console_logging(logging.INFO)
+        root = logging.getLogger(ROOT_LOGGER_NAME)
+        kaji_handlers = [h for h in root.handlers if getattr(h, "_kaji", False)]
+        # stdout + stderr ちょうど 2 個のみ（重複登録されない）
+        assert len(kaji_handlers) == 2
+        logging.getLogger("kaji.runner").info("once")
+        out_lines = [ln for ln in capsys.readouterr().out.splitlines() if "once" in ln]
+        assert len(out_lines) == 1, f"line emitted {len(out_lines)} times: {out_lines}"
+
+
+@pytest.mark.small
+class TestLogLevelArg:
+    def test_default_is_info(self) -> None:
+        parser = create_parser()
+        ns = parser.parse_args(["run", "wf.yaml", "1"])
+        assert ns.log_level == "INFO"
+
+    def test_explicit_choice_parsed(self) -> None:
+        parser = create_parser()
+        ns = parser.parse_args(["run", "wf.yaml", "1", "--log-level", "WARNING"])
+        assert ns.log_level == "WARNING"
+
+    def test_invalid_choice_exits_2(self) -> None:
+        parser = create_parser()
+        with pytest.raises(SystemExit) as excinfo:
+            parser.parse_args(["run", "wf.yaml", "1", "--log-level", "TRACE"])
+        assert excinfo.value.code == 2

--- a/tests/test_script_exec.py
+++ b/tests/test_script_exec.py
@@ -10,7 +10,7 @@ import pytest
 
 from kaji_harness.errors import ScriptExecutionError, StepTimeoutError
 from kaji_harness.models import Step
-from kaji_harness.script_exec import execute_script
+from kaji_harness.script_exec import execute_exec, execute_script
 
 
 def _make_step() -> Step:
@@ -287,3 +287,74 @@ class TestStepAgentOptional:
     def test_step_default_agent_is_none(self) -> None:
         step = Step(id="s", skill="k", on={"PASS": "end"})
         assert step.agent is None
+
+
+@pytest.mark.small
+class TestExecStartProgress:
+    """Issue #235: `_run_argv` が起動コンソールへ exec start progress を出す。"""
+
+    def _configure(self) -> None:
+        import logging
+
+        from kaji_harness.console_log import configure_console_logging
+
+        configure_console_logging(logging.INFO)
+
+    def _teardown(self) -> None:
+        import logging
+
+        from kaji_harness.console_log import ROOT_LOGGER_NAME
+
+        root = logging.getLogger(ROOT_LOGGER_NAME)
+        for h in [h for h in root.handlers if getattr(h, "_kaji", False)]:
+            root.removeHandler(h)
+
+    def test_exec_start_logged_with_full_argv(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._configure()
+        try:
+            with patch(
+                "kaji_harness.script_exec.subprocess.Popen",
+                return_value=_mock_popen(stdout_lines=["---VERDICT---\n", "status: PASS\n"]),
+            ):
+                execute_exec(
+                    step=_make_step(),
+                    argv=["echo", "hello", "world"],
+                    env={},
+                    workdir=tmp_path,
+                    log_dir=tmp_path / "log",
+                    timeout=60,
+                    verbose=False,
+                )
+            out = capsys.readouterr().out
+            assert "exec start: echo hello world" in out
+            assert "[kaji]" in out
+        finally:
+            self._teardown()
+
+    def test_exec_start_truncates_long_argv(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._configure()
+        try:
+            long_arg = "x" * 500
+            with patch(
+                "kaji_harness.script_exec.subprocess.Popen",
+                return_value=_mock_popen(stdout_lines=["---VERDICT---\n", "status: PASS\n"]),
+            ):
+                execute_exec(
+                    step=_make_step(),
+                    argv=["run", long_arg],
+                    env={},
+                    workdir=tmp_path,
+                    log_dir=tmp_path / "log",
+                    timeout=60,
+                    verbose=False,
+                )
+            exec_line = next(
+                ln for ln in capsys.readouterr().out.splitlines() if "exec start:" in ln
+            )
+            assert exec_line.endswith("…")
+        finally:
+            self._teardown()

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -446,3 +446,102 @@ class TestWorkflowEndLogging:
         assert len(logged_calls) == 1
         assert logged_calls[0]["status"] == "ERROR"
         assert "RuntimeError" in logged_calls[0]["error"]
+
+
+@pytest.mark.medium
+class TestConsoleProgress:
+    """Issue #235: 起動コンソール向け console progress（kaji.* logging）の検証。"""
+
+    def _configure(self) -> None:
+        import logging as _logging
+
+        from kaji_harness.console_log import configure_console_logging
+
+        configure_console_logging(_logging.INFO)
+
+    def _teardown(self) -> None:
+        import logging as _logging
+
+        from kaji_harness.console_log import ROOT_LOGGER_NAME
+
+        root = _logging.getLogger(ROOT_LOGGER_NAME)
+        for h in [h for h in root.handlers if getattr(h, "_kaji", False)]:
+            root.removeHandler(h)
+
+    def test_progress_lines_routed_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        workflow = _simple_workflow()
+        results = [
+            _make_cli_result("PASS", session_id="sess-1"),
+            _make_cli_result("PASS", session_id="sess-2"),
+        ]
+        call_count = 0
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            nonlocal call_count
+            r = results[call_count]
+            call_count += 1
+            return r
+
+        self._configure()
+        try:
+            with (
+                patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+                patch("kaji_harness.runner.validate_skill_exists"),
+            ):
+                runner = _make_runner(tmp_path, workflow)
+                runner.run()
+            out = capsys.readouterr().out
+        finally:
+            self._teardown()
+
+        assert "[kaji] workflow start: test-workflow" in out
+        assert "step start: design attempt-001 dispatch=agent agent=claude" in out
+        assert "verdict detected: design source=" in out
+        assert "step end: design status=PASS" in out and "next=review" in out
+        assert "step end: review status=PASS" in out and "next=end" in out
+        assert "workflow end: status=COMPLETE" in out
+
+    def test_run_log_jsonl_unchanged_by_console_progress(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """console progress を有効化しても run.log の JSONL イベント列は不変。"""
+        import json as _json
+
+        workflow = _simple_workflow()
+        results = [
+            _make_cli_result("PASS", session_id="sess-1"),
+            _make_cli_result("PASS", session_id="sess-2"),
+        ]
+        call_count = 0
+
+        def mock_execute_cli(**kwargs: object) -> CLIResult:
+            nonlocal call_count
+            r = results[call_count]
+            call_count += 1
+            return r
+
+        self._configure()
+        try:
+            with (
+                patch("kaji_harness.runner.execute_cli", side_effect=mock_execute_cli),
+                patch("kaji_harness.runner.validate_skill_exists"),
+            ):
+                runner = _make_runner(tmp_path, workflow)
+                runner.run()
+        finally:
+            self._teardown()
+
+        run_logs = list((tmp_path / ".kaji-artifacts").rglob("run.log"))
+        assert run_logs, "run.log not found"
+        events = [
+            _json.loads(line)["event"]
+            for line in run_logs[0].read_text().splitlines()
+            if line.strip()
+        ]
+        # console progress 行は run.log（JSONL 機械可読ログ）に混入しない。
+        assert "workflow_start" in events
+        assert "workflow_end" in events
+        for ev in events:
+            assert not ev.startswith("[kaji]")


### PR DESCRIPTION
## Summary

`kaji run` の起動コンソールに harness 進行状況（workflow / step / verdict / transition）を stdlib logging 経由で出力し、`review-poll` の polling ループに定期 heartbeat を追加する。

Closes #235

## Changes

- `kaji run` に `--log-level` オプションを追加（`INFO` / `DEBUG` / `WARNING` / `ERROR`、デフォルト `INFO`）
- harness 進行状況を `INFO` 以下は stdout、`WARNING` 以上は stderr へ出力する 2-handler 構成を実装
- `review-poll` ステップの polling ループに `POLL_INTERVAL_SEC`（10s）ごとの heartbeat 出力を追加
- API リトライおよび eyes-grace sleep 時にも heartbeat を emit するよう対応

## Documentation

- `draft/design/issue-235-harness-progress-review-poll-heartbeat.md` を設計書として追加
- 設計書更新（design_path はアーカイブ不要な実装済み状態）

## Test Plan

- [x] 既存テストがパス（`make check`）
- [x] 新規テストを追加（heartbeat / progress logging のユニットテスト）
- [x] 手動検証: `kaji run` 起動時に `[kaji]` progress 行が出力されることを確認