### PR TITLE
feat: add public workflow set and refresh README

### DIFF
--- a/.kaji/wf/dev-thorough.yaml
+++ b/.kaji/wf/dev-thorough.yaml
@@ -180,7 +180,7 @@ steps:
       ABORT: end
 
   - id: review-poll
-    exec: [uv, run, --no-sync, python, -m, kaji_harness.scripts.review_poll_entry]
+    exec: [kaji, pr, review-poll]
     on:
       PASS: close
       RETRY: pr-fix

--- a/.kaji/wf/dev-thorough.yaml
+++ b/.kaji/wf/dev-thorough.yaml
@@ -1,0 +1,227 @@
+name: dev-thorough
+description: |
+  開発作業の丁寧版 workflow。設計・実装・修正を厚めに行う高品質優先の構成。
+  dev.yaml と同じ遷移グラフで、design/fix-design=xhigh, implement/fix-code=high。
+  レビュー系は標準の dev.yaml と同じ high を維持する。
+  issue-create は事前に完了していることが前提。
+  review-ready が RETRY の場合は fix-ready で Issue 本文を修正してから再試行する。
+execution_policy: auto
+requires_provider: github
+
+cycles:
+  ready-review:
+    entry: review-ready
+    loop: [fix-ready, review-ready]
+    max_iterations: 3
+    on_exhaust: ABORT
+  design-review:
+    entry: review-design
+    loop: [fix-design, verify-design]
+    max_iterations: 3
+    on_exhaust: ABORT
+  code-review:
+    entry: review-code
+    loop: [fix-code, verify-code]
+    max_iterations: 3
+    on_exhaust: ABORT
+  implementation:
+    entry: implement
+    loop: [implement]
+    max_iterations: 3
+    on_exhaust: ABORT
+  final-check:
+    entry: final-check
+    loop: [final-check]
+    max_iterations: 3
+    on_exhaust: ABORT
+  pr-create:
+    entry: pr
+    loop: [pr]
+    max_iterations: 3
+    on_exhaust: ABORT
+  pr-review:
+    entry: review-poll
+    loop: [pr-fix, pr-verify]
+    max_iterations: 3
+    on_exhaust: ABORT
+
+steps:
+  - id: review-ready
+    skill: issue-review-ready
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: start
+      RETRY: fix-ready
+      ABORT: end
+
+  - id: fix-ready
+    skill: issue-fix-ready
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    on:
+      PASS: review-ready
+      ABORT: end
+
+  - id: start
+    skill: issue-start
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: design
+      ABORT: end
+
+  - id: design
+    skill: issue-design
+    agent: claude
+    model: opus
+    effort: xhigh
+    on:
+      PASS: review-design
+      ABORT: end
+
+  - id: review-design
+    skill: issue-review-design
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: implement
+      RETRY: fix-design
+      ABORT: end
+
+  - id: fix-design
+    skill: issue-fix-design
+    agent: claude
+    model: opus
+    effort: xhigh
+    resume: design
+    on:
+      PASS: verify-design
+      ABORT: end
+
+  - id: verify-design
+    skill: issue-verify-design
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: implement
+      RETRY: fix-design
+      ABORT: end
+
+  - id: implement
+    skill: issue-implement
+    agent: claude
+    model: opus
+    effort: high
+    on:
+      PASS: review-code
+      RETRY: implement
+      BACK: design
+      ABORT: end
+
+  - id: review-code
+    skill: issue-review-code
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: final-check
+      RETRY: fix-code
+      BACK: design
+      BACK_IMPLEMENT: implement
+      ABORT: end
+
+  - id: fix-code
+    skill: issue-fix-code
+    agent: claude
+    model: opus
+    effort: high
+    inject_verdict: true
+    on:
+      PASS: verify-code
+      ABORT: end
+
+  - id: verify-code
+    skill: issue-verify-code
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: final-check
+      RETRY: fix-code
+      ABORT: end
+
+  - id: final-check
+    skill: i-dev-final-check
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: pr
+      RETRY: final-check
+      BACK_DESIGN: design
+      BACK_IMPLEMENT: implement
+      ABORT: end
+
+  - id: pr
+    skill: i-pr
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: review-poll
+      RETRY: pr
+      ABORT: end
+
+  - id: review-poll
+    exec: [uv, run, --no-sync, python, -m, kaji_harness.scripts.review_poll_entry]
+    on:
+      PASS: close
+      RETRY: pr-fix
+      BACK_FALLBACK: review
+      ABORT: end
+
+  - id: review
+    skill: review
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: close
+      RETRY: pr-fix
+      ABORT: end
+
+  - id: pr-fix
+    skill: pr-fix
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    on:
+      PASS: pr-verify
+      ABORT: end
+
+  - id: pr-verify
+    skill: pr-verify
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: close
+      RETRY: pr-fix
+      ABORT: end
+
+  - id: close
+    skill: issue-close
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: end
+      ABORT: end

--- a/.kaji/wf/dev.yaml
+++ b/.kaji/wf/dev.yaml
@@ -178,7 +178,7 @@ steps:
       ABORT: end
 
   - id: review-poll
-    exec: [uv, run, --no-sync, python, -m, kaji_harness.scripts.review_poll_entry]
+    exec: [kaji, pr, review-poll]
     on:
       PASS: close
       RETRY: pr-fix

