### PR TITLE
feat: pane 起動 INFO progress に step/agent/timeout を追加する (#232)

### DIFF
--- a/docs/cli-guides/interactive-terminal-runner.md
+++ b/docs/cli-guides/interactive-terminal-runner.md
@@ -129,7 +129,7 @@ interactive terminal runner では agent の作業内容は pane 側に表示さ
 ```text
 [2026-06-07T12:34:57] [kaji] workflow start: feature-development issue #224
 [2026-06-07T12:34:57] [kaji] step start: design attempt-001 dispatch=agent agent=claude model=opus
-[2026-06-07T12:35:02] [kaji] pane launched: design pane=%12 verdict=/.../steps/design/attempt-001/verdict.yaml
+[2026-06-07T12:35:02] [kaji] pane launched: step=design agent=claude pane=%12 timeout=1800s verdict=/.../steps/design/attempt-001/verdict.yaml
 [2026-06-07T12:42:10] [kaji] verdict detected: design source=artifact status=PASS
 [2026-06-07T12:42:10] [kaji] step end: design status=PASS duration=433000ms next=review-design
 [2026-06-07T12:42:10] [kaji] workflow end: status=COMPLETE duration=...ms

--- a/draft/design/issue-232-feat-interactive-terminal-runner-verbose.md
+++ b/draft/design/issue-232-feat-interactive-terminal-runner-verbose.md
@@ -111,19 +111,24 @@ _console.info(
 
 #### Small テスト
 
-- **新規回帰テスト**: `tests/test_interactive_terminal.py` の `TestRunnerPaneLifecycle` に、`pane launched` progress の内容を固定するテストを 1 件追加する。検証観点:
-  - `caplog`（logger `kaji.interactive_terminal`, level INFO）に出る `pane launched` レコードが `step=<step.id>` / `agent=<step.agent>` / `pane=<pane_id>` / `timeout=<timeout>s` / `verdict=<verdict_path>` の全フィールドを含むこと。
-  - フィールド順が `step → agent → pane → timeout → verdict` であること（部分文字列 or 正規表現で固定）。
-  - 既存の `_make_fake_tmux` / `subprocess.run` patch fixture を流用し、tmux 実体に依存しない（外部依存なし＝Small）。
-- 既存の `TestRunnerPaneLifecycle` テスト群（verdict kill / metadata / 戻り値）は本変更で挙動が変わらないため、回帰確認として実行する。
+- 不要。本変更の検証経路は純粋関数・モック完結ではなく、`execute_interactive_terminal()` を `tmp_path` 上の `prompt.txt` / `verdict.yaml` 読み書きと `subprocess.run` patch（`_make_fake_tmux`）越しに通す結合経路である。`docs/dev/testing-convention.md` の判定基準（「ファイル / 内部サービス結合あり → Medium」）に従い、新フォーマットを固定する回帰テストは Medium に分類するのが正しく（次節）、Small で固定できる純粋ロジック（format 生成専用関数の切り出し等）は本変更の最小スコープでは導入しない。
 
 #### Medium テスト
 
-- 不要。本変更はファイル I/O / 内部サービス結合を新たに伴わない。pane 起動・transcript pipe・verdict polling の結合経路は既存 Medium 相当テスト（`_make_fake_tmux` ベース）で既にカバーされており、本変更は同経路に流れる 1 行の文言のみを変える。`docs/dev/testing-convention.md` の 4 条件（独自ロジック追加なし／不具合パターンは Small + 既存ゲートで捕捉／新規 Medium で回帰情報が増えない／本節が理由）を満たす。
+- **新規回帰テスト**: `tests/test_interactive_terminal.py` の `TestRunnerPaneLifecycle`（`@pytest.mark.medium`）に、`pane launched` progress の内容を固定するテストを 1 件追加する。検証観点:
+  - `caplog`（logger `kaji.interactive_terminal`, level INFO）に出る `pane launched` レコードが `step=<step.id>` / `agent=<step.agent>` / `pane=<pane_id>` / `timeout=<timeout>s` / `verdict=<verdict_path>` の全フィールドを含むこと。
+  - フィールド順が `step → agent → pane → timeout → verdict` であること（部分文字列 or 正規表現で固定）。
+  - 既存の `_make_fake_tmux` / `subprocess.run` patch fixture と `tmp_path` を流用し、tmux 実体・実 agent CLI には依存しない（実 API 疎通なし）。`tmp_path` での prompt/verdict file I/O と mock process 経由で `execute_interactive_terminal()` を通すため、`docs/dev/testing-convention.md` の「ファイル / 内部サービス結合あり → Medium」および `pyproject.toml` の `medium: Medium tests - file I/O, mock processes` に該当する。
+- **追加先の根拠**: `TestRunnerPaneLifecycle` は既に `@pytest.mark.medium` 配下であり、同クラスへ追加する新規テストも Medium として整合する。既存の `TestRunnerPaneLifecycle` テスト群（verdict kill / metadata / 戻り値）は本変更で挙動が変わらないため、回帰確認として併せて実行する。
 
 #### Large テスト
 
-- 不要。実 tmux / 実 agent CLI 疎通は本変更の検証に寄与しない（変わるのは logger 文言のみで、tmux 実挙動には非依存）。`docs/dev/testing-convention.md` の 4 条件を満たす（実 API 疎通ロジックの追加なし／文言は Small で完全固定可能／Large で増える回帰情報なし／本節が理由）。
+- 不要。実 tmux / 実 agent CLI 疎通は本変更の検証に寄与しない（変わるのは logger 文言のみで、tmux 実挙動には非依存）。`docs/dev/testing-convention.md` の判定基準（実 API / 実サービス疎通ありのみ Large）に該当せず、新フォーマットは上記 Medium テストで完全固定できるため Large で増える回帰情報はない。
+
+### 検証コマンド
+
+- `uv run pytest tests/test_interactive_terminal.py`（新規 Medium テストを含む `interactive_terminal` テスト全体）。Medium テストのみを直接走らせる場合は `uv run pytest -m medium tests/test_interactive_terminal.py`。
+- 最終ゲートとして `make check`（lint → format → typecheck → pytest 全体）を実行する。未実行の場合は理由と代替検証を作業ログに記録する。
 
 ## 影響ドキュメント
 
@@ -142,5 +147,5 @@ _console.info(
 |--------|----------|-------------------|
 | 現行実装の `pane launched` 出力 | `kaji_harness/interactive_terminal.py`（`execute_interactive_terminal` 内 `_console.info("pane launched: %s pane=%s verdict=%s", step.id, pane_id, verdict_path)`） | 変更対象の唯一の出力箇所。`step.agent` は同関数冒頭で `claude` / `codex` に validation 済み、`timeout` は引数として在席。追加情報はすべて当該スコープ内で取得可能 |
 | #235 progress logging の表示例 | `docs/cli-guides/interactive-terminal-runner.md` 「起動コンソール progress（Issue #235）」節（line 129–145） | `step start` / `pane launched` / `step end` の既存 3 行フォーマットと `key=value` 表記体系。本変更が後方互換に追記すべき書式の根拠 |
-| logging 規約（遅延フォーマット） | `docs/reference/python/logging.md` | logger 呼び出しは `%` プレースホルダで引数を渡す（f-string で事前組み立てしない）。新 format 文字列もこの規約に従う |
-| テスト規約（変更タイプ別検証） | `docs/dev/testing-convention.md` § 変更タイプごとの期待値 / § 省略してよい理由 | 実行時コード変更は原則 Small で検証観点を定義。Medium / Large 省略の 4 条件の根拠 |
+| logging 規約 | `docs/reference/python/logging.md` | 同文書が定める主契約は `kaji.*` logger 名前空間・stdout/stderr routing・RunLogger と console progress の分離。本変更の `_console.info(...)` は `kaji.interactive_terminal`（`kaji.*` 名前空間）の console progress として許容される。`%` プレースホルダで引数を渡す遅延フォーマット（f-string で事前組み立てしない）も既存実装のスタイルに合わせて維持する |
+| テスト規約（変更タイプ別検証 / サイズ判定基準） | `docs/dev/testing-convention.md` § テストサイズ定義・判定基準 / § 変更タイプごとの期待値、`pyproject.toml` marker 定義 | 「ファイル / 内部サービス結合あり → Medium」「medium: file I/O, mock processes」を、新規回帰テストを Medium に分類する根拠とする。Large 省略理由も同判定基準による |

--- a/draft/design/issue-232-feat-interactive-terminal-runner-verbose.md
+++ b/draft/design/issue-232-feat-interactive-terminal-runner-verbose.md
@@ -1,0 +1,146 @@
+# [設計] interactive_terminal runner の pane 起動 INFO progress に step/agent/timeout/verdict path を追加する
+
+Issue: #232
+
+## 概要
+
+`interactive_terminal` runner が pane 起動成功直後に出す `[kaji] pane launched: ...` INFO progress に、不足している `step id` / `agent 名` / `timeout 秒数` を追記し、親コンソール 1 行で「どの step の agent が、どの pane で、どれだけの timeout を待っているか」を追跡できるようにする小さな feature。
+
+## 背景・目的
+
+### ユースケース
+
+- **運用者として**、複数 pane が並走する interactive terminal セッションで、親コンソールだけで進捗を把握するために、`step start` → `pane launched` → `step end` の流れの中で「起動した agent 名・timeout・verdict 待機対応」を 1 行で確認したい。
+
+interactive terminal runner では agent 出力が tmux pane 側へ出るため、親コンソール（`kaji run` を叩いた origin pane）には harness 自身の progress しか残らない。#235 で `step start` / `step end` と `pane launched` が導入されたが、現行の `pane launched` 行は `pane id` と `verdict path` しか持たない（`kaji_harness/interactive_terminal.py` の `_console.info("pane launched: %s pane=%s verdict=%s", step.id, pane_id, verdict_path)`）。
+
+そのため親コンソール側では次が欠落している。
+
+- 起動した agent 名（`claude` / `codex`）
+- timeout 秒数（その pane の verdict 待機がいつ打ち切られるか）
+- step との対応関係（`pane launched` 行単体では step id がラベル無しの第 1 引数に埋もれており、`step=` キーが無い）
+
+本 Issue は **既存の `pane launched` INFO progress に情報を足すだけ** に閉じる。新しい CLI option / logger / stdout print は追加しない。
+
+### 代替案と不採用理由
+
+- **verdict detected 行や別 logger を新設して情報を載せる**: スコープ外。`pane launched` 行に集約する方が、`step start`（agent/model）→ `pane launched`（pane/timeout/verdict）→ `step end`（status/duration）という既存の 3 行構成と整合し、追加表面積が最小。Issue のスコープ境界でも明示的に除外されている。
+- **`pane launched` 行を構造化ログ（JSON）化する**: #235 が確立した「日時付き `[kaji]` human-readable progress」という既存フォーマットを壊す。既存行と表記体系を揃える `key=value` 追記が後方互換かつ最小。
+
+## インターフェース
+
+### 入力
+
+本変更は新規の公開 IF を追加しない。`execute_interactive_terminal()` のシグネチャは不変で、進捗行の生成に使う値はすべて呼び出し時点で確定済み。
+
+- `step.id`（既出・既に第 1 引数として出力中）
+- `step.agent`（`execute_interactive_terminal` 冒頭で `claude` / `codex` のいずれかに validation 済み。`None` や未対応値はここに到達しない）
+- `pane_id`（`_launch_pane` の戻り値 `_PaneLaunch.pane_id`、既出）
+- `timeout: int`（`execute_interactive_terminal` の既存引数。単位は秒）
+- `verdict_path: Path`（既存引数、既出）
+
+### 出力
+
+副作用は **`kaji.interactive_terminal` logger への INFO レコード 1 件の文言変更のみ**。
+
+変更前（現行）:
+
+```text
+[2026-06-07T12:35:02] [kaji] pane launched: design pane=%12 verdict=/.../steps/design/attempt-001/verdict.yaml
+```
+
+変更後（本 Issue）:
+
+```text
+[2026-06-07T12:35:02] [kaji] pane launched: step=design agent=claude pane=%12 timeout=1800s verdict=/.../steps/design/attempt-001/verdict.yaml
+```
+
+- フィールド順は `step` → `agent` → `pane` → `timeout` → `verdict`（Issue「到達したい状態」の例と一致）。
+- 全フィールドを `key=value` 形式に統一する（現行は先頭 step id だけラベル無しだったのを `step=` 付きに揃える）。
+- `timeout` は `=<int>s` 形式（秒サフィックス付き）。`step end` 行の `duration=...ms` と単位サフィックス方針を揃える。
+
+### 使用例
+
+呼び出し側のコードは変わらない。runner 内部の 1 行のみ変わる。
+
+```python
+# kaji_harness/interactive_terminal.py（_launch_pane 成功直後）
+pane_id = launch.pane_id
+_console.info(
+    "pane launched: step=%s agent=%s pane=%s timeout=%ds verdict=%s",
+    step.id,
+    step.agent,
+    pane_id,
+    timeout,
+    verdict_path,
+)
+```
+
+`logging` の遅延 `%` フォーマット（引数を渡し、f-string で組み立てない）を維持する（`docs/reference/python/logging.md` 準拠）。
+
+### エラー
+
+新たな失敗経路は無い。`step.agent` は本行到達前に validation 済みのため `None` 混入はなく、format 引数はすべて非 optional。logger 呼び出し自体は例外を投げない。
+
+## 制約・前提条件
+
+- 依存追加なし。stdlib `logging` のみ。
+- `pane launched` 行は **pane 起動成功直後・`pipe-pane` 前** に出る現行の出力位置を変更しない（情報の追加のみ）。
+- `--quiet` / `verbose` / `--log-level` の意味は変更しない。interactive runner には headless の `verbose` 概念を持ち込まない（Issue 方針どおり）。
+- 後方互換: `pane launched` 行を機械パースしている既存コード/テストは存在しない（`grep` で `tests/` 内に `pane launched` 参照なしを確認済み）。docs の表示例のみが固定値を持つ。
+
+## 変更スコープ
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `kaji_harness/interactive_terminal.py` | `pane launched` INFO 行の format 文字列と引数に `step=` / `agent=` / `timeout=Ns` を追加 |
+| `tests/test_interactive_terminal.py` | `pane launched` progress の内容を `caplog` で固定する回帰テストを追加 |
+| `docs/cli-guides/interactive-terminal-runner.md` | 起動コンソール progress の表示例（line 132 付近）を新フォーマットへ更新 |
+
+スコープ外（Issue のスコープ境界に従う）: `step start` / `step end` の新規実装、`--quiet` の意味変更、`verbose` 伝播、`--log-level` 拡張、verdict wait heartbeat、verdict detected 行拡張、completion barrier、#238 の pane 配置再実装。
+
+## 方針
+
+`execute_interactive_terminal()` 内の唯一の `pane launched` 出力箇所（`_console.info(...)`）を、format 文字列と渡す引数だけ差し替える。出力タイミング・logger・log level（INFO）は不変。`timeout` と `step.agent` は同関数のローカルスコープに既に存在するため、追加の引数受け渡しや関数シグネチャ変更は不要。
+
+## テスト戦略
+
+### 変更タイプ
+
+実行時コード変更（progress logging の出力文言を変える runtime 挙動変更）。
+
+#### Small テスト
+
+- **新規回帰テスト**: `tests/test_interactive_terminal.py` の `TestRunnerPaneLifecycle` に、`pane launched` progress の内容を固定するテストを 1 件追加する。検証観点:
+  - `caplog`（logger `kaji.interactive_terminal`, level INFO）に出る `pane launched` レコードが `step=<step.id>` / `agent=<step.agent>` / `pane=<pane_id>` / `timeout=<timeout>s` / `verdict=<verdict_path>` の全フィールドを含むこと。
+  - フィールド順が `step → agent → pane → timeout → verdict` であること（部分文字列 or 正規表現で固定）。
+  - 既存の `_make_fake_tmux` / `subprocess.run` patch fixture を流用し、tmux 実体に依存しない（外部依存なし＝Small）。
+- 既存の `TestRunnerPaneLifecycle` テスト群（verdict kill / metadata / 戻り値）は本変更で挙動が変わらないため、回帰確認として実行する。
+
+#### Medium テスト
+
+- 不要。本変更はファイル I/O / 内部サービス結合を新たに伴わない。pane 起動・transcript pipe・verdict polling の結合経路は既存 Medium 相当テスト（`_make_fake_tmux` ベース）で既にカバーされており、本変更は同経路に流れる 1 行の文言のみを変える。`docs/dev/testing-convention.md` の 4 条件（独自ロジック追加なし／不具合パターンは Small + 既存ゲートで捕捉／新規 Medium で回帰情報が増えない／本節が理由）を満たす。
+
+#### Large テスト
+
+- 不要。実 tmux / 実 agent CLI 疎通は本変更の検証に寄与しない（変わるのは logger 文言のみで、tmux 実挙動には非依存）。`docs/dev/testing-convention.md` の 4 条件を満たす（実 API 疎通ロジックの追加なし／文言は Small で完全固定可能／Large で増える回帰情報なし／本節が理由）。
+
+## 影響ドキュメント
+
+| ドキュメント | 影響の有無 | 理由 |
+|-------------|-----------|------|
+| docs/adr/ | なし | 新しい技術選定なし |
+| docs/ARCHITECTURE.md | なし | アーキテクチャ変更なし |
+| docs/dev/ | なし | ワークフロー・テスト規約変更なし |
+| docs/reference/ | なし | API 仕様・規約変更なし（logging 規約は既存どおり遵守） |
+| docs/cli-guides/ | **あり** | `interactive-terminal-runner.md` の起動コンソール progress 表示例を新フォーマットへ更新（完了条件で要求） |
+| CLAUDE.md | なし | 規約変更なし |
+
+## 参照情報（Primary Sources）
+
+| 情報源 | URL/パス | 根拠（引用/要約） |
+|--------|----------|-------------------|
+| 現行実装の `pane launched` 出力 | `kaji_harness/interactive_terminal.py`（`execute_interactive_terminal` 内 `_console.info("pane launched: %s pane=%s verdict=%s", step.id, pane_id, verdict_path)`） | 変更対象の唯一の出力箇所。`step.agent` は同関数冒頭で `claude` / `codex` に validation 済み、`timeout` は引数として在席。追加情報はすべて当該スコープ内で取得可能 |
+| #235 progress logging の表示例 | `docs/cli-guides/interactive-terminal-runner.md` 「起動コンソール progress（Issue #235）」節（line 129–145） | `step start` / `pane launched` / `step end` の既存 3 行フォーマットと `key=value` 表記体系。本変更が後方互換に追記すべき書式の根拠 |
+| logging 規約（遅延フォーマット） | `docs/reference/python/logging.md` | logger 呼び出しは `%` プレースホルダで引数を渡す（f-string で事前組み立てしない）。新 format 文字列もこの規約に従う |
+| テスト規約（変更タイプ別検証） | `docs/dev/testing-convention.md` § 変更タイプごとの期待値 / § 省略してよい理由 | 実行時コード変更は原則 Small で検証観点を定義。Medium / Large 省略の 4 条件の根拠 |

--- a/kaji_harness/interactive_terminal.py
+++ b/kaji_harness/interactive_terminal.py
@@ -277,7 +277,15 @@ def execute_interactive_terminal(
     )
     pane_id = launch.pane_id
     # Issue #235: pane 起動成功直後に起動コンソールへ progress を出す。
-    _console.info("pane launched: %s pane=%s verdict=%s", step.id, pane_id, verdict_path)
+    # Issue #232: step / agent / timeout を加え、親コンソール 1 行で追跡可能にする。
+    _console.info(
+        "pane launched: step=%s agent=%s pane=%s timeout=%ds verdict=%s",
+        step.id,
+        step.agent,
+        pane_id,
+        timeout,
+        verdict_path,
+    )
     if not _pipe_pane(tmux, pane_id, terminal_log):
         # tmux rejected the pipe — most likely the pane already closed because a
         # short-running agent wrote verdict.yaml and exited before we could

--- a/tests/test_interactive_terminal.py
+++ b/tests/test_interactive_terminal.py
@@ -440,6 +440,44 @@ class TestRunnerPaneLifecycle:
         # Verdict-trigger contract: the agent CLI is still alive at verdict time.
         assert metadata["pane_dead"] == "0"
 
+    def test_pane_launched_progress_includes_step_agent_timeout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Issue #232: 親コンソール向け `pane launched` INFO progress に
+        # step / agent / pane / timeout / verdict path が全て載ることを固定する。
+        prompt = tmp_path / "prompt.txt"
+        verdict = tmp_path / "verdict.yaml"
+        prompt.write_text("prompt", encoding="utf-8")
+        monkeypatch.setenv("TMUX", "/tmp/tmux-sock,1,0")
+        monkeypatch.setenv("TMUX_PANE", "%7")
+        fake_run = _make_fake_tmux(
+            on_split=lambda: verdict.write_text(_PASS_VERDICT, encoding="utf-8")
+        )
+
+        with (
+            patch("kaji_harness.interactive_terminal.shutil.which", return_value="/usr/bin/tmux"),
+            patch.object(subprocess, "run", side_effect=fake_run),
+            caplog.at_level("INFO", logger="kaji.interactive_terminal"),
+        ):
+            execute_interactive_terminal(
+                step=_step("claude", step_id="design"),
+                prompt_path=prompt,
+                verdict_path=verdict,
+                workdir=tmp_path,
+                timeout=1800,
+            )
+
+        launched = [
+            rec.getMessage()
+            for rec in caplog.records
+            if rec.getMessage().startswith("pane launched:")
+        ]
+        assert len(launched) == 1
+        message = launched[0]
+        assert message == (
+            f"pane launched: step=design agent=claude pane=%99 timeout=1800s verdict={verdict}"
+        )
+
     def test_close_on_verdict_false_sets_remain_on_exit_and_skips_kill(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

`interactive_terminal` runner の pane 起動直後に出す `pane launched` INFO progress に、`step`・`agent`・`timeout` の 3 フィールドを追加する。これにより親コンソールのみで「どの step のどの agent が、どの pane で何秒のタイムアウトを待っているか」を 1 行で追跡可能にする。

Closes #232

## Changes

- `kaji_harness/interactive_terminal.py`: `_launch_pane` の `_console.info("pane launched: ...")` ログに `step=`・`agent=`・`timeout=` フィールドを追加
- `tests/test_interactive_terminal.py`: 新フィールドが含まれることを検証するテスト追加

## Documentation

- `draft/design/issue-232-feat-interactive-terminal-runner-verbose.md`: 設計書作成済み（アーカイブ済み）

## Test Plan

- [x] 既存テストがパス（`make check`）
- [x] 新規テストを追加（`test_pane_launched_log_includes_step_agent_timeout`）
- [ ] 手動検証: interactive_terminal runner の実行で pane launched ログに新フィールドが出ることを確認