### PR TITLE
chore(docs): README 設定例と verify-docs 対象を更新 (#253)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-large-local:
 	pytest -m large_local
 
 verify-docs:
-	python3 scripts/check_doc_links.py docs/ README.md CLAUDE.md .claude/skills/
+	python3 scripts/check_doc_links.py docs/ README.md README.ja.md CLAUDE.md .claude/skills/
 
 verify-packaging:
 	@scripts/verify-packaging.sh

--- a/README.ja.md
+++ b/README.ja.md
@@ -121,9 +121,12 @@ GitHub前提のworkflowです。
 [paths]
 artifacts_dir = ".kaji-artifacts"
 skill_dir = ".claude/skills"
+worktree_prefix = "kaji"
 
 [execution]
 default_timeout = 1800
+agent_runner = "headless"
+interactive_terminal_close_on_verdict = true
 
 [provider]
 type = "github"
@@ -131,7 +134,11 @@ type = "github"
 [provider.github]
 repo = "<owner>/<name>"
 default_branch = "main"
+git_remote = "origin"
 ```
+
+`.kaji/config.toml` の全設定項目、overlay、利用可能なkeyの詳細は
+[設定リファレンス](docs/reference/configuration.md)を参照してください。
 
 GitHubを使わないlocal issue storageの場合は、local provider configにし、
 gitignoredなmachine overlayを作成します。
@@ -147,7 +154,8 @@ kaji local init
 
 `kaji local init` は現在のmachine用の `.kaji/config.local.toml` を作成します。
 trackedなbase configを置き換えるものではありません。local modeでは
-`.kaji/wf/dev-local.yaml` などのlocal専用workflowを使います。
+`.kaji/wf/dev-local.yaml` などのlocal専用workflowを使います。local providerの
+セットアップは [Local Mode CLI Guide](docs/cli-guides/local-mode.md) を参照してください。
 
 skillは `.claude/skills/` に配置します。他agent向けのskill directoryは、
 同じcanonical skill fileへのsymlinkとして構成できます。

--- a/README.md
+++ b/README.md
@@ -132,9 +132,12 @@ opens PRs, polls review state, and closes issues.
 [paths]
 artifacts_dir = ".kaji-artifacts"
 skill_dir = ".claude/skills"
+worktree_prefix = "kaji"
 
 [execution]
 default_timeout = 1800
+agent_runner = "headless"
+interactive_terminal_close_on_verdict = true
 
 [provider]
 type = "github"
@@ -142,7 +145,12 @@ type = "github"
 [provider.github]
 repo = "<owner>/<name>"
 default_branch = "main"
+git_remote = "origin"
 ```
+
+For the full `.kaji/config.toml` reference, including overlays and all
+available keys, see
+[Configuration Reference](docs/reference/configuration.en.md).
 
 For local issue storage without GitHub, use a local provider config and create a
 gitignored machine overlay:
@@ -158,7 +166,9 @@ kaji local init
 
 `kaji local init` creates `.kaji/config.local.toml` for the current machine; it
 does not replace the tracked base config. Local mode uses local-specific
-workflows such as `.kaji/wf/dev-local.yaml`.
+workflows such as `.kaji/wf/dev-local.yaml`. See
+[Local Mode CLI Guide](docs/cli-guides/local-mode.md) for the local provider
+setup.
 
 Skills live under `.claude/skills/`. Other agent-specific skill directories can
 point to the same canonical skill files with symlinks.


### PR DESCRIPTION
## Summary

README の Quick start にある `.kaji/config.toml` 例を、設定リファレンスで明示した GitHub 標準運用の値に揃えます。

Related issue: #253

## Changes

- README.md / README.ja.md の `.kaji/config.toml` 例に `worktree_prefix`、`agent_runner`、`interactive_terminal_close_on_verdict`、`git_remote` を追加
- README.md / README.ja.md から設定リファレンスと Local Mode guide へリンク
- `make verify-docs` の対象に README.ja.md を追加

## Test Plan

- [x] `source /home/aki/dev/kaji/main/.venv/bin/activate && make verify-docs`
- [x] `source /home/aki/dev/kaji/main/.venv/bin/activate && kaji validate .kaji/wf/*.yaml`
