### PR TITLE
feat: 右列最大2枚の tmux agent pane 配置を実装する (#238)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,13 +166,14 @@ agent 経路の起動 backend は repository config の `[execution] agent_runne
 - **`headless`（既定）**: 従来どおり `execute_cli()` が `claude -p --output-format
   stream-json` / `codex exec --json` を起動し、stdout を読む。
 - **`interactive_terminal`**: `execute_interactive_terminal()` が **tmux pane** 上で通常の
-  対話 `claude` / `codex` を起動し（`tmux split-window -h` で現ウィンドウの右に追加）、
+  対話 `claude` / `codex` を起動し（初回は `split-window -h` で origin の右、2枚目以降は右列内を
+  `-v` で上下分割し、kaji 管理 agent pane を右列に最大2枚まで維持 / Issue #238）、
   stdout を読まずに attempt directory の `verdict.yaml` を polling する。完了判定は
-  artifact-primary 経路（Issue #220）に完全に乗る。`tmux`（>= 3.0）/ `$TMUX` 不在は
+  artifact-primary 経路（Issue #220）に完全に乗る。`tmux`（>= 3.1）/ `$TMUX` 不在は
   fail-fast、`interactive_terminal_close_on_verdict` で verdict 検知後に pane を `kill-pane`
   するか（best-effort cleanup）を制御する。transcript は `tmux pipe-pane` で `terminal.log` に
   常時記録され、`/proc` scan も util-linux `script(1)` 依存も無く Linux / macOS 同一に動く
-  （tmux 単一 backend / Issue #230, [ADR 007](./adr/007-interactive-terminal-runner.md) v2）。
+  （tmux 単一 backend / Issue #230, [ADR 007](./adr/007-interactive-terminal-runner.md) v3）。
 
 設定方法と手動検証手順は
 [Interactive Terminal Runner ガイド](./cli-guides/interactive-terminal-runner.md) を参照。

--- a/docs/adr/007-interactive-terminal-runner.md
+++ b/docs/adr/007-interactive-terminal-runner.md
@@ -17,7 +17,9 @@ terminal backend = `tmux` 単一の実現性を確定し、本版を承認に確
   検知後に pane を killする（観測上は ~1s 以内だが、次 step 開始後に killしても問題なく、速さに
   利得はない）。Codex fresh で session id 未解決時の session-id 回収 grace（≤5s）を挟むことも許容。
   検証は `#{pane_dead}` / `list-panes` の高頻度サンプリングで実施。
-- **実行 pane の配置**: ユーザー視点で**右**に追加する（下記スコープ参照）。
+- **実行 pane の配置**: ユーザー視点で**右**に追加する（下記スコープ参照）。Issue #238 で、初回のみ
+  origin pane の右、2枚目以降は右列内の上下分割とし、kaji が作成した agent pane は右列に最大2枚まで
+  に制限する配置へ更新した（§ 改訂履歴 v3）。
 - **macOS**: tmux 版が WSL で安定動作することをもって当面の確認とし、full macOS 実機検証は
   WSL 安定後に別 Issue で実施する（deferred）。
 
@@ -26,11 +28,12 @@ terminal backend = `tmux` 単一の実現性を確定し、本版を承認に確
 | 版 | 日付 | 決定 | 備考 |
 |----|------|------|------|
 | v1 | 2026-06-05 | terminal backend = `kitty` 単一 | GUI ウィンドウを spawn して並列可視性を得る前提。`/proc` cmdline scan による cleanup、util-linux `script(1)` による transcript |
-| v2（本版） | 2026-06-06 | terminal backend = `tmux` 単一 | 「kaji を tmux 内で起動 → runner が `split-window` で pane 追加」で**並列可視性をディスプレイ無しで再現できる**と判明し、v1 の前提が崩れたため改訂 |
+| v2 | 2026-06-06 | terminal backend = `tmux` 単一 | 「kaji を tmux 内で起動 → runner が `split-window` で pane 追加」で**並列可視性をディスプレイ無しで再現できる**と判明し、v1 の前提が崩れたため改訂 |
+| v3（本版） | 2026-06-08 | pane 配置を「初回右・以後右列内・最大2枚」に変更、最小 tmux を 3.1 に引き上げ | v2 の「毎 step で現在 pane の右に追加」は `close_on_verdict=false` で pane を残すと横幅が step ごとに狭くなる。Issue #238 で、初回のみ origin の右、2枚目以降は右列内の上下分割、右列の kaji 管理 pane を最大2枚に制限する配置へ更新。pane を kaji marker（pane user option）で識別するため最小 tmux を 3.1 に引き上げ |
 
-v2 は v1 の **runner 抽象・verdict 解決経路・session 継続方針を維持**し、terminal backend の実体だけを
+v2 / v3 は v1 の **runner 抽象・verdict 解決経路・session 継続方針を維持**し、terminal backend の実体だけを
 `kitty` → `tmux` に差し替える。`agent_runner = "interactive_terminal"` という設定面・workflow 契約・
-ADR 005 artifact-primary verdict 解決は不変。
+ADR 005 artifact-primary verdict 解決は不変。v3 は v2 の pane 配置契約のみを更新し、その他の決定は維持する。
 
 ## コンテキスト
 
@@ -81,9 +84,22 @@ runner backend `interactive_terminal` の terminal backend を **`tmux` 単一**
   こと（`$TMUX` が設定されていること）を前提**とする。`$TMUX` が無ければ step failure として
   **fail-fast**（「`tmux` 内で `kaji run` を実行してください」）。自動 fallback はしない。
 - runner は現在ウィンドウに pane を作って wrapper を起動する:
-  `tmux split-window -d -h -P -F '#{pane_id}' -t "$TMUX_PANE" <wrapper.sh> <args>` で **pane id を
+  `tmux split-window -d <-h|-v> -P -F '#{pane_id}' -t <split target> <wrapper.sh> <args>` で **pane id を
   回収**し、それを以後のライフサイクルのハンドルにする。`-d` でフォーカスを奪わない。
-  **`-h` で pane をユーザー視点の「右」に追加する**（既定の `split-window`（下に追加）ではなく横分割）。
+  **配置（v3 / Issue #238）**: kaji が作成した agent pane が右列に0枚なら origin pane を `-h` で右に分割し
+  右列を作る。1枚あれば右列の pane を `-v` で上下分割して2枚目を作る。2枚以上ある場合は、`pane_top`
+  昇順で最古（上側）の管理対象 pane を `kill-pane` してから残った最新 pane を `-v` で分割し、右列を
+  常に最新2枚相当に保つ。これにより `close_on_verdict=false` で pane を残しても横幅が step ごとに
+  狭くならない。
+- **kaji 管理 pane の識別**: 作成直後の pane に pane user option `@kaji_interactive_terminal`
+  （値 `origin=<origin pane id>`）を `set-option -p` で付与する。launch 前に `list-panes` で同一 window
+  の pane を列挙し、marker が origin 一致する pane だけを管理対象として prune 候補にする。marker 設定に
+  失敗した場合は作成済み pane を best-effort `kill-pane` してから `CLIExecutionError` で fail-loud する
+  （識別不能な pane を残さない）。`list-panes` / pane lookup が失敗した場合も `CLIExecutionError` で
+  fail-loud する（壊れた tmux state で誤 cleanup するより停止を優先）。最古判定は wall-clock ではなく
+  `pane_top` 昇順で行う。ユーザーが手動で agent pane を active にした後にその pane が prune 対象に
+  なった場合、active pane が tmux 通常挙動で移ることは許容する（「自動作成時に origin からフォーカスを
+  奪わない」ことのみを契約とし、ユーザー操作後の active 復帰は範囲外）。
 - 完了判定は ADR 005 の artifact-primary 経路。runner は attempt directory の `verdict.yaml` を
   polling し、出現したら verdict を読んで次 step へ進む。stdout は読まない
   （`CLIResult.full_output=""`）。pane の存命は `#{pane_dead}` / `list-panes` で確認し、verdict
@@ -105,8 +121,9 @@ runner backend `interactive_terminal` の terminal backend を **`tmux` 単一**
   `--session-id` に渡し、同じ UUID を session state に保存する。Codex fresh は `terminal.log` の
   `codex resume <uuid>` を抽出し、取れなければ `CODEX_HOME/sessions/**/*.jsonl` →
   `~/.codex/sessions/**/*.jsonl` を marker 一致で fallback 抽出する（v1 と同一）。
-- 起動時に **`tmux -V` で最低バージョン（`tmux >= 3.0`）を検査**し、満たさなければ fail-fast する
-  （`remain-on-exit -p` / `#{pane_dead}` / `split-window -P -F` が 3.0 を要求）。`kitty` の PATH
+- 起動時に **`tmux -V` で最低バージョン（v3 / Issue #238 以降は `tmux >= 3.1`）を検査**し、満たさなければ
+  fail-fast する。`#{pane_dead}` / `split-window -P -F` は 3.0 を要求し、v3 で導入する pane user option
+  marker（`set-option -p @...`）は tmux 3.1 を要求するため、最小を 3.1 へ引き上げた。`kitty` の PATH
   検査はこのバージョン検査に置換される。
 - `agent_runner` 未指定時は既存の `headless` runner を使い、headless の CLI 引数 / stdout logging
   / verdict 解決挙動は変更しない（互換維持）。
@@ -129,7 +146,8 @@ runner backend `interactive_terminal` の terminal backend を **`tmux` 単一**
   `--interactive-terminal-close-on-verdict` / `--no-...` は不変。
 - docs: 本 ADR、`docs/ARCHITECTURE.md` § runner backend dispatch、
   `docs/cli-guides/interactive-terminal-runner.md`（前提を `kitty`→`tmux` / `$TMUX` 必須 /
-  `tmux >= 3.0` に更新、トラブルシュート更新）、`github-mode.md` / `local-mode.md` の `[execution]`
+  `tmux >= 3.1`（v3）に更新、配置契約と右列最大2枚、トラブルシュート更新）、`github-mode.md` /
+  `local-mode.md` の `[execution]`
   例（更新があれば）。
 - workflow YAML / 遷移仕様 / verdict 解決経路（ADR 005）は不変。runner backend の選択は repository
   config の責務であり workflow step の責務にしない。
@@ -152,5 +170,6 @@ runner backend `interactive_terminal` の terminal backend を **`tmux` 単一**
 - ADR 005: artifact-primary verdict resolution（本 runner の前提）
 - Issue #220 / PR #221: attempt layout / `verdict.yaml` primary
 - Issue #224: interactive_terminal runner（v1, kitty backend）の実装
-- Issue #229: terminal backend を tmux に改訂（本版の PoC 検証 + 実装）
+- Issue #229: terminal backend を tmux に改訂（v2 の PoC 検証 + 実装）
+- Issue #238: pane 配置を「初回右・以後右列内・最大2枚」に変更し最小 tmux を 3.1 に引き上げ（v3）
 - `docs/cli-guides/interactive-terminal-runner.md`: 設定・手動検証手順

--- a/docs/cli-guides/interactive-terminal-runner.md
+++ b/docs/cli-guides/interactive-terminal-runner.md
@@ -5,10 +5,12 @@
 `verdict.yaml` を書いたら、kaji は artifact-primary 経路（[ADR 005](../adr/005-artifact-primary-verdict.md)）
 で verdict を読み、次 step へ進む。
 
-`kaji run` を tmux session 内で起動し、runner が `tmux split-window -h` で現ウィンドウの右に pane を
+`kaji run` を tmux session 内で起動し、runner が `tmux split-window` で現ウィンドウに pane を
 追加して agent を起動するため、ディスプレイ無し環境（WSL2 / SSH / headless）でも `kaji run` の出力と
-agent を同一画面で並列に見られる。cleanup は `tmux kill-pane`、transcript は `tmux pipe-pane` で行い、
-`/proc` scan も util-linux `script(1)` 依存も無いため Linux / macOS で同一に動く。
+agent を同一画面で並列に見られる。pane 配置は **初回のみ origin pane の右、2枚目以降は右列内の上下
+分割**で、kaji が作成した agent pane は右列に**最大2枚**まで残す（Issue #238）。cleanup は
+`tmux kill-pane`、transcript は `tmux pipe-pane` で行い、`/proc` scan も util-linux `script(1)` 依存も
+無いため Linux / macOS で同一に動く。
 
 技術選定の経緯は [ADR 007](../adr/007-interactive-terminal-runner.md)、runner dispatch の
 位置づけは [ARCHITECTURE](../ARCHITECTURE.md) § Runner backend dispatch を参照。
@@ -18,7 +20,8 @@ agent を同一画面で並列に見られる。cleanup は `tmux kill-pane`、t
 - 従量課金の headless 経路ではなく、通常コンソール利用に近い形で workflow を進めたいとき。
 - ディスプレイ無し環境（WSL2 / SSH / headless）でも `kaji run` 出力と agent を同一画面で並列に見たいとき。
 - step ごとに Claude / Codex の session を `--resume` / `codex resume` で引き継ぎたいとき。
-- agent の最終状態を verdict 後も pane に残して確認したいとき（`close_on_verdict = false`）。
+- agent の最終状態を verdict 後も pane に残して確認したいとき（`close_on_verdict = false`）。pane を
+  残しても右列は最新2枚相当に保たれ、横幅が step ごとに狭くならない。
 
 `agent_runner` 未指定時は既存の `headless` runner が使われる。既存 workflow / CI の挙動は
 変わらない。
@@ -29,8 +32,9 @@ agent を同一画面で並列に見られる。cleanup は `tmux kill-pane`、t
   failure として **fail-fast** する（自動 fallback / 他 terminal 探索はしない）。tmux 外で使いたい
   場合は `--agent-runner headless` に戻す。
 - `$TMUX_PANE`（split の `-t` ターゲット）が設定されていること（tmux pane 内なら自動で入る）。
-- `tmux`（**>= 3.0**）が PATH にあること。pane option（`set-option -p` による per-pane
-  `remain-on-exit`）が tmux 3.0 で追加されたため。無ければ / 古ければ fail-fast。
+- `tmux`（**>= 3.1**）が PATH にあること。kaji 管理 pane を識別する pane user option
+  （`set-option -p @kaji_interactive_terminal`）が tmux 3.1 で追加されたため（Issue #238 で 3.0 から
+  引き上げ）。無ければ / 古ければ fail-fast。
 - `claude` / `codex` CLI が PATH にあること（runner が起動する agent）。
 - transcript（`terminal.log`）は `tmux pipe-pane` で **常時記録**される（OS 分岐なし）。
 - wrapper は agent 起動前に `NO_COLOR` を unset し、`COLORTERM=truecolor` を設定する。
@@ -147,9 +151,21 @@ kaji run .kaji/wf/feature-development.yaml 224 --log-level WARNING
 
 ## 振る舞い
 
-1. runner は `tmux split-window -d -h -P -F '#{pane_id}' -t "$TMUX_PANE" <wrapper.sh + 8 args>` を
-   実行する。`-d` でフォーカスを奪わず、**`-h` で現ウィンドウの右**に pane を追加し、`-P -F '#{pane_id}'`
-   で生成された pane id を回収して以降のライフサイクルハンドルにする。
+1. runner は launch 前に `tmux list-panes` で同一 window の kaji 管理 agent pane（pane user option
+   `@kaji_interactive_terminal` が `origin=<origin pane>` 一致）を列挙し、配置を決める（Issue #238）:
+   - 管理対象0枚: origin pane を `tmux split-window -d -h -t "$TMUX_PANE"` で右に分割し、右列を作る。
+   - 管理対象1枚: その agent pane を `-d -v` で上下分割し、右列の2枚目を作る。
+   - 管理対象2枚以上: `pane_top` 昇順で最古（上側）の管理対象 pane を `kill-pane` してから、残った最新
+     pane を `-d -v` で分割する。これで右列は常に最新2枚相当に保たれ、横幅が step ごとに狭くならない。
+
+   いずれも `-d` でフォーカスを奪わず、`-P -F '#{pane_id}'` で生成された pane id を回収して以降の
+   ライフサイクルハンドルにする。作成直後の pane には `tmux set-option -p -t <pane> @kaji_interactive_terminal
+   origin=<origin pane>` で marker を付与し、kaji が作成した pane だけを後続の prune 対象にする
+   （ユーザーが手動で作った pane や別 origin の pane は誤って閉じない）。marker 設定に失敗した場合は
+   作成済み pane を best-effort `kill-pane` してから fail-loud する。`list-panes` / pane lookup が
+   失敗した場合も fail-loud する（壊れた tmux state での誤 cleanup を避ける）。ユーザーが手動で agent
+   pane を active にした後にその pane が prune された場合、active pane が tmux 通常挙動で移ることは
+   許容する（自動作成時に origin からフォーカスを奪わないことのみが契約）。
 2. runner は `tmux pipe-pane -o -t %id 'cat >> terminal.log'` で pane 出力を attempt directory の
    `terminal.log` に記録する。
 3. wrapper は最初に `cd <workdir>`（trusted な project worktree。`/tmp` や attempt directory を
@@ -164,12 +180,16 @@ kaji run .kaji/wf/feature-development.yaml 224 --log-level WARNING
    （次 step 開始後の kill も許容）。timeout 経路でも best-effort `kill-pane` してから fail-loud する。
 7. `interactive_terminal_close_on_verdict = false` なら、polling 前に
    `tmux set-option -p -t %id remain-on-exit on` を設定し、verdict 後に `kill-pane` しない。pane は
-   agent 自然終了後も `[dead]`（`#{pane_dead}=1`）として残り、ユーザーが後から内容を確認できる。
+   agent 自然終了後も `[dead]`（`#{pane_dead}=1`）として残り、ユーザーが後から内容を確認できる。次 step
+   の launch 時にその pane は kaji marker 付き pane として検出され、右列が最大2枚になるよう最古 pane が
+   prune される（直近の agent step と1つ前を見比べられる）。
 
 > **pane metadata（診断用）**: runner は verdict 検知時点の `#{pane_dead}` 等を
 > attempt directory の `pane-metadata.json` に snapshot 記録する。verdict-trigger 契約のもとでは
 > verdict 時点の agent CLI は生存しているため、この snapshot は通常 `#{pane_dead}=0` になる。
 > `[dead]` への遷移は `remain-on-exit on` が保証する最終状態で、metadata snapshot とは別物。
+> Issue #238 以降は配置診断として `layout_target_pane` / `split_target_pane` / `split_direction`
+> （`horizontal` / `vertical`）/ `kaji_agent_panes_before` / `kaji_agent_panes_pruned` も記録する。
 
 ### session 継続
 
@@ -215,6 +235,10 @@ Codex の `reasoning.effort = minimal` は現 tool 構成（`image_gen` / `web_s
 7. `interactive_terminal_close_on_verdict = true` で verdict 後に pane が消える（`kill-pane`）こと、
    `false`（`--no-interactive-terminal-close-on-verdict`）で `[dead]` pane が残ることを確認する。
 8. `terminal.log` が attempt directory に記録されることを確認する（OS を問わず常時記録）。
+9. `--no-interactive-terminal-close-on-verdict` で **agent step を3回以上**連続実行し、右列の kaji 管理
+   pane が**最大2枚**に保たれること、origin pane と右列 agent pane の `pane_width` が連続作成後も横方向に
+   狭くならない（毎 step で縮み続けない）ことを確認する。手動で作った別 pane が誤って閉じられないことも
+   合わせて確認する。
 
 ## トラブルシュート
 
@@ -222,7 +246,7 @@ Codex の `reasoning.effort = minimal` は現 tool 構成（`image_gen` / `web_s
 |------|-------------|
 | `CLI 'tmux' not found` で即終了 | `tmux` を PATH に入れるか `--agent-runner headless` で実行する |
 | `requires tmux. Run kaji run inside tmux` で即終了 | tmux session の外で実行している。`tmux new-session` 内で再実行するか `--agent-runner headless` |
-| `requires tmux >= 3.0` で即終了 | tmux が古い。3.0 以上へ更新する（pane option / `#{pane_dead}` / `split-window -P -F` が 3.0 を要求） |
+| `requires tmux >= 3.1` で即終了 | tmux が古い。3.1 以上へ更新する（kaji marker の pane user option `set-option -p` が 3.1、`#{pane_dead}` / `split-window -P -F` が 3.0 を要求） |
 | `TMUX_PANE is not set` で即終了 | tmux pane 内で実行していない。通常の tmux session なら自動設定される |
 | step が timeout する | agent が `verdict.yaml` を書いていない。prompt の verdict 書き出し指示と path を確認 |
 | pane が verdict 前に消える / `tmux pane exited before writing verdict.yaml` | agent が起動失敗。`terminal.log` の tail（エラー文面に添付）を確認 |

--- a/kaji_harness/interactive_terminal.py
+++ b/kaji_harness/interactive_terminal.py
@@ -6,11 +6,20 @@ intentionally avoids parsing stdout: completion is decided by the
 artifact-primary verdict resolution introduced in Issue #220.
 
 The terminal backend is tmux only (ADR 007 v2, Issue #230). ``kaji run`` must
-run inside a tmux session; the runner adds a pane to the current window with
-``tmux split-window -h`` (to the user's right), records the transcript with
-``tmux pipe-pane``, decides liveness via ``#{pane_dead}``, and cleans up with
-``tmux kill-pane``. There is no ``/proc`` scan and no util-linux ``script(1)``
-dependency, so Linux and macOS share one implementation.
+run inside a tmux session; the runner adds a pane to the current window,
+records the transcript with ``tmux pipe-pane``, decides liveness via
+``#{pane_dead}``, and cleans up with ``tmux kill-pane``. There is no ``/proc``
+scan and no util-linux ``script(1)`` dependency, so Linux and macOS share one
+implementation.
+
+Pane placement (Issue #238): the first agent pane is created to the right of
+the origin pane (``split-window -h``); subsequent agent panes split the right
+column vertically (``split-window -v``) so the origin/agent widths stay stable
+instead of shrinking each step. The right column keeps at most
+``_MAX_VISIBLE_AGENT_PANES`` kaji-managed agent panes — when a new pane would
+exceed that, the oldest (top-most) managed pane is killed first. kaji-created
+panes are tagged with a ``@kaji_interactive_terminal`` pane option so manually
+created panes are never pruned.
 
 The single completion trigger is the appearance of ``verdict.yaml``; the agent
 process is not waited on. The post-verdict ``kill-pane`` is best-effort cleanup
@@ -28,6 +37,7 @@ import shutil
 import subprocess
 import time
 import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from .errors import CLIExecutionError, CLINotFoundError, StepTimeoutError
@@ -46,7 +56,40 @@ _SESSION_ID_GRACE_SECONDS = 5.0
 _CODEX_SESSION_SCAN_LIMIT = 100
 _VERDICT_POLL_INTERVAL_SECONDS = 2
 _TERMINAL_LOG_TAIL_CHARS = 2000
-_MIN_TMUX_VERSION = (3, 0)
+# Issue #238: pane scoped user options (`set-option -p`) are used as the kaji
+# marker; they were added in tmux 3.1, so the minimum is raised from 3.0.
+_MIN_TMUX_VERSION = (3, 1)
+# Pane option name marking a pane as kaji-created (value: ``origin=<pane_id>``).
+_KAJI_PANE_OPTION = "@kaji_interactive_terminal"
+# Max kaji-managed agent panes kept visible in the right column at once.
+_MAX_VISIBLE_AGENT_PANES = 2
+
+
+@dataclass(frozen=True)
+class KajiAgentPane:
+    """A kaji-created agent pane discovered via ``tmux list-panes``.
+
+    ``pane_top`` is the y-offset used to order panes: in the right-column layout
+    a newly created pane is added below, so a smaller ``pane_top`` means an older
+    pane. ``created_at`` wall-clock is intentionally *not* used (NTP corrections
+    can run it backwards), so the geometry is the single ordering source.
+    """
+
+    pane_id: str
+    pane_top: int
+    pane_left: int
+    pane_width: int
+
+
+@dataclass(frozen=True)
+class _PaneLaunch:
+    """Placement outcome of a single agent-pane launch (diagnostic metadata)."""
+
+    pane_id: str
+    split_target_pane: str
+    split_flag: str
+    panes_before: list[str] = field(default_factory=list)
+    panes_pruned: list[str] = field(default_factory=list)
 
 
 def _terminal_exit_detail(terminal_log: Path) -> str:
@@ -106,7 +149,8 @@ def _build_tmux_split_argv(
     tmux: str,
     wrapper: Path,
     *,
-    target_pane: str,
+    split_target_pane: str,
+    split_flag: str,
     agent: str,
     prompt_path: Path,
     verdict_path: Path,
@@ -118,21 +162,33 @@ def _build_tmux_split_argv(
 ) -> list[str]:
     """Assemble the ``tmux split-window`` argv.
 
-    ``-d`` keeps focus on the current pane; ``-h`` splits horizontally so the
-    new pane appears to the user's right (Issue #230 MF2); ``-P -F '#{pane_id}'``
-    prints the created pane id, which becomes the lifecycle handle for polling,
-    transcript, and cleanup.
+    ``-d`` keeps focus on the current pane; ``-P -F '#{pane_id}'`` prints the
+    created pane id, which becomes the lifecycle handle for polling, transcript,
+    and cleanup. The split direction and target are chosen by the caller (Issue
+    #238): the first agent pane splits the origin pane horizontally (``-h``,
+    right column), and later panes split the right column's bottom pane
+    vertically (``-v``) so widths stay stable.
+
+    Args:
+        split_target_pane: The ``-t`` target the new pane splits off from.
+        split_flag: ``"-h"`` (right) or ``"-v"`` (below). Any other value is a
+            programming error.
+
+    Raises:
+        ValueError: ``split_flag`` is neither ``"-h"`` nor ``"-v"``.
     """
+    if split_flag not in {"-h", "-v"}:
+        raise ValueError(f"split_flag must be '-h' or '-v', got {split_flag!r}")
     return [
         tmux,
         "split-window",
         "-d",
-        "-h",
+        split_flag,
         "-P",
         "-F",
         "#{pane_id}",
         "-t",
-        target_pane,
+        split_target_pane,
         _build_wrapper_command(
             wrapper,
             agent=agent,
@@ -177,9 +233,10 @@ def execute_interactive_terminal(
 
     Raises:
         CLINotFoundError: ``tmux`` is missing, ``$TMUX`` / ``$TMUX_PANE`` is
-            unset, or ``tmux`` is older than 3.0.
-        CLIExecutionError: ``split-window`` failed, or the pane died before
-            writing ``verdict.yaml``.
+            unset, or ``tmux`` is older than 3.1.
+        CLIExecutionError: ``split-window`` failed, ``list-panes`` failed, the
+            kaji marker could not be set, or the pane died before writing
+            ``verdict.yaml``.
         StepTimeoutError: ``verdict.yaml`` did not appear before the deadline.
         ValueError: ``step.agent`` is missing or unsupported.
         FileNotFoundError: ``prompt.txt`` or the wrapper script is missing.
@@ -205,7 +262,7 @@ def execute_interactive_terminal(
     # Resume runs and Codex (which mints its own id) pass an empty marker.
     launch_session_id = str(uuid.uuid4()) if step.agent == "claude" and session_id is None else ""
 
-    pane_id = _launch_pane(
+    launch = _launch_pane(
         tmux,
         wrapper,
         target_pane=target_pane,
@@ -218,6 +275,7 @@ def execute_interactive_terminal(
         model=step.model or "",
         effort=step.effort or "",
     )
+    pane_id = launch.pane_id
     # Issue #235: pane 起動成功直後に起動コンソールへ progress を出す。
     _console.info("pane launched: %s pane=%s verdict=%s", step.id, pane_id, verdict_path)
     if not _pipe_pane(tmux, pane_id, terminal_log):
@@ -250,6 +308,7 @@ def execute_interactive_terminal(
                 metadata_path,
                 target_pane=target_pane,
                 close_on_verdict=close_on_verdict,
+                layout=launch,
             )
             result_session_id = session_id or launch_session_id or None
             if result_session_id is None and step.agent == "codex":
@@ -283,13 +342,19 @@ def execute_interactive_terminal(
                 metadata_path,
                 target_pane=target_pane,
                 close_on_verdict=close_on_verdict,
+                layout=launch,
             )
             raise CLIExecutionError(step.id, 1, _terminal_exit_detail(terminal_log))
         time.sleep(_VERDICT_POLL_INTERVAL_SECONDS)
 
     # Timeout: verdict never appeared. Best-effort cleanup, then fail-loud.
     _write_pane_metadata(
-        tmux, pane_id, metadata_path, target_pane=target_pane, close_on_verdict=close_on_verdict
+        tmux,
+        pane_id,
+        metadata_path,
+        target_pane=target_pane,
+        close_on_verdict=close_on_verdict,
+        layout=launch,
     )
     _kill_pane(tmux, pane_id)
     raise StepTimeoutError(step.id, timeout)
@@ -324,7 +389,7 @@ def _validate_tmux_version(tmux: str) -> None:
     version = (int(match.group(1)), int(match.group(2)))
     if version < _MIN_TMUX_VERSION:
         raise CLINotFoundError(
-            f"interactive terminal runner requires tmux >= 3.0, got {proc.stdout.strip()}"
+            f"interactive terminal runner requires tmux >= 3.1, got {proc.stdout.strip()}"
         )
 
 
@@ -341,11 +406,35 @@ def _launch_pane(
     launch_session_id: str,
     model: str,
     effort: str,
-) -> str:
+) -> _PaneLaunch:
+    """Place and launch one agent pane, returning its id and placement metadata.
+
+    Placement (Issue #238): existing kaji-managed agent panes are listed; if the
+    right column already holds the maximum, the oldest (top-most) panes are
+    pruned so the new pane keeps the column at ``_MAX_VISIBLE_AGENT_PANES``. With
+    no managed pane left the origin pane is split horizontally (right column);
+    otherwise the bottom managed pane is split vertically.
+    """
+    existing = _list_kaji_agent_panes(tmux, target_pane)
+    # keep one slot free for the pane we are about to create, so launch ends at
+    # _MAX_VISIBLE_AGENT_PANES.
+    remaining = _prune_kaji_agent_panes(tmux, existing, keep=_MAX_VISIBLE_AGENT_PANES - 1)
+    remaining_ids = {pane.pane_id for pane in remaining}
+    pruned_ids = [pane.pane_id for pane in existing if pane.pane_id not in remaining_ids]
+
+    if remaining:
+        # remaining is sorted by pane_top ascending; the last is the bottom pane.
+        split_target_pane = remaining[-1].pane_id
+        split_flag = "-v"
+    else:
+        split_target_pane = target_pane
+        split_flag = "-h"
+
     argv = _build_tmux_split_argv(
         tmux,
         wrapper,
-        target_pane=target_pane,
+        split_target_pane=split_target_pane,
+        split_flag=split_flag,
         agent=agent,
         prompt_path=prompt_path,
         verdict_path=verdict_path,
@@ -365,7 +454,131 @@ def _launch_pane(
             proc.returncode,
             f"tmux did not return a pane id: {proc.stdout!r}",
         )
-    return pane_id
+    try:
+        _set_kaji_agent_pane_marker(tmux, pane_id, target_pane=target_pane)
+    except CLIExecutionError:
+        # Without the marker the pane cannot be safely identified for later
+        # cleanup; best-effort kill it before failing loud.
+        _kill_pane(tmux, pane_id)
+        raise
+    return _PaneLaunch(
+        pane_id=pane_id,
+        split_target_pane=split_target_pane,
+        split_flag=split_flag,
+        panes_before=[pane.pane_id for pane in existing],
+        panes_pruned=pruned_ids,
+    )
+
+
+def _parse_kaji_pane_marker(value: str) -> dict[str, str]:
+    """Parse a ``@kaji_interactive_terminal`` marker into a field dict.
+
+    The marker is a whitespace-separated list of ``key=value`` tokens (currently
+    just ``origin=<pane_id>``). Unknown fields, empty values, and malformed
+    tokens are tolerated: malformed tokens are dropped rather than raising, so a
+    user-set or corrupted option never crashes pane discovery.
+    """
+    fields: dict[str, str] = {}
+    for token in value.split():
+        key, sep, val = token.partition("=")
+        if sep and key:
+            fields[key] = val
+    return fields
+
+
+def _list_kaji_agent_panes(tmux: str, target_pane: str) -> list[KajiAgentPane]:
+    """List kaji-created agent panes in ``target_pane``'s window, oldest first.
+
+    Only panes whose ``@kaji_interactive_terminal`` marker resolves to
+    ``origin=<target_pane>`` are returned; the origin pane itself, unmarked
+    panes, and panes from a different origin are ignored so manually created
+    panes are never touched. A failed ``list-panes`` fails loud rather than
+    risk mis-cleanup on broken tmux state.
+    """
+    format_string = "\t".join(
+        [
+            "#{pane_id}",
+            "#{pane_top}",
+            "#{pane_left}",
+            "#{pane_width}",
+            f"#{{{_KAJI_PANE_OPTION}}}",
+        ]
+    )
+    proc = subprocess.run(
+        [tmux, "list-panes", "-F", format_string, "-t", target_pane],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise CLIExecutionError(
+            "interactive_terminal",
+            proc.returncode,
+            proc.stderr or "tmux list-panes failed",
+        )
+    panes: list[KajiAgentPane] = []
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 5:
+            continue
+        pane_id, top, left, width, marker = parts[0], parts[1], parts[2], parts[3], parts[4]
+        if pane_id == target_pane:
+            continue
+        if _parse_kaji_pane_marker(marker).get("origin") != target_pane:
+            continue
+        try:
+            pane = KajiAgentPane(
+                pane_id=pane_id,
+                pane_top=int(top),
+                pane_left=int(left),
+                pane_width=int(width),
+            )
+        except ValueError:
+            continue
+        panes.append(pane)
+    panes.sort(key=lambda pane: pane.pane_top)
+    return panes
+
+
+def _prune_kaji_agent_panes(
+    tmux: str, panes: list[KajiAgentPane], *, keep: int
+) -> list[KajiAgentPane]:
+    """Kill the oldest panes so at most ``keep`` remain, returning the survivors.
+
+    Oldest = smallest ``pane_top`` (top of the right column). The survivors are
+    the newest ``keep`` panes, returned sorted by ``pane_top`` ascending.
+    """
+    ordered = sorted(panes, key=lambda pane: pane.pane_top)
+    if len(ordered) <= keep:
+        return ordered
+    survivors = ordered[len(ordered) - keep :] if keep > 0 else []
+    for pane in ordered[: len(ordered) - len(survivors)]:
+        _kill_pane(tmux, pane.pane_id)
+    return survivors
+
+
+def _set_kaji_agent_pane_marker(tmux: str, pane_id: str, *, target_pane: str) -> None:
+    """Tag a freshly created pane as kaji-managed via a pane user option.
+
+    Raises:
+        CLIExecutionError: ``set-option`` failed; the caller cleans up the
+            orphaned pane and fails loud, since an unmarked pane cannot be safely
+            identified for later pruning.
+    """
+    proc = subprocess.run(
+        [tmux, "set-option", "-p", "-t", pane_id, _KAJI_PANE_OPTION, f"origin={target_pane}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise CLIExecutionError(
+            "interactive_terminal",
+            proc.returncode,
+            proc.stderr or "tmux set-option (kaji marker) failed",
+        )
 
 
 def _pipe_pane(tmux: str, pane_id: str, terminal_log: Path) -> bool:
@@ -423,6 +636,7 @@ def _write_pane_metadata(
     *,
     target_pane: str,
     close_on_verdict: bool,
+    layout: _PaneLaunch | None = None,
 ) -> None:
     """Snapshot the pane's ``#{pane_dead}`` (and related) fields for diagnostics."""
     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -432,6 +646,13 @@ def _write_pane_metadata(
         "target_pane": target_pane,
         "close_on_verdict": close_on_verdict,
     }
+    if layout is not None:
+        # Issue #238: pane placement diagnostics (right-column layout).
+        metadata["layout_target_pane"] = target_pane
+        metadata["split_target_pane"] = layout.split_target_pane
+        metadata["split_direction"] = "horizontal" if layout.split_flag == "-h" else "vertical"
+        metadata["kaji_agent_panes_before"] = layout.panes_before
+        metadata["kaji_agent_panes_pruned"] = layout.panes_pruned
     format_string = "\t".join(
         [
             "pane_id=#{pane_id}",

--- a/tests/test_interactive_terminal.py
+++ b/tests/test_interactive_terminal.py
@@ -21,8 +21,12 @@ import pytest
 
 from kaji_harness.errors import CLIExecutionError, CLINotFoundError, StepTimeoutError
 from kaji_harness.interactive_terminal import (
+    KajiAgentPane,
     _build_tmux_split_argv,
+    _list_kaji_agent_panes,
     _pane_dead,
+    _parse_kaji_pane_marker,
+    _prune_kaji_agent_panes,
     execute_interactive_terminal,
 )
 from kaji_harness.models import Step
@@ -63,6 +67,9 @@ def _make_fake_tmux(
     pane_id: str = "%99",
     pane_dead: str = "0",
     pipe_returncode: int = 0,
+    list_panes_output: str = "",
+    list_panes_returncode: int = 0,
+    set_option_returncode: int = 0,
     on_split: object = None,
     calls: list[list[str]] | None = None,
 ):
@@ -70,6 +77,9 @@ def _make_fake_tmux(
 
     ``on_split`` (a no-arg callable) fires when ``split-window`` is seen so the
     test can write ``verdict.yaml`` / ``terminal.log`` at pane-launch time.
+    ``list_panes_output`` is the stdout for the kaji-pane discovery call (empty =
+    no existing managed panes); ``set_option_returncode`` lets a test simulate a
+    failed kaji marker write.
     """
 
     def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -77,6 +87,8 @@ def _make_fake_tmux(
             calls.append(argv)
         if argv == [tmux, "-V"]:
             return _completed(stdout=version)
+        if argv[:2] == [tmux, "list-panes"]:
+            return _completed(stdout=list_panes_output, returncode=list_panes_returncode)
         if argv[:2] == [tmux, "split-window"]:
             if on_split is not None:
                 on_split()  # type: ignore[operator]
@@ -84,6 +96,8 @@ def _make_fake_tmux(
         if argv[:2] == [tmux, "pipe-pane"]:
             return _completed(returncode=pipe_returncode, stderr="can't find pane")
         if argv[:2] == [tmux, "set-option"]:
+            return _completed(returncode=set_option_returncode, stderr="set-option failed")
+        if argv[:2] == [tmux, "kill-pane"]:
             return _completed()
         if argv[:2] == [tmux, "display-message"]:
             if argv[-1] == "#{pane_dead}":
@@ -91,8 +105,6 @@ def _make_fake_tmux(
             return _completed(
                 stdout=_PANE_METADATA.replace("pane_dead=0", f"pane_dead={pane_dead}")
             )
-        if argv[:2] == [tmux, "kill-pane"]:
-            return _completed()
         raise AssertionError(f"unexpected tmux call: {argv}")
 
     return fake_run
@@ -100,15 +112,16 @@ def _make_fake_tmux(
 
 @pytest.mark.small
 class TestBuildTmuxSplitArgv:
-    """tmux ``split-window`` command construction (MF2: right split via ``-h``)."""
+    """tmux ``split-window`` command construction (Issue #238: -h / -v split)."""
 
-    def test_split_window_prefix_includes_dash_h_and_pane_id_format(self, tmp_path: Path) -> None:
+    def _argv(self, tmp_path: Path, *, split_target_pane: str, split_flag: str) -> list[str]:
         prompt = tmp_path / "prompt.txt"
         verdict = tmp_path / "verdict.yaml"
-        argv = _build_tmux_split_argv(
+        return _build_tmux_split_argv(
             "/usr/bin/tmux",
             WRAPPER,
-            target_pane="%7",
+            split_target_pane=split_target_pane,
+            split_flag=split_flag,
             agent="claude",
             prompt_path=prompt,
             verdict_path=verdict,
@@ -119,7 +132,10 @@ class TestBuildTmuxSplitArgv:
             effort="low",
         )
 
-        # Exact prefix: `-h` after `-d` puts the new pane to the user's right.
+    def test_horizontal_split_prefix_and_pane_id_format(self, tmp_path: Path) -> None:
+        argv = self._argv(tmp_path, split_target_pane="%7", split_flag="-h")
+
+        # Exact prefix: `-h` after `-d` puts the first agent pane to the right.
         assert argv[:9] == [
             "/usr/bin/tmux",
             "split-window",
@@ -136,11 +152,30 @@ class TestBuildTmuxSplitArgv:
         command = argv[9]
         assert str(WRAPPER) in command
         assert "claude" in command
-        assert str(prompt) in command
-        assert str(verdict) in command
+        assert str(tmp_path / "prompt.txt") in command
+        assert str(tmp_path / "verdict.yaml") in command
         assert "11111111-1111-4111-8111-111111111111" in command
         assert "haiku" in command
         assert "low" in command
+
+    def test_vertical_split_targets_existing_agent_pane(self, tmp_path: Path) -> None:
+        argv = self._argv(tmp_path, split_target_pane="%12", split_flag="-v")
+        # `-v` splits the right column's bottom pane; target is the agent pane.
+        assert argv[:9] == [
+            "/usr/bin/tmux",
+            "split-window",
+            "-d",
+            "-v",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-t",
+            "%12",
+        ]
+
+    def test_invalid_split_flag_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="split_flag"):
+            self._argv(tmp_path, split_target_pane="%7", split_flag="-x")
 
 
 @pytest.mark.small
@@ -192,9 +227,11 @@ class TestRunnerEntryValidation:
                     timeout=5,
                 )
 
+    @pytest.mark.parametrize("version", ["tmux 2.9\n", "tmux 3.0\n"])
     def test_tmux_version_below_minimum_fails_loud(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: str
     ) -> None:
+        # Issue #238: pane options require tmux 3.1, so 3.0 now also fails fast.
         prompt = tmp_path / "prompt.txt"
         prompt.write_text("prompt", encoding="utf-8")
         monkeypatch.setenv("TMUX", "/tmp/tmux-sock,1,0")
@@ -202,13 +239,13 @@ class TestRunnerEntryValidation:
 
         def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
             assert argv == ["/usr/bin/tmux", "-V"]
-            return _completed(stdout="tmux 2.9\n")
+            return _completed(stdout=version)
 
         with (
             patch("kaji_harness.interactive_terminal.shutil.which", return_value="/usr/bin/tmux"),
             patch.object(subprocess, "run", side_effect=fake_run),
         ):
-            with pytest.raises(CLINotFoundError, match="tmux >= 3.0"):
+            with pytest.raises(CLINotFoundError, match="tmux >= 3.1"):
                 execute_interactive_terminal(
                     step=_step("claude"),
                     prompt_path=prompt,
@@ -216,6 +253,32 @@ class TestRunnerEntryValidation:
                     workdir=tmp_path,
                     timeout=5,
                 )
+
+    def test_tmux_3_1_passes_version_check(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # tmux 3.1 is the minimum and must clear the version gate.
+        prompt = tmp_path / "prompt.txt"
+        verdict = tmp_path / "verdict.yaml"
+        prompt.write_text("prompt", encoding="utf-8")
+        monkeypatch.setenv("TMUX", "/tmp/tmux-sock,1,0")
+        monkeypatch.setenv("TMUX_PANE", "%7")
+        fake_run = _make_fake_tmux(
+            version="tmux 3.1\n",
+            on_split=lambda: verdict.write_text(_PASS_VERDICT, encoding="utf-8"),
+        )
+        with (
+            patch("kaji_harness.interactive_terminal.shutil.which", return_value="/usr/bin/tmux"),
+            patch.object(subprocess, "run", side_effect=fake_run),
+        ):
+            result = execute_interactive_terminal(
+                step=_step("claude"),
+                prompt_path=prompt,
+                verdict_path=verdict,
+                workdir=tmp_path,
+                timeout=5,
+            )
+        assert result.full_output == ""
 
     def test_rejects_unsupported_agent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -839,7 +902,263 @@ class TestInteractiveTerminalWrapper:
         ]
 
 
-def _tmux_at_least_3() -> bool:
+@pytest.mark.small
+class TestKajiPaneMarker:
+    """`_parse_kaji_pane_marker` tolerates unknown / empty / malformed values."""
+
+    def test_parses_origin_field(self) -> None:
+        assert _parse_kaji_pane_marker("origin=%7") == {"origin": "%7"}
+
+    def test_empty_value_is_empty_dict(self) -> None:
+        assert _parse_kaji_pane_marker("") == {}
+
+    def test_malformed_token_without_equals_is_dropped(self) -> None:
+        assert _parse_kaji_pane_marker("garbage") == {}
+
+    def test_unknown_fields_kept_origin_extracted(self) -> None:
+        parsed = _parse_kaji_pane_marker("origin=%7 extra=foo")
+        assert parsed["origin"] == "%7"
+        assert parsed["extra"] == "foo"
+
+    def test_empty_origin_value_kept_as_empty_string(self) -> None:
+        assert _parse_kaji_pane_marker("origin=") == {"origin": ""}
+
+
+def _list_panes_lines(*rows: tuple[str, int, int, int, str]) -> str:
+    """Render fake ``list-panes -F`` output rows (pane_id, top, left, width, marker)."""
+    return "".join(
+        f"{pid}\t{top}\t{left}\t{width}\t{marker}\n" for pid, top, left, width, marker in rows
+    )
+
+
+@pytest.mark.medium
+class TestListKajiAgentPanes:
+    """`_list_kaji_agent_panes` filtering, ordering, and fail-loud behaviour."""
+
+    def _list(self, output: str, *, returncode: int = 0) -> list[KajiAgentPane]:
+        fake_run = _make_fake_tmux(list_panes_output=output, list_panes_returncode=returncode)
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            return _list_kaji_agent_panes("/usr/bin/tmux", "%7")
+
+    def test_returns_managed_panes_sorted_by_pane_top(self) -> None:
+        output = _list_panes_lines(
+            ("%7", 0, 0, 60, ""),  # origin pane, excluded
+            ("%2", 18, 61, 60, "origin=%7"),  # newer (lower) pane
+            ("%1", 0, 61, 60, "origin=%7"),  # older (upper) pane
+        )
+        panes = self._list(output)
+        assert [pane.pane_id for pane in panes] == ["%1", "%2"]
+        assert panes[0].pane_top == 0
+        assert panes[1].pane_top == 18
+        assert panes[1].pane_left == 61
+        assert panes[1].pane_width == 60
+
+    def test_ignores_origin_and_unmarked_and_foreign_origin(self) -> None:
+        output = _list_panes_lines(
+            ("%7", 0, 0, 60, ""),  # origin
+            ("%3", 0, 61, 60, ""),  # unmarked manual pane
+            ("%4", 5, 61, 60, "origin=%99"),  # marked for a different origin
+            ("%5", 9, 61, 60, "origin=%7"),  # our managed pane
+        )
+        panes = self._list(output)
+        assert [pane.pane_id for pane in panes] == ["%5"]
+
+    def test_list_panes_failure_fails_loud(self) -> None:
+        with pytest.raises(CLIExecutionError):
+            self._list("", returncode=1)
+
+
+@pytest.mark.small
+class TestPruneKajiAgentPanes:
+    """`_prune_kaji_agent_panes` keeps the newest N panes, killing the oldest."""
+
+    def test_keeps_all_when_under_limit(self) -> None:
+        panes = [KajiAgentPane("%1", 0, 61, 60)]
+        calls: list[list[str]] = []
+        fake_run = _make_fake_tmux(calls=calls)
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            survivors = _prune_kaji_agent_panes("/usr/bin/tmux", panes, keep=1)
+        assert [p.pane_id for p in survivors] == ["%1"]
+        assert not any(call[:2] == ["/usr/bin/tmux", "kill-pane"] for call in calls)
+
+    def test_kills_oldest_top_pane_when_over_limit(self) -> None:
+        panes = [
+            KajiAgentPane("%2", 18, 61, 60),
+            KajiAgentPane("%1", 0, 61, 60),
+        ]
+        calls: list[list[str]] = []
+        fake_run = _make_fake_tmux(calls=calls)
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            survivors = _prune_kaji_agent_panes("/usr/bin/tmux", panes, keep=1)
+        # %1 (pane_top 0, top of column) is the oldest and is killed.
+        assert [p.pane_id for p in survivors] == ["%2"]
+        assert ["/usr/bin/tmux", "kill-pane", "-t", "%1"] in calls
+        assert ["/usr/bin/tmux", "kill-pane", "-t", "%2"] not in calls
+
+
+@pytest.mark.medium
+class TestRightColumnPanePlacement:
+    """Issue #238: first pane splits right; later panes split the right column."""
+
+    def _run(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        list_panes_output: str = "",
+        set_option_returncode: int = 0,
+        list_panes_returncode: int = 0,
+        write_verdict: bool = True,
+    ) -> list[list[str]]:
+        prompt = tmp_path / "prompt.txt"
+        verdict = tmp_path / "verdict.yaml"
+        prompt.write_text("prompt", encoding="utf-8")
+        monkeypatch.setenv("TMUX", "/tmp/tmux-sock,1,0")
+        monkeypatch.setenv("TMUX_PANE", "%7")
+        calls: list[list[str]] = []
+        on_split = (
+            (lambda: verdict.write_text(_PASS_VERDICT, encoding="utf-8")) if write_verdict else None
+        )
+        fake_run = _make_fake_tmux(
+            calls=calls,
+            list_panes_output=list_panes_output,
+            list_panes_returncode=list_panes_returncode,
+            set_option_returncode=set_option_returncode,
+            on_split=on_split,
+        )
+        with (
+            patch("kaji_harness.interactive_terminal.shutil.which", return_value="/usr/bin/tmux"),
+            patch.object(subprocess, "run", side_effect=fake_run),
+        ):
+            execute_interactive_terminal(
+                step=_step("claude"),
+                prompt_path=prompt,
+                verdict_path=verdict,
+                workdir=tmp_path,
+                timeout=5,
+            )
+        return calls
+
+    def _split_call(self, calls: list[list[str]]) -> list[str]:
+        for call in calls:
+            if call[:2] == ["/usr/bin/tmux", "split-window"]:
+                return call
+        raise AssertionError("split-window was never called")
+
+    def test_zero_panes_splits_origin_horizontally(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = self._run(
+            tmp_path, monkeypatch, list_panes_output=_list_panes_lines(("%7", 0, 0, 60, ""))
+        )
+        split = self._split_call(calls)
+        assert split[2:4] == ["-d", "-h"]
+        assert split[7:9] == ["-t", "%7"]
+        # The new pane is tagged with the kaji marker.
+        assert [
+            "/usr/bin/tmux",
+            "set-option",
+            "-p",
+            "-t",
+            "%99",
+            "@kaji_interactive_terminal",
+            "origin=%7",
+        ] in calls
+
+    def test_one_pane_splits_existing_agent_vertically(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output = _list_panes_lines(
+            ("%7", 0, 0, 60, ""),
+            ("%1", 0, 61, 60, "origin=%7"),
+        )
+        calls = self._run(tmp_path, monkeypatch, list_panes_output=output)
+        split = self._split_call(calls)
+        assert split[2:4] == ["-d", "-v"]
+        assert split[7:9] == ["-t", "%1"]
+        # The existing managed pane is reused (split), never pruned. (The created
+        # pane %99 is still killed by the close_on_verdict cleanup.)
+        assert ["/usr/bin/tmux", "kill-pane", "-t", "%1"] not in calls
+
+    def test_two_panes_kills_oldest_then_splits_newest_vertically(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output = _list_panes_lines(
+            ("%7", 0, 0, 60, ""),
+            ("%1", 0, 61, 60, "origin=%7"),  # oldest (top)
+            ("%2", 18, 61, 60, "origin=%7"),  # newest (bottom)
+        )
+        calls = self._run(tmp_path, monkeypatch, list_panes_output=output)
+        # The oldest managed pane is pruned before the split.
+        assert ["/usr/bin/tmux", "kill-pane", "-t", "%1"] in calls
+        split = self._split_call(calls)
+        assert split[2:4] == ["-d", "-v"]
+        assert split[7:9] == ["-t", "%2"]
+
+    def test_foreign_origin_pane_is_not_pruned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A pane marked for a different origin must never be killed and must not
+        # count toward the limit (so we split the origin horizontally).
+        output = _list_panes_lines(
+            ("%7", 0, 0, 60, ""),
+            ("%8", 0, 61, 60, "origin=%99"),
+        )
+        calls = self._run(tmp_path, monkeypatch, list_panes_output=output)
+        # The foreign-origin pane %8 is never pruned.
+        assert ["/usr/bin/tmux", "kill-pane", "-t", "%8"] not in calls
+        split = self._split_call(calls)
+        assert split[2:4] == ["-d", "-h"]
+        assert split[7:9] == ["-t", "%7"]
+
+    def test_list_panes_failure_fails_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with pytest.raises(CLIExecutionError):
+            self._run(tmp_path, monkeypatch, list_panes_returncode=1, write_verdict=False)
+
+    def test_marker_set_failure_kills_pane_and_fails_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+        prompt = tmp_path / "prompt.txt"
+        prompt.write_text("prompt", encoding="utf-8")
+        monkeypatch.setenv("TMUX", "/tmp/tmux-sock,1,0")
+        monkeypatch.setenv("TMUX_PANE", "%7")
+        fake_run = _make_fake_tmux(
+            calls=calls,
+            list_panes_output=_list_panes_lines(("%7", 0, 0, 60, "")),
+            set_option_returncode=1,
+        )
+        with (
+            patch("kaji_harness.interactive_terminal.shutil.which", return_value="/usr/bin/tmux"),
+            patch.object(subprocess, "run", side_effect=fake_run),
+        ):
+            with pytest.raises(CLIExecutionError):
+                execute_interactive_terminal(
+                    step=_step("claude"),
+                    prompt_path=prompt,
+                    verdict_path=tmp_path / "verdict.yaml",
+                    workdir=tmp_path,
+                    timeout=5,
+                )
+        # The orphaned (unmarked) pane is best-effort killed before failing loud.
+        assert ["/usr/bin/tmux", "kill-pane", "-t", "%99"] in calls
+
+    def test_metadata_records_layout(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = _list_panes_lines(
+            ("%7", 0, 0, 60, ""),
+            ("%1", 0, 61, 60, "origin=%7"),
+        )
+        self._run(tmp_path, monkeypatch, list_panes_output=output)
+        metadata = json.loads((tmp_path / "pane-metadata.json").read_text(encoding="utf-8"))
+        assert metadata["split_target_pane"] == "%1"
+        assert metadata["split_direction"] == "vertical"
+        assert metadata["kaji_agent_panes_before"] == ["%1"]
+        assert metadata["kaji_agent_panes_pruned"] == []
+
+
+def _tmux_at_least_3_1() -> bool:
     tmux = shutil.which("tmux")
     if tmux is None:
         return False
@@ -849,12 +1168,12 @@ def _tmux_at_least_3() -> bool:
     match = re.search(r"tmux\s+(\d+)\.(\d+)", proc.stdout)
     if match is None:
         return False
-    return (int(match.group(1)), int(match.group(2))) >= (3, 0)
+    return (int(match.group(1)), int(match.group(2))) >= (3, 1)
 
 
 @pytest.mark.large
 @pytest.mark.large_local
-@pytest.mark.skipif(not _tmux_at_least_3(), reason="requires real tmux >= 3.0 on PATH")
+@pytest.mark.skipif(not _tmux_at_least_3_1(), reason="requires real tmux >= 3.1 on PATH")
 class TestInteractiveTerminalEndToEnd:
     """E2E: real tmux split-window → wrapper.sh → fake agent → verdict → kill-pane."""
 
@@ -897,6 +1216,117 @@ class TestInteractiveTerminalEndToEnd:
             check=False,
         )
         return proc.stdout.split()
+
+    def _kaji_pane_geometry(self, socket: str, origin_pane: str) -> list[tuple[str, int, int]]:
+        """Return (pane_id, pane_left, pane_width) for kaji-managed agent panes.
+
+        Filters to panes whose ``@kaji_interactive_terminal`` marker resolves to
+        ``origin=<origin_pane>``, ordered by ``pane_top`` ascending.
+        """
+        tmux = shutil.which("tmux")
+        assert tmux is not None
+        fmt = "\t".join(
+            [
+                "#{pane_id}",
+                "#{pane_top}",
+                "#{pane_left}",
+                "#{pane_width}",
+                "#{@kaji_interactive_terminal}",
+            ]
+        )
+        proc = subprocess.run(
+            [tmux, "-L", socket, "list-panes", "-t", origin_pane, "-F", fmt],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        rows: list[tuple[int, str, int, int]] = []
+        for line in proc.stdout.splitlines():
+            parts = line.split("\t")
+            if len(parts) < 5:
+                continue
+            pane_id, top, left, width, marker = parts[:5]
+            if pane_id == origin_pane or marker != f"origin={origin_pane}":
+                continue
+            rows.append((int(top), pane_id, int(left), int(width)))
+        rows.sort()
+        return [(pid, left, width) for _, pid, left, width in rows]
+
+    def _write_fake_claude(self, fake_bin: Path) -> None:
+        fake_claude = fake_bin / "claude"
+        # Write the verdict path embedded in the prompt, then stay alive so the
+        # pane survives under close_on_verdict=False.
+        fake_claude.write_text(
+            "#!/usr/bin/env bash\n"
+            'for arg in "$@"; do prompt="$arg"; done\n'
+            "verdict_path=$(printf '%s\\n' \"$prompt\" | "
+            "awk '/write only a pure YAML verdict file to this exact path:/{getline; print; exit}')\n"
+            'printf "status: PASS\\nreason: ok\\nevidence: e2e\\nsuggestion: \x27\x27\\n"'
+            ' > "$verdict_path"\n'
+            "sleep 30\n",
+            encoding="utf-8",
+        )
+        fake_claude.chmod(0o755)
+
+    def test_real_tmux_keeps_right_column_at_two_panes_with_stable_width(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Issue #238: launch agent panes repeatedly with close_on_verdict=False
+        # and confirm the right column never exceeds two kaji panes and that the
+        # origin/agent widths do not shrink with each additional launch.
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        self._write_fake_claude(fake_bin)
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+
+        socket = f"kaji-e2e-{uuid.uuid4().hex[:8]}"
+        monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+        tmux_env, origin_pane = self._start_server(socket)
+        tmux = shutil.which("tmux")
+        assert tmux is not None
+        try:
+            monkeypatch.setenv("TMUX", tmux_env)
+            monkeypatch.setenv("TMUX_PANE", origin_pane)
+
+            geometries: list[list[tuple[str, int, int]]] = []
+            for index in range(4):
+                attempt = tmp_path / f"attempt-{index}"
+                attempt.mkdir()
+                prompt = attempt / "prompt.txt"
+                prompt.write_text("the full task prompt", encoding="utf-8")
+                execute_interactive_terminal(
+                    step=_step("claude", model="haiku", effort="low"),
+                    prompt_path=prompt,
+                    verdict_path=attempt / "verdict.yaml",
+                    workdir=workdir,
+                    timeout=30,
+                    close_on_verdict=False,
+                )
+                geometries.append(self._kaji_pane_geometry(socket, origin_pane))
+
+            # First launch: exactly one managed agent pane in the right column.
+            assert len(geometries[0]) == 1
+            # Subsequent launches stabilise at the two-pane cap.
+            assert len(geometries[1]) == 2
+            assert len(geometries[2]) == 2
+            assert len(geometries[3]) == 2
+
+            # The right column stays in a single vertical column: every managed
+            # pane shares the same pane_left, and that left does not drift right
+            # with additional launches (no horizontal re-splitting).
+            agent_lefts = {left for geo in geometries for _, left, _ in geo}
+            assert len(agent_lefts) == 1
+            # Agent pane width is preserved across launches (no shrinking).
+            agent_widths = {width for geo in geometries for _, _, width in geo}
+            assert len(agent_widths) == 1
+
+            # The origin pane is still present after repeated launches.
+            assert origin_pane in self._list_panes(socket)
+        finally:
+            subprocess.run(
+                [tmux, "-L", socket, "kill-server"], capture_output=True, text=True, check=False
+            )
 
     def test_real_tmux_drives_wrapper_to_write_and_resolve_verdict(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

`interactive_terminal` runner の tmux pane 配置を改善し、左に `kaji run` 本体、右列に agent pane 最大2枚を維持する配置へ変更する。右列が2枚満杯の場合は最古 pane を kill し、常に最新2枚だけを表示する。

Closes #238

> Issue close は kaji workflow の `/issue-close`（`kaji pr merge` + `kaji issue close`）が担当する。GitHub の auto-close は repository 側で無効化しているため、Development link（Issue 側の紐づけ表示）のために `Closes #238` を記載している。merge による自動 close は発生しない。

## Changes

- `kaji_harness/interactive_terminal.py`: agent pane 生成ロジックを「右列最大2枚維持」方式へ変更（`tmux select-pane -P` で `tmux-marker` を設定し、古い agent pane を識別・kill する）
- `tests/test_interactive_terminal.py`: 新ロジックに対応したテストを追加・更新
- `docs/adr/007-interactive-terminal-runner.md`: 右列2枚制限の設計決定を ADR へ追記
- `docs/cli-guides/interactive-terminal-runner.md`: tmux >= 3.1 最小要件と pane 配置動作の説明を更新

## Documentation

- `docs/adr/007-interactive-terminal-runner.md` に右列2枚制限のアーキテクチャ決定を追記済み
- `docs/cli-guides/interactive-terminal-runner.md` に tmux 最小バージョン要件と pane 配置動作を追記済み

## Test Plan

- [x] 既存テストがパス（make check 確認済み）
- [x] 新規テストを追加（右列2枚制限の境界値テスト）
- [x] tmux select-pane -P による marker 管理のユニットテスト