--- a/.kaji/wf/dev.yaml
+++ b/.kaji/wf/dev.yaml
@@ -1,0 +1,225 @@
+name: dev
+description: |
+  開発作業の標準 workflow。GitHub Issue から PR review / close まで進める。
+  issue-create は事前に完了していることが前提。
+  review-ready が RETRY の場合は fix-ready で Issue 本文を修正してから再試行する。
+execution_policy: auto
+requires_provider: github
+
+cycles:
+  ready-review:
+    entry: review-ready
+    loop: [fix-ready, review-ready]
+    max_iterations: 3
+    on_exhaust: ABORT
+  design-review:
+    entry: review-design
+    loop: [fix-design, verify-design]
+    max_iterations: 3
+    on_exhaust: ABORT
+  code-review:
+    entry: review-code
+    loop: [fix-code, verify-code]
+    max_iterations: 3
+    on_exhaust: ABORT
+  implementation:
+    entry: implement
+    loop: [implement]
+    max_iterations: 3
+    on_exhaust: ABORT
+  final-check:
+    entry: final-check
+    loop: [final-check]
+    max_iterations: 3
+    on_exhaust: ABORT
+  pr-create:
+    entry: pr
+    loop: [pr]
+    max_iterations: 3
+    on_exhaust: ABORT
+  pr-review:
+    entry: review-poll
+    loop: [pr-fix, pr-verify]
+    max_iterations: 3
+    on_exhaust: ABORT
+
+steps:
+  - id: review-ready
+    skill: issue-review-ready
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: start
+      RETRY: fix-ready
+      ABORT: end
+
+  - id: fix-ready
+    skill: issue-fix-ready
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    on:
+      PASS: review-ready
+      ABORT: end
+
+  - id: start
+    skill: issue-start
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: design
+      ABORT: end
+
+  - id: design
+    skill: issue-design
+    agent: claude
+    model: opus
+    effort: high
+    on:
+      PASS: review-design
+      ABORT: end
+
+  - id: review-design
+    skill: issue-review-design
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: implement
+      RETRY: fix-design
+      ABORT: end
+
+  - id: fix-design
+    skill: issue-fix-design
+    agent: claude
+    model: opus
+    effort: medium
+    resume: design
+    on:
+      PASS: verify-design
+      ABORT: end
+
+  - id: verify-design
+    skill: issue-verify-design
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: implement
+      RETRY: fix-design
+      ABORT: end
+
+  - id: implement
+    skill: issue-implement
+    agent: claude
+    model: opus
+    effort: medium
+    on:
+      PASS: review-code
+      RETRY: implement
+      BACK: design
+      ABORT: end
+
+  - id: review-code
+    skill: issue-review-code
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: final-check
+      RETRY: fix-code
+      BACK: design
+      BACK_IMPLEMENT: implement
+      ABORT: end
+
+  - id: fix-code
+    skill: issue-fix-code
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    on:
+      PASS: verify-code
+      ABORT: end
+
+  - id: verify-code
+    skill: issue-verify-code
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: final-check
+      RETRY: fix-code
+      ABORT: end
+
+  - id: final-check
+    skill: i-dev-final-check
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: pr
+      RETRY: final-check
+      BACK_DESIGN: design
+      BACK_IMPLEMENT: implement
+      ABORT: end
+
+  - id: pr
+    skill: i-pr
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: review-poll
+      RETRY: pr
+      ABORT: end
+
+  - id: review-poll
+    exec: [uv, run, --no-sync, python, -m, kaji_harness.scripts.review_poll_entry]
+    on:
+      PASS: close
+      RETRY: pr-fix
+      BACK_FALLBACK: review
+      ABORT: end
+
+  - id: review
+    skill: review
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: close
+      RETRY: pr-fix
+      ABORT: end
+
+  - id: pr-fix
+    skill: pr-fix
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    on:
+      PASS: pr-verify
+      ABORT: end
+
+  - id: pr-verify
+    skill: pr-verify
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: close
+      RETRY: pr-fix
+      ABORT: end
+
+  - id: close
+    skill: issue-close
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: end
+      ABORT: end

--- a/.kaji/wf/docs.yaml
+++ b/.kaji/wf/docs.yaml
@@ -126,7 +126,7 @@ steps:
       ABORT: end
 
   - id: review-poll
-    exec: [uv, run, --no-sync, python, -m, kaji_harness.scripts.review_poll_entry]
+    exec: [kaji, pr, review-poll]
     on:
       PASS: close
       RETRY: pr-fix

--- a/.kaji/wf/docs.yaml
+++ b/.kaji/wf/docs.yaml
@@ -1,0 +1,173 @@
+name: docs
+description: |
+  docs-only 作業用 workflow。GitHub Issue から docs 更新、PR review、close まで進める。
+  issue-create は事前に完了していることが前提。
+  PR 作成後、review-poll / pr-fix / pr-verify / issue-close まで実行する。
+execution_policy: auto
+requires_provider: github
+
+cycles:
+  ready-review:
+    entry: review-ready
+    loop: [fix-ready, review-ready]
+    max_iterations: 3
+    on_exhaust: ABORT
+  doc-review:
+    entry: doc-review
+    loop: [doc-fix, doc-verify]
+    max_iterations: 3
+    on_exhaust: ABORT
+  final-check:
+    entry: final-check
+    loop: [final-check]
+    max_iterations: 3
+    on_exhaust: ABORT
+  pr-create:
+    entry: pr
+    loop: [pr]
+    max_iterations: 3
+    on_exhaust: ABORT
+  pr-review:
+    entry: review-poll
+    loop: [pr-fix, pr-verify]
+    max_iterations: 3
+    on_exhaust: ABORT
+
+steps:
+  - id: review-ready
+    skill: issue-review-ready
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: start
+      RETRY: fix-ready
+      ABORT: end
+
+  - id: fix-ready
+    skill: issue-fix-ready
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    on:
+      PASS: review-ready
+      ABORT: end
+
+  - id: start
+    skill: issue-start
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: doc-update
+      ABORT: end
+
+  - id: doc-update
+    skill: i-doc-update
+    agent: claude
+    model: opus
+    effort: high
+    on:
+      PASS: doc-review
+      ABORT: end
+
+  - id: doc-review
+    skill: i-doc-review
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: final-check
+      RETRY: doc-fix
+      ABORT: end
+
+  - id: doc-fix
+    skill: i-doc-fix
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    resume: doc-update
+    on:
+      PASS: doc-verify
+      ABORT: end
+
+  - id: doc-verify
+    skill: i-doc-verify
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    resume: doc-review
+    on:
+      PASS: final-check
+      RETRY: doc-fix
+      ABORT: end
+
+  - id: final-check
+    skill: i-doc-final-check
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: pr
+      RETRY: final-check
+      BACK: doc-update
+      ABORT: end
+
+  - id: pr
+    skill: i-pr
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: review-poll
+      RETRY: pr
+      ABORT: end
+
+  - id: review-poll
+    exec: [uv, run, --no-sync, python, -m, kaji_harness.scripts.review_poll_entry]
+    on:
+      PASS: close
+      RETRY: pr-fix
+      BACK_FALLBACK: review
+      ABORT: end
+
+  - id: review
+    skill: review
+    agent: codex
+    model: gpt-5.5
+    effort: high
+    on:
+      PASS: close
+      RETRY: pr-fix
+      ABORT: end
+
+  - id: pr-fix
+    skill: pr-fix
+    agent: claude
+    model: opus
+    effort: medium
+    inject_verdict: true
+    on:
+      PASS: pr-verify
+      ABORT: end
+
+  - id: pr-verify
+    skill: pr-verify
+    agent: codex
+    model: gpt-5.5
+    effort: medium
+    on:
+      PASS: close
+      RETRY: pr-fix
+      ABORT: end
+
+  - id: close
+    skill: issue-close
+    agent: claude
+    model: sonnet
+    effort: medium
+    on:
+      PASS: end
+      ABORT: end

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,318 @@
+# kaji
+
+言語: [English](README.md) | 日本語
+
+[![Release](https://img.shields.io/github/v/release/apokamo/kaji?include_prereleases)](https://github.com/apokamo/kaji/releases)
+[![Python](https://img.shields.io/badge/Python-3.11%2B-blue)](pyproject.toml)
+[![License](https://img.shields.io/badge/License-Apache--2.0-blue)](LICENSE)
+
+Claude Code、Codex、Gemini CLIのための closed-loop agentic development。
+
+kajiは、Issueを起点に、設計 -> 実装 -> レビュー -> 修正 -> 検証 -> PR までを
+再開可能なワークフローとして実行するAIエージェントオーケストレータです。
+human-in-the-loop の判断ポイントと、`verdict.yaml` などのartifact-backed verdictにより、
+AIエージェントの作業をブラックボックスにせず運用できます。
+
+> `kaji` は日本語の「舵」です。人間が方向を決め、エージェントが作業を進めます。
+
+## なぜkajiか
+
+AI coding agentは強力ですが、一発プロンプトだけでは開発プロセスを統制しにくいです。
+設計するタイミング、レビューするタイミング、修正するタイミング、止めるタイミング、
+そして人間が判断すべきタイミングを、agentの外側で管理する必要があります。
+
+kajiはその層を提供します。
+
+- 開発プロセスをworkflow YAMLとして定義する
+- 各stepをClaude Code、Codex、Gemini CLIへ割り当てる
+- 無限チャットではなく、上限付きの review -> fix -> verify ループにする
+- 判断結果を構造化されたverdict artifactとして残す
+- 中断した作業を特定stepから再開する
+- 重要な判断ポイントは人間に残す
+
+Beyond vibe coding: kajiはAI支援開発に、loop、log、quality gateを与えます。
+
+## 仕組み
+
+```mermaid
+flowchart TB
+  Issue["Issue"] --> Ready["Ready gate"]
+  Ready --> Design["Design"]
+  Design --> DesignReview{"Design review"}
+  DesignReview -- "PASS" --> Implement["Implement"]
+  DesignReview -- "RETRY" --> FixDesign["Fix design"]
+  FixDesign --> VerifyDesign["Verify design"]
+  VerifyDesign --> DesignReview
+
+  Implement --> CodeReview{"Code review"}
+  CodeReview -- "PASS" --> FinalCheck["Final check"]
+  CodeReview -- "RETRY" --> FixCode["Fix code"]
+  FixCode --> VerifyCode["Verify code"]
+  VerifyCode --> CodeReview
+  CodeReview -- "BACK" --> Design
+
+  FinalCheck --> PR["Pull request"]
+```
+
+各agent stepはverdictを返します。
+
+| Verdict | 意味 |
+|---------|------|
+| `PASS` | 次のstepへ進む |
+| `RETRY` | 現在の問題を修正し、再検証する |
+| `BACK` | 設計や実装など、前のフェーズへ戻る |
+| `ABORT` | 理由を明示してworkflowを停止する |
+
+harnessは `verdict.yaml` などの構造化出力を読み、attempt artifactを記録しながら、
+各verdictから次のworkflow stepを決定論的に進めます。
+
+## 主な機能
+
+- **Multi-agent workflow orchestration**: 1つのworkflow定義からClaude Code、Codex、Gemini CLIを呼び分ける
+- **Closed review loops**: review -> fix -> verify の閉じたサイクルでレビュー指摘を収束させる
+- **Interactive tmux runner**: 通常のCLI agentをtmux paneで起動し、kajiがartifact-backed verdictを監視する
+- **Headless runner**: CI的な非対話実行に向いた既存のheadless経路も維持する
+- **Deterministic exec steps**: LLMが不要なstepはsubprocessとして直接実行する
+- **Artifact-primary verdicts**: `verdict.yaml` を優先し、必要に応じてIssue commentやstdoutへfallbackする
+- **Issue and PR lifecycle**: GitHub Issue、branch、PR、review、closeの流れを扱う
+- **TDD and docs-as-code**: 実装、レビュー、テスト、ドキュメント更新を同じプロセスに載せる
+
+## 拡張性
+
+kajiは現在、Claude Code、Codex、Gemini CLIを中心に対応しています。runnerとworkflow modelは、
+実際の需要があるcoding-agent CLIを追加できるように設計しています。
+
+このループに組み込みたい別のcoding agentがあれば、ぜひIssueで教えてください。
+どのようなworkflowで使いたいかも含めてリクエストしてもらえると助かります。
+
+## Quick start
+
+### 前提
+
+- Python 3.11以上
+- `uv`
+- 使用したいagentのClaude Code、Codex、Gemini CLI
+- GitHub Issue / PR連携を使う場合は認証済みの `gh`
+- interactive terminal runnerを使う場合は `tmux` 3.1以上
+- 対象リポジトリに `.claude/skills/` 配下のkaji skillがあること
+
+### kajiをインストールする
+
+配布がリポジトリベースの間は、Gitからインストールします。
+
+```bash
+uv tool install git+https://github.com/apokamo/kaji.git
+kaji --help
+```
+
+将来PyPI公開する場合は、次の形に差し替えられます。
+
+```bash
+uv tool install kaji
+```
+
+### 対象リポジトリを設定する
+
+kajiを実行したいリポジトリに `.kaji/config.toml` を追加します。
+下の例で使う `.kaji/wf/dev.yaml` は、PR作成、PR review polling、Issue closeまで扱う
+GitHub前提のworkflowです。
+
+```toml
+[paths]
+artifacts_dir = ".kaji-artifacts"
+skill_dir = ".claude/skills"
+
+[execution]
+default_timeout = 1800
+
+[provider]
+type = "github"
+
+[provider.github]
+repo = "<owner>/<name>"
+default_branch = "main"
+```
+
+GitHubを使わないlocal issue storageの場合は、local provider configにし、
+gitignoredなmachine overlayを作成します。
+
+```toml
+[provider]
+type = "local"
+```
+
+```bash
+kaji local init
+```
+
+`kaji local init` は現在のmachine用の `.kaji/config.local.toml` を作成します。
+trackedなbase configを置き換えるものではありません。local modeでは
+`.kaji/wf/feature-development-local.yaml` などのlocal専用workflowを使います。
+
+skillは `.claude/skills/` に配置します。他agent向けのskill directoryは、
+同じcanonical skill fileへのsymlinkとして構成できます。
+
+### workflowを実行する
+
+workflow fileは各リポジトリの `.kaji/wf/` から実行します。このリポジトリでは現在、
+GitHub前提のworkflow setとして `.kaji/wf/dev.yaml`、`.kaji/wf/dev-thorough.yaml`、
+`.kaji/wf/docs.yaml` を置いています。template配布と初回導入の詳細は
+[Initial Setup Guide issue #242](https://github.com/apokamo/kaji/issues/242)で扱います。
+
+`dev.yaml` の例は、GitHub Issueが存在し、必要なskillがあり、選択するagent CLIが使え、
+`/issue-create` が完了していることを前提にします。`issue-start` はworkflow内で実行します。
+
+workflowを実行:
+
+```bash
+kaji run .kaji/wf/dev.yaml <issue-id>
+```
+
+特定stepから再開:
+
+```bash
+kaji run .kaji/wf/dev.yaml <issue-id> --from fix-code
+```
+
+単一stepだけ実行:
+
+```bash
+kaji run .kaji/wf/dev.yaml <issue-id> --step review-code
+```
+
+### kaji自体を開発する
+
+別リポジトリでkajiを使うのではなく、kaji自体を開発する場合だけ、この手順を使います。
+
+```bash
+git clone https://github.com/apokamo/kaji.git
+cd kaji
+uv sync
+source .venv/bin/activate
+kaji --help
+```
+
+## tmux interactive terminal runner
+
+headless runnerではなく、通常のClaude CodeやCodex CLI sessionをtmux pane内で起動したい場合に使います。
+
+```toml
+[execution]
+default_timeout = 2400
+agent_runner = "interactive_terminal"
+interactive_terminal_close_on_verdict = true
+```
+
+tmux session内で実行します。
+
+```bash
+tmux new-session
+kaji run .kaji/wf/dev.yaml <issue-id> --agent-runner interactive-terminal
+```
+
+runnerは管理対象paneを開き、terminal transcriptを記録し、`verdict.yaml` を待ってworkflowを進めます。
+ライブ観察、subscription CLI利用、agent挙動のデバッグに向いています。
+
+詳細:
+[Interactive Terminal Runner](docs/cli-guides/interactive-terminal-runner.md)
+
+## workflow例
+
+```yaml
+name: minimal-code-review
+description: "Bounded implement -> review -> fix -> verify loop"
+execution_policy: auto
+
+cycles:
+  code-review:
+    entry: review-code
+    loop: [fix-code, verify-code]
+    max_iterations: 3
+    on_exhaust: ABORT
+
+steps:
+  - id: implement
+    skill: issue-implement
+    agent: claude
+    on:
+      PASS: review-code
+      ABORT: end
+
+  - id: review-code
+    skill: issue-review-code
+    agent: codex
+    on:
+      PASS: end
+      RETRY: fix-code
+      BACK_IMPLEMENT: implement
+      ABORT: end
+
+  - id: fix-code
+    skill: issue-fix-code
+    agent: claude
+    on:
+      PASS: verify-code
+      ABORT: end
+
+  - id: verify-code
+    skill: issue-verify-code
+    agent: codex
+    resume: review-code
+    on:
+      PASS: end
+      RETRY: fix-code
+      ABORT: end
+```
+
+review loopの上限は `cycles.code-review.max_iterations` で指定します。上のskill名はkaji標準skill setの
+実名に合わせています。対象リポジトリ側に対応するskill fileが必要です。
+`model` と `effort` はYAML schema上は任意なので、この短い例では省略しています。
+実運用workflowではpinすることが多いです。
+
+`resume` は、runnerが対応している場合に、同じagentの前回sessionから続行するための指定です。
+
+## ドキュメント
+
+| Topic | Link |
+|-------|------|
+| Architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Workflow overview | [docs/dev/workflow_overview.md](docs/dev/workflow_overview.md) |
+| Workflow authoring | [docs/dev/workflow-authoring.md](docs/dev/workflow-authoring.md) |
+| Skill authoring | [docs/dev/skill-authoring.md](docs/dev/skill-authoring.md) |
+| Interactive terminal runner | [docs/cli-guides/interactive-terminal-runner.md](docs/cli-guides/interactive-terminal-runner.md) |
+| AI-driven development strategy | [docs/concepts/ai-driven-strategy.md](docs/concepts/ai-driven-strategy.md) |
+| CLI guides | [docs/cli-guides/](docs/cli-guides/) |
+
+## AIが読みやすいドキュメント
+
+AI assistantやクローラ向けに、[llms.txt](llms.txt) に重要docs、主要コマンド、
+workflow概念への短い索引を置いています。
+
+## ステータス
+
+現在の公開バージョンは v0.12.0 です。kajiはactive development中であり、
+ユーザー向けのサポート対象エントリポイントは `kaji` CLIです。
+
+`legacy/` directoryは過去実装の参照用であり、現在のサポート対象runtimeには含めません。
+
+## 開発
+
+```bash
+source .venv/bin/activate
+make check
+```
+
+個別target:
+
+```bash
+make lint
+make format
+make typecheck
+make test
+make verify-docs
+make verify-packaging
+```
+
+## License
+
+Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,110 +1,277 @@
-# kaji「舵」
+# kaji
 
-AI-driven software development workflow orchestrator. Claude Code / Codex / Gemini CLI のスキルをワークフロー YAML に従って実行する。
+Language: English | [Japanese](README.ja.md)
 
-> **V7 (kaji_harness) が現在の正規エントリポイントです。** `legacy/` は V5/V6 の参照用アーカイブであり、サポート対象外です。
+[![Release](https://img.shields.io/github/v/release/apokamo/kaji?include_prereleases)](https://github.com/apokamo/kaji/releases)
+[![Python](https://img.shields.io/badge/Python-3.11%2B-blue)](pyproject.toml)
+[![License](https://img.shields.io/badge/License-Apache--2.0-blue)](LICENSE)
 
-## アーキテクチャ概要
+Closed-loop agentic development for Claude Code, Codex, and Gemini CLI.
 
-3層アーキテクチャでAIエージェントを制御:
+kaji turns an issue into a resumable design -> implement -> review -> fix
+-> verify -> PR loop, with human-in-the-loop gates and artifact-backed
+verdicts. It is built for developers who want AI agents to do real work without
+turning the development process into a black box.
 
+> `kaji` means "rudder" in Japanese: the human keeps direction, agents do the
+> rowing.
+
+## Why kaji
+
+AI coding agents are powerful, but one-shot prompting is hard to govern. The
+missing layer is often the workflow around the agent: when to design, when to
+review, when to fix, when to stop, and when a human should decide.
+
+kaji provides that layer.
+
+- Define the development process as workflow YAML.
+- Route each step to Claude Code, Codex, or Gemini CLI.
+- Use bounded review/fix/verify loops instead of endless chat.
+- Capture decisions as structured verdict artifacts.
+- Resume from a specific step when work is interrupted.
+- Keep human approval at the points that matter.
+
+Beyond vibe coding: kaji gives AI-assisted development a loop, a log, and a
+quality gate.
+
+## How it works
+
+```mermaid
+flowchart TB
+  Issue["Issue"] --> Ready["Ready gate"]
+  Ready --> Design["Design"]
+  Design --> DesignReview{"Design review"}
+  DesignReview -- "PASS" --> Implement["Implement"]
+  DesignReview -- "RETRY" --> FixDesign["Fix design"]
+  FixDesign --> VerifyDesign["Verify design"]
+  VerifyDesign --> DesignReview
+
+  Implement --> CodeReview{"Code review"}
+  CodeReview -- "PASS" --> FinalCheck["Final check"]
+  CodeReview -- "RETRY" --> FixCode["Fix code"]
+  FixCode --> VerifyCode["Verify code"]
+  VerifyCode --> CodeReview
+  CodeReview -- "BACK" --> Design
+
+  FinalCheck --> PR["Pull request"]
 ```
-┌─────────────────────────────────────────────┐
-│  ハーネス (kaji_harness/)                     │
-│  ワークフロー YAML を解釈し CLI を順次呼出  │
-├─────────────────────────────────────────────┤
-│  スキル (.claude/skills/, .agents/skills/)   │
-│  実体は .claude、.agents は symlink         │
-├─────────────────────────────────────────────┤
-│  CLI (Claude Code / Codex / Gemini)          │
-│  スキルをロードし PJ コンテキストで実行     │
-└─────────────────────────────────────────────┘
-```
 
-詳細: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+Every agent step returns a verdict:
 
-## セットアップ（開発者向け）
+| Verdict | Meaning |
+|---------|---------|
+| `PASS` | Continue to the next step. |
+| `RETRY` | Fix the current problem and verify again. |
+| `BACK` | Return to an earlier phase, such as design or implementation. |
+| `ABORT` | Stop the workflow with an explicit reason. |
+
+The harness reads structured outputs such as `verdict.yaml`, records attempt
+artifacts, and advances the workflow deterministically from each verdict.
+
+## Core features
+
+- **Multi-agent workflow orchestration**: run Claude Code, Codex, and Gemini CLI
+  from one workflow definition.
+- **Closed review loops**: model review feedback as explicit
+  review -> fix -> verify cycles.
+- **Interactive tmux runner**: run normal CLI agents in tmux panes while kaji
+  watches for artifact-backed verdicts.
+- **Headless runner**: keep existing non-interactive automation paths for CI-like
+  execution.
+- **Deterministic exec steps**: run subprocess steps directly when no LLM is
+  needed.
+- **Artifact-primary verdicts**: prefer `verdict.yaml`, then fall back to issue
+  comments or stdout parsing.
+- **Issue and PR lifecycle**: coordinate GitHub issue, branch, PR, review, and
+  close workflows.
+- **TDD and docs-as-code**: keep implementation, review, tests, and docs in the
+  same process.
+
+## Extensibility
+
+kaji currently focuses on Claude Code, Codex, and Gemini CLI. The runner and
+workflow model are designed to support additional coding-agent CLIs when there
+is real demand.
+
+Have another coding agent you want to plug into the loop? Open an issue and
+tell us what workflow you want to run.
+
+## Quick start
+
+### Prerequisites
+
+- Python 3.11 or newer
+- `uv`
+- Claude Code, Codex, or Gemini CLI installed for the agents you want to run
+- `gh` authenticated if you use GitHub-backed issue and PR operations
+- `tmux` 3.1 or newer if you use the interactive terminal runner
+- A target repository with kaji skills under `.claude/skills/`
+
+### Install kaji
+
+Install from Git while distribution is repository-based:
 
 ```bash
-uv sync
-source .venv/bin/activate
+uv tool install git+https://github.com/apokamo/kaji.git
+kaji --help
 ```
 
-## 開発ワークフロー
+If kaji is later published to PyPI, this can become:
 
-Issue 駆動の TDD 開発フロー。`/issue-review-ready` を着手前ゲートとして全 workflow 共通で適用し、PR 作成後は `/pr-verify` / `/pr-fix` のレビュー収束サイクルを経て `/issue-close` に到達する:
-
-```
-/issue-create → /issue-review-ready → /issue-start → /issue-design → /issue-implement
-              → /i-pr → /pr-fix → /pr-verify → /issue-close
+```bash
+uv tool install kaji
 ```
 
-ワークフローガイド: [docs/dev/workflow_guide.md](docs/dev/workflow_guide.md)
+### Configure your repository
 
-## 最小導入
-
-対象プロジェクトには `.kaji/config.toml` を配置する（コロケーテッドモデル）:
+In the repository where you want to run kaji, add `.kaji/config.toml`.
+The default workflow below, `.kaji/wf/dev.yaml`, is GitHub-backed because it
+opens PRs, polls review state, and closes issues.
 
 ```toml
-# .kaji/config.toml
 [paths]
-artifacts_dir = ".kaji/artifacts"    # 必須: アーティファクト保存先
-skill_dir = ".claude/skills"         # 必須: スキルディレクトリ
+artifacts_dir = ".kaji-artifacts"
+skill_dir = ".claude/skills"
 
 [execution]
-default_timeout = 1800  # 必須: タイムアウトのデフォルト値（秒）
+default_timeout = 1800
+
+[provider]
+type = "github"
+
+[provider.github]
+repo = "<owner>/<name>"
+default_branch = "main"
 ```
 
-skill の実体は `.claude/skills/` に置き、`.agents/skills/` はそれを参照する symlink として扱う。
+For local issue storage without GitHub, use a local provider config and create a
+gitignored machine overlay:
 
-```text
-.claude/skills/
-  implement/
-    SKILL.md
-  review-code/
-    SKILL.md
-  fix-code/
-    SKILL.md
-  verify-code/
-    SKILL.md
-
-.agents/skills/
-  review-code -> ../../.claude/skills/review-code
-  verify-code -> ../../.claude/skills/verify-code
+```toml
+[provider]
+type = "local"
 ```
 
-最小の workflow は次のようになる。
+```bash
+kaji local init
+```
+
+`kaji local init` creates `.kaji/config.local.toml` for the current machine; it
+does not replace the tracked base config. Local mode uses local-specific
+workflows such as `.kaji/wf/feature-development-local.yaml`.
+
+Skills live under `.claude/skills/`. Other agent-specific skill directories can
+point to the same canonical skill files with symlinks.
+
+### Run a workflow
+
+Workflow files are run from `.kaji/wf/` in each repository. This repository
+ships `.kaji/wf/dev.yaml`, `.kaji/wf/dev-thorough.yaml`, and `.kaji/wf/docs.yaml`
+as the current GitHub-backed workflow set. Template distribution and first-time
+setup details are tracked in
+[Initial Setup Guide issue #242](https://github.com/apokamo/kaji/issues/242).
+
+The `dev.yaml` example assumes that a GitHub issue already exists, required
+skills are available, selected agent CLIs are installed, and `/issue-create` has
+already been completed. The workflow runs `issue-start` itself.
+
+Run a workflow:
+
+```bash
+kaji run .kaji/wf/dev.yaml <issue-id>
+```
+
+Resume from a specific step:
+
+```bash
+kaji run .kaji/wf/dev.yaml <issue-id> --from fix-code
+```
+
+Run only one step:
+
+```bash
+kaji run .kaji/wf/dev.yaml <issue-id> --step review-code
+```
+
+### Develop kaji itself
+
+Use this path only when you want to work on kaji, not just run it in another
+repository:
+
+```bash
+git clone https://github.com/apokamo/kaji.git
+cd kaji
+uv sync
+source .venv/bin/activate
+kaji --help
+```
+
+## tmux interactive terminal runner
+
+Use this when you want kaji to launch normal Claude Code or Codex CLI sessions
+inside tmux panes instead of using the headless runner.
+
+```toml
+[execution]
+default_timeout = 2400
+agent_runner = "interactive_terminal"
+interactive_terminal_close_on_verdict = true
+```
+
+Then run from inside a tmux session:
+
+```bash
+tmux new-session
+kaji run .kaji/wf/dev.yaml <issue-id> --agent-runner interactive-terminal
+```
+
+The runner opens managed panes, records terminal transcripts, waits for
+`verdict.yaml`, and advances the workflow. This is useful for live observation,
+subscription CLI usage, and debugging agent behavior.
+
+Read more:
+[Interactive Terminal Runner](docs/cli-guides/interactive-terminal-runner.md)
+
+## Workflow example
 
 ```yaml
 name: minimal-code-review
-description: "最小のコードレビュー付きフロー"
+description: "Bounded implement -> review -> fix -> verify loop"
 execution_policy: auto
+
+cycles:
+  code-review:
+    entry: review-code
+    loop: [fix-code, verify-code]
+    max_iterations: 3
+    on_exhaust: ABORT
 
 steps:
   - id: implement
-    skill: implement
+    skill: issue-implement
     agent: claude
     on:
       PASS: review-code
       ABORT: end
 
   - id: review-code
-    skill: review-code
+    skill: issue-review-code
     agent: codex
     on:
       PASS: end
       RETRY: fix-code
+      BACK_IMPLEMENT: implement
       ABORT: end
 
   - id: fix-code
-    skill: fix-code
+    skill: issue-fix-code
     agent: claude
     on:
       PASS: verify-code
       ABORT: end
 
   - id: verify-code
-    skill: verify-code
+    skill: issue-verify-code
     agent: codex
     resume: review-code
     on:
@@ -113,80 +280,55 @@ steps:
       ABORT: end
 ```
 
-`resume` は、同じ agent の前段ステップのコンテキストを引き継いで続きから実行するための指定。
+The review loop is bounded by `cycles.code-review.max_iterations`. The skill
+names above match kaji's standard skill set; your repository must provide those
+skill files. `model` and `effort` are optional in the YAML schema and omitted in
+this compact example; production workflows often pin them.
 
-## ワークフロー実行
+`resume` tells kaji to continue from a previous session for the same agent when
+the runner supports it.
 
-```bash
-# 最小 workflow を実行
-kaji run workflows/minimal-code-review.yaml 57
+## Documentation
 
-# 途中から再開
-kaji run workflows/minimal-code-review.yaml 57 --from fix-code
+| Topic | Link |
+|-------|------|
+| Architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Workflow overview | [docs/dev/workflow_overview.md](docs/dev/workflow_overview.md) |
+| Workflow authoring | [docs/dev/workflow-authoring.md](docs/dev/workflow-authoring.md) |
+| Skill authoring | [docs/dev/skill-authoring.md](docs/dev/skill-authoring.md) |
+| Interactive terminal runner | [docs/cli-guides/interactive-terminal-runner.md](docs/cli-guides/interactive-terminal-runner.md) |
+| AI-driven development strategy | [docs/concepts/ai-driven-strategy.md](docs/concepts/ai-driven-strategy.md) |
+| CLI guides | [docs/cli-guides/](docs/cli-guides/) |
 
-# 単一ステップ実行
-kaji run workflows/minimal-code-review.yaml 57 --step review-code
+## AI-readable docs
 
-# 指定ステップの直前で停止（exclusive barrier。指定ステップは実行されない）
-kaji run workflows/feature-development.yaml 57 --before implement
+For AI assistants and crawlers, [llms.txt](llms.txt) provides a compact index of
+the most important docs, commands, and workflow concepts.
 
-# `--from` と組み合わせ: A から B の手前まで
-kaji run workflows/feature-development.yaml 57 --from fix-design --before implement
-```
+## Project status
 
-詳細:
-- [docs/dev/workflow-authoring.md](docs/dev/workflow-authoring.md)
-- [docs/dev/skill-authoring.md](docs/dev/skill-authoring.md)
+Current release: v0.12.0. kaji is under active development, and the supported
+user-facing entry point is the `kaji` CLI.
 
-## 品質チェック
+The `legacy/` directory contains historical code and is not part of the current
+supported runtime.
 
-コミット前に必ず実行:
+## Development
 
 ```bash
 source .venv/bin/activate
-make check                            # lint → format → typecheck → test
+make check
 ```
 
-変更タイプに応じた追加検証:
+Individual targets:
 
 ```bash
-make verify-docs                      # docs-only: リンク・参照整合チェック
-make verify-packaging                 # packaging/metadata: 隔離環境で uv install + metadata 確認
-```
-
-個別ターゲット: `make lint` / `make format` / `make typecheck` / `make test`
-
-## ドキュメント
-
-| ドキュメント | 内容 |
-|-------------|------|
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | V7 アーキテクチャ詳細 |
-| [docs/adr/](docs/adr/) | アーキテクチャ決定記録 |
-| [docs/dev/workflow_overview.md](docs/dev/workflow_overview.md) | ワークフロー選択のエントリポイント |
-| [docs/dev/workflow_guide.md](docs/dev/workflow_guide.md) | ワークフロー選択基準 |
-| [docs/dev/workflow_completion_criteria.md](docs/dev/workflow_completion_criteria.md) | フェーズ別完了条件チェックリスト |
-| [docs/dev/documentation_update_criteria.md](docs/dev/documentation_update_criteria.md) | ドキュメント更新要否の判断フレームワーク |
-| [docs/dev/shared_skill_rules.md](docs/dev/shared_skill_rules.md) | スキル横断の責務境界ルール |
-| [docs/dev/testing-convention.md](docs/dev/testing-convention.md) | テスト規約 (S/M/L) |
-| [docs/dev/workflow-authoring.md](docs/dev/workflow-authoring.md) | ワークフロー YAML 定義 |
-| [docs/dev/skill-authoring.md](docs/dev/skill-authoring.md) | スキル作成ガイド |
-| [docs/concepts/ai-driven-strategy.md](docs/concepts/ai-driven-strategy.md) | 95% AI / 5% 人間の開発モデル |
-| [docs/concepts/ai-docs-management.md](docs/concepts/ai-docs-management.md) | Docs-as-Code 運用ルール |
-| [docs/cli-guides/](docs/cli-guides/) | CLI ツールガイド (Claude/Codex/Gemini) |
-
-## `legacy/` ディレクトリ
-
-V5/V6 の旧コード・テスト・ドキュメントを参照用に保持。
-
-```
-legacy/
-├── bugfix_agent/                  # V5/V6 パッケージ
-├── bugfix_agent_orchestrator.py   # V5 エントリポイント
-├── prompts/                       # V6 プロンプト
-├── tests/                         # V5 テスト
-├── docs/                          # V5 ドキュメント
-├── config.toml                    # V5 設定
-└── AGENT.md                       # V5 エージェント指示書
+make lint
+make format
+make typecheck
+make test
+make verify-docs
+make verify-packaging
 ```
 
 ## License

--- a/kaji_harness/cli_main.py
+++ b/kaji_harness/cli_main.py
@@ -592,7 +592,7 @@ def _forward_to_gh(group: str, raw_args: list[str], *, repo: str | None = None) 
     return result.returncode
 
 
-_PR_BUILTIN_SUBCOMMANDS = {"review-comments", "reviews", "reply-to-comment"}
+_PR_BUILTIN_SUBCOMMANDS = {"review-comments", "reviews", "reply-to-comment", "review-poll"}
 
 _PR_BARE_PROVIDER_ERROR = (
     "Error: 'kaji pr' is a forge-only command and cannot run under "
@@ -623,7 +623,7 @@ def _is_ascii_decimal(s: str) -> bool:
 _GH_MISSING_GUIDANCE = (
     "Error: 'gh' CLI not found in PATH. "
     "Install GitHub CLI to use 'kaji pr review-comments' / 'reviews' / "
-    "'reply-to-comment' (Phase 2).\n"
+    "'reply-to-comment' / 'review-poll' (Phase 2).\n"
 )
 
 
@@ -777,12 +777,26 @@ def _forward_pr_reply_to_comment(
         return EXIT_RUNTIME_ERROR
 
 
+def _run_pr_review_poll(rest: list[str]) -> int:
+    """Run the review-poll workflow helper through the installed kaji package."""
+    p = argparse.ArgumentParser(prog="kaji pr review-poll", add_help=True)
+    p.parse_args(rest)
+
+    from .scripts import review_poll_entry
+
+    return review_poll_entry.main([])
+
+
 def _dispatch_pr_builtin(sub: str, rest: list[str], *, repo_override: str | None = None) -> int:
     """Parse ``rest`` with a sub-specific argparse and dispatch to the handler.
 
     ``--help`` / ``-h`` prints sub-specific usage. argparse's default exit
     code on invalid args is 2, matching ``EXIT_INVALID_INPUT``.
     """
+    if sub == "review-poll":
+        del repo_override
+        return _run_pr_review_poll(rest)
+
     p = argparse.ArgumentParser(prog=f"kaji pr {sub}", add_help=True)
     p.add_argument("pr_id", type=str, help="PR number")
     if sub in {"review-comments", "reviews"}:

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,143 @@
+# kaji
+
+> Closed-loop agentic development workflows for Claude Code, Codex, and Gemini CLI.
+
+kaji is a Python CLI workflow orchestrator for AI-assisted software development.
+It turns an issue into a resumable design -> implement -> review -> fix -> verify
+-> PR loop, with human-in-the-loop gates and artifact-backed verdicts.
+
+Current public release: v0.12.0.
+
+The supported user-facing entry point is the `kaji` CLI. The implementation lives
+in the `kaji_harness` package.
+
+## Core Concepts
+
+- Closed-loop workflow: explicit review -> fix -> verify cycles instead of
+  one-shot prompting.
+- Multi-agent orchestration: workflow steps can route work to Claude Code,
+  Codex, or Gemini CLI.
+- Verdict-driven control flow: steps return `PASS`, `RETRY`, `BACK`, or `ABORT`.
+- Artifact-backed verdicts: `verdict.yaml` is the primary completion signal when
+  available.
+- Human-in-the-loop gates: humans keep control of issue readiness, design
+  direction, PR review, and merge decisions.
+- Interactive terminal runner: kaji can run normal agent CLIs in tmux panes and
+  advance the workflow when verdict artifacts appear.
+
+## Start Here
+
+- [README](README.md): public overview, quick start, workflow example, and
+  feature summary.
+- [Japanese README](README.ja.md): Japanese overview of the same public content.
+- [Documentation index](docs/README.md): map of how-to, reference, operations,
+  and concept docs.
+- [Changelog](CHANGELOG.md): release history and current behavior changes.
+
+## Architecture and Workflow
+
+- [Architecture](docs/ARCHITECTURE.md): harness architecture, dispatch paths,
+  verdict resolution, state, logging, and artifact layout.
+- [Workflow overview](docs/dev/workflow_overview.md): entry point for choosing a
+  workflow by issue type.
+- [Workflow authoring](docs/dev/workflow-authoring.md): how to write workflow
+  YAML, steps, transitions, cycles, and verdict mappings.
+- [Skill authoring](docs/dev/skill-authoring.md): how to write skills and their
+  verdict contracts.
+- [Interactive terminal runner](docs/cli-guides/interactive-terminal-runner.md):
+  tmux-backed runner for normal Claude Code and Codex CLI sessions.
+- [AI-driven strategy](docs/concepts/ai-driven-strategy.md): project philosophy
+  for human direction and AI-executed development loops.
+
+## CLI and Setup
+
+Install kaji for use in another repository:
+
+```bash
+uv tool install git+https://github.com/apokamo/kaji.git
+kaji --help
+```
+
+Run a workflow in a configured target repository:
+
+```bash
+kaji run .kaji/wf/dev.yaml <issue-id>
+kaji run .kaji/wf/dev.yaml <issue-id> --from <step-id>
+kaji run .kaji/wf/dev.yaml <issue-id> --step <step-id>
+```
+
+Workflow files are run from `.kaji/wf/` in each repository. This repository
+currently includes `.kaji/wf/dev.yaml`, `.kaji/wf/dev-thorough.yaml`, and
+`.kaji/wf/docs.yaml` as GitHub-backed workflow examples. Template distribution
+and first-time setup details are tracked in:
+https://github.com/apokamo/kaji/issues/242
+
+The `dev.yaml` workflow assumes that a GitHub issue exists, required skills are
+available, selected agent CLIs are installed, and `/issue-create` has already
+been completed. It runs `issue-start` itself.
+
+Set up kaji for repository development:
+
+```bash
+git clone https://github.com/apokamo/kaji.git
+cd kaji
+uv sync
+source .venv/bin/activate
+kaji --help
+```
+
+Quality checks:
+
+```bash
+make check
+make verify-docs
+make verify-packaging
+```
+
+Minimal repository config for the GitHub-backed workflow set:
+
+```toml
+[paths]
+artifacts_dir = ".kaji-artifacts"
+skill_dir = ".claude/skills"
+
+[execution]
+default_timeout = 1800
+
+[provider]
+type = "github"
+
+[provider.github]
+repo = "<owner>/<name>"
+default_branch = "main"
+```
+
+For local mode without GitHub, use `type = "local"` and create the local machine
+overlay:
+
+```bash
+kaji local init
+```
+
+Local mode uses local-specific workflows such as
+`.kaji/wf/feature-development-local.yaml`.
+
+## Important Paths
+
+- `kaji_harness/`: supported runtime package behind the `kaji` CLI.
+- `.kaji/wf/`: repository-local operational workflow YAML layout.
+- `docs/`: canonical documentation.
+- `docs/cli-guides/`: CLI and runner guides.
+- `docs/dev/`: workflow and skill authoring docs.
+- `legacy/`: historical reference code, not the current supported runtime.
+
+## Notes for AI Assistants
+
+- Prefer the public README and this file for orientation before reading deeper
+  docs.
+- Use `docs/ARCHITECTURE.md` for implementation architecture.
+- Use `docs/dev/workflow-authoring.md` and `docs/dev/skill-authoring.md` for
+  workflow or skill changes.
+- Do not infer support for agents beyond Claude Code, Codex, and Gemini CLI
+  unless a workflow or adapter explicitly exists.
+- Do not treat `legacy/` as the current runtime.

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -830,6 +830,37 @@ class TestPrReplyToCommentBuiltin:
 
 
 @pytest.mark.small
+class TestPrReviewPollBuiltin:
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "kaji_harness.cli_main._load_config_for_dispatch",
+            _stub_github_config,
+        )
+
+    def test_dispatches_to_installed_review_poll_entry(self) -> None:
+        from kaji_harness.cli_main import _handle_pr
+
+        with patch("kaji_harness.scripts.review_poll_entry.main", return_value=0) as mock_main:
+            rc = _handle_pr(["review-poll"])
+
+        assert rc == 0
+        mock_main.assert_called_once_with([])
+
+    def test_unknown_arg_exits_two(self) -> None:
+        from kaji_harness.cli_main import _handle_pr
+
+        with (
+            patch("kaji_harness.scripts.review_poll_entry.main") as mock_main,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            _handle_pr(["review-poll", "--unexpected"])
+
+        assert exc_info.value.code == 2
+        mock_main.assert_not_called()
+
+
+@pytest.mark.small
 class TestHasApproveFlag:
     """`_has_approve_flag` 純粋関数の単体テスト。"""
 

--- a/tests/workflows/test_review_poll_exec_migration.py
+++ b/tests/workflows/test_review_poll_exec_migration.py
@@ -37,6 +37,12 @@ TARGET_WORKFLOWS = [
     "full-cycle-xhigh.yaml",
 ]
 
+PUBLIC_WORKFLOWS = [
+    "dev.yaml",
+    "dev-thorough.yaml",
+    "docs.yaml",
+]
+
 EXPECTED_EXEC = [
     "uv",
     "run",
@@ -46,8 +52,12 @@ EXPECTED_EXEC = [
     "kaji_harness.scripts.review_poll_entry",
 ]
 
+PUBLIC_EXPECTED_EXEC = ["kaji", "pr", "review-poll"]
+
 TARGET_PATHS = [REPO_ROOT / ".kaji" / "wf" / name for name in TARGET_WORKFLOWS]
 TARGET_IDS = TARGET_WORKFLOWS
+PUBLIC_PATHS = [REPO_ROOT / ".kaji" / "wf" / name for name in PUBLIC_WORKFLOWS]
+PUBLIC_IDS = PUBLIC_WORKFLOWS
 
 
 def _review_poll_step(path: Path) -> Step:
@@ -104,6 +114,32 @@ class TestReviewPollExecStatic:
         assert step.on.get("PASS") == expected_pass, (
             f"{path.name}: PASS routing が変化した（期待 {expected_pass}）"
         )
+
+
+@pytest.mark.small
+class TestPublicReviewPollExecStatic:
+    def test_all_public_workflows_exist(self) -> None:
+        """READMEで案内する新標準workflowが存在する。"""
+        missing = [p.name for p in PUBLIC_PATHS if not p.exists()]
+        assert not missing, f"対象 workflow が見つからない: {missing}"
+
+    @pytest.mark.parametrize("path", PUBLIC_PATHS, ids=PUBLIC_IDS)
+    def test_review_poll_uses_installed_kaji_cli(self, path: Path) -> None:
+        """公開workflowは対象repoのPython環境ではなくinstalled kaji CLI経由でpollする。"""
+        step = _review_poll_step(path)
+        assert step.exec == PUBLIC_EXPECTED_EXEC, (
+            f"{path.name}: review-poll.exec がportableなCLI経由ではない。"
+            f"got={step.exec!r} expected={PUBLIC_EXPECTED_EXEC!r}"
+        )
+
+    @pytest.mark.parametrize("path", PUBLIC_PATHS, ids=PUBLIC_IDS)
+    def test_review_poll_has_no_agent_fields(self, path: Path) -> None:
+        """公開workflowのreview-pollもexec stepとしてdispatchされる。"""
+        step = _review_poll_step(path)
+        assert step.skill is None, f"{path.name}: review-poll.skill が残存している"
+        assert step.agent is None, f"{path.name}: review-poll.agent が残存している"
+        assert step.model is None, f"{path.name}: review-poll.model が残存している"
+        assert step.effort is None, f"{path.name}: review-poll.effort が残存している"
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Refresh the public README as English-first positioning for kaji.
- Add Japanese README and `llms.txt` for AI/crawler-oriented project discovery.
- Add real `.kaji/wf/dev.yaml`, `dev-thorough.yaml`, and `docs.yaml` so README commands point to existing workflows.
- Clarify GitHub-backed vs local-mode setup and link first-time setup follow-up.
- Route public workflow `review-poll` steps through `kaji pr review-poll` so target repositories can use the installed kaji tool environment.

## Follow-up issues

- #242 Initial Setup Guide
- #243 AGENTS.md / CLAUDE.md review
- #244 launch post and short tmux demo asset

## Validation

- `uv run kaji validate .kaji/wf/*.yaml`
- `make verify-docs`
- `python3 scripts/check_doc_links.py README.ja.md llms.txt`
- `source .venv/bin/activate && pytest tests/test_cli_main.py::TestPrReviewPollBuiltin tests/workflows/test_review_poll_exec_migration.py -q` (`26 passed`)
- `source .venv/bin/activate && make check` (`1867 passed, 1 skipped`)
